### PR TITLE
feat: HTTP server runtime — endpoint registration and request dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +366,7 @@ dependencies = [
  "anyhow",
  "ariadne",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "dirs",
@@ -322,6 +378,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "toml",
+ "tower-http",
 ]
 
 [[package]]
@@ -455,6 +512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +530,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -733,10 +797,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1155,6 +1231,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1517,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1468,6 +1556,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 toml = "0.8"
 dirs = "5"
+axum = "0.7"
+tower-http = { version = "0.6", features = ["cors"] }

--- a/examples/hello_server.forge
+++ b/examples/hello_server.forge
@@ -1,0 +1,11 @@
+#! boundary: server
+
+task greet
+  needs name: Text
+  gives Text
+  do
+    give "Hello, {name}!"
+
+endpoint hello(name: Text) -> Text
+  result = greet(name)
+  give result

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,24 @@ use thiserror::Error;
 pub struct ForgeConfig {
     pub llm: LLMConfig,
     pub providers: HashMap<String, ProviderConfig>,
+    pub server: Option<ServerConfig>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ServerConfig {
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub cors_origins: Option<Vec<String>>,
+}
+
+impl ServerConfig {
+    pub fn host_or_default(&self) -> &str {
+        self.host.as_deref().unwrap_or("127.0.0.1")
+    }
+
+    pub fn port_or_default(&self) -> u16 {
+        self.port.unwrap_or(3000)
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -119,6 +137,26 @@ impl ForgeConfig {
             config.llm.default = provider;
         }
 
+        // FORGE_HOST / FORGE_PORT overrides
+        if let Ok(host) = std::env::var("FORGE_HOST") {
+            let server = config.server.get_or_insert(ServerConfig {
+                host: None,
+                port: None,
+                cors_origins: None,
+            });
+            server.host = Some(host);
+        }
+        if let Ok(port) = std::env::var("FORGE_PORT") {
+            if let Ok(val) = port.parse::<u16>() {
+                let server = config.server.get_or_insert(ServerConfig {
+                    host: None,
+                    port: None,
+                    cors_origins: None,
+                });
+                server.port = Some(val);
+            }
+        }
+
         // FORGE_BUDGET override
         if let Ok(budget) = std::env::var("FORGE_BUDGET") {
             if let Ok(val) = budget.parse::<f32>() {
@@ -193,6 +231,7 @@ impl ForgeConfig {
                 budget: None,
             },
             providers,
+            server: None,
         }
     }
 }
@@ -242,6 +281,7 @@ mod tests {
                 budget: None,
             },
             providers: HashMap::new(),
+            server: None,
         };
         assert!(matches!(
             config.validate(),
@@ -285,6 +325,7 @@ mod tests {
                 budget: None,
             },
             providers,
+            server: None,
         };
         assert!(matches!(
             config.validate(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,17 @@ enum Command {
         /// Path to the .forge source file
         file: PathBuf,
     },
+    /// Start an HTTP server for endpoint declarations
+    Serve {
+        /// Path to a .forge file containing endpoint declarations
+        file: PathBuf,
+        /// Host to bind to (overrides config)
+        #[arg(long)]
+        host: Option<String>,
+        /// Port to bind to (overrides config)
+        #[arg(long)]
+        port: Option<u16>,
+    },
     /// Generate skeleton FORGE code from a plain-text system description
     Fleet {
         /// Plain-text system description (e.g., "a chat system with moderator and logger")
@@ -154,6 +165,9 @@ async fn main() -> anyhow::Result<()> {
             let estimate = forge::cost_estimator::estimate(&program, &config);
             print!("{}", estimate);
         }
+        Command::Serve { file, host, port } => {
+            serve_program(&file, host, port).await?;
+        }
         Command::Fleet { spec, output } => {
             let result = forge::fleet::generate(&spec)?;
             match output {
@@ -236,6 +250,64 @@ async fn run_program(file: &PathBuf, trace: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+async fn serve_program(
+    file: &PathBuf,
+    cli_host: Option<String>,
+    cli_port: Option<u16>,
+) -> anyhow::Result<()> {
+    let source = read_source(file)?;
+    let program = parse_or_exit(&source, file);
+    let fname = file.display().to_string();
+
+    // Validate before serving
+    let mut diagnostics = Vec::new();
+
+    let ctx = forge::resolver::CheckContext::new(&fname);
+    if let Err(errors) = ctx.check(&program) {
+        let registry = forge::resolver::CapabilityRegistry::builtin();
+        diagnostics.extend(errors.iter().map(|e| e.to_diagnostic(&fname, &registry)));
+    }
+
+    diagnostics.extend(forge::checker::check_all(&program, &fname));
+
+    let boundary_refs = vec![(&program, fname.as_str())];
+    diagnostics.extend(forge::checker::boundary_checker::check(&boundary_refs));
+
+    if !diagnostics.is_empty() {
+        forge::diagnostic::render_diagnostics(&source, &diagnostics);
+        std::process::exit(1);
+    }
+
+    let config = forge::config::ForgeConfig::load_or_default();
+
+    let tracer = if std::env::var("FORGE_TRACE")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        Some(forge::tracer::Tracer::new())
+    } else {
+        None
+    };
+
+    let registry = forge::llm::registry::ProviderRegistry::from_config(config.clone())
+        .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
+
+    let executor =
+        forge::runtime::executor::TaskExecutor::new(program, Arc::new(registry), tracer);
+
+    let mut server =
+        forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref());
+
+    if let Some(host) = cli_host {
+        server = server.with_host(host);
+    }
+    if let Some(port) = cli_port {
+        server = server.with_port(port);
+    }
+
+    server.run().await
 }
 
 async fn run_agent(file: &PathBuf) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,8 +294,7 @@ async fn serve_program(
     let registry = forge::llm::registry::ProviderRegistry::from_config(config.clone())
         .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
 
-    let executor =
-        forge::runtime::executor::TaskExecutor::new(program, Arc::new(registry), tracer);
+    let executor = forge::runtime::executor::TaskExecutor::new(program, Arc::new(registry), tracer);
 
     let mut server =
         forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref());

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -105,6 +105,7 @@ pub struct TaskExecutor {
     pure_map: HashMap<String, PureDecl>,
     flow_map: HashMap<String, FlowDecl>,
     pool_map: HashMap<String, PoolDecl>,
+    endpoint_map: HashMap<String, EndpointDecl>,
     output: Arc<Mutex<Vec<String>>>,
     agent_context: Option<Arc<Mutex<AgentContext>>>,
     timer_engine: Option<Arc<Mutex<TimerEngine>>>,
@@ -116,6 +117,7 @@ impl TaskExecutor {
         let mut pure_map = HashMap::new();
         let mut flow_map = HashMap::new();
         let mut pool_map = HashMap::new();
+        let mut endpoint_map = HashMap::new();
 
         for item in &program.items {
             match &item.node {
@@ -131,6 +133,9 @@ impl TaskExecutor {
                 TopLevel::Pool(pl) => {
                     pool_map.insert(pl.name.node.clone(), pl.clone());
                 }
+                TopLevel::Endpoint(e) => {
+                    endpoint_map.insert(e.name.node.clone(), e.clone());
+                }
                 _ => {}
             }
         }
@@ -143,6 +148,7 @@ impl TaskExecutor {
             pure_map,
             flow_map,
             pool_map,
+            endpoint_map,
             output: Arc::new(Mutex::new(Vec::new())),
             agent_context: None,
             timer_engine: None,
@@ -169,6 +175,41 @@ impl TaskExecutor {
     /// Get collected `say` output (for testing)
     pub fn outputs(&self) -> Vec<String> {
         self.output.lock().unwrap().clone()
+    }
+
+    /// Get the tracer, if enabled.
+    pub fn tracer(&self) -> Option<&Tracer> {
+        self.tracer.as_ref()
+    }
+
+    /// Get registered endpoints (for HTTP server).
+    pub fn endpoints(&self) -> &HashMap<String, EndpointDecl> {
+        &self.endpoint_map
+    }
+
+    /// Execute an endpoint body with the given arguments.
+    pub async fn exec_endpoint(
+        &self,
+        name: &str,
+        args: HashMap<String, ConfidentValue>,
+    ) -> Result<ConfidentValue, RuntimeError> {
+        let endpoint = self
+            .endpoint_map
+            .get(name)
+            .ok_or_else(|| RuntimeError::NotCallable {
+                name: name.to_string(),
+            })?;
+
+        let mut env = Env::new();
+        for (k, v) in args {
+            env.bind(&k, v);
+        }
+
+        match self.exec_stmts(&endpoint.body, &mut env).await {
+            Ok(val) => Ok(val),
+            Err(RuntimeError::GiveSignal(val)) => Ok(val),
+            Err(e) => Err(e),
+        }
     }
 
     /// Run the program starting from `fn main`

--- a/src/runtime/http_server.rs
+++ b/src/runtime/http_server.rs
@@ -217,11 +217,7 @@ async fn dispatch_endpoint(
         Ok(val) => {
             let duration_ms = start.elapsed().as_millis() as u64;
             let response = value_to_response(val);
-            let status = if response.status().is_success() {
-                response.status().as_u16()
-            } else {
-                response.status().as_u16()
-            };
+            let status = response.status().as_u16();
             if let Some(tracer) = executor.tracer() {
                 tracer.http_response(endpoint_name, status, duration_ms);
             }

--- a/src/runtime/http_server.rs
+++ b/src/runtime/http_server.rs
@@ -69,9 +69,11 @@ impl ForgeServer {
             router = router
                 .route(
                     &get_path,
-                    get(move |state: State<TaskExecutor>, query: Query<HashMap<String, String>>| {
-                        handle_get(state, Path(name_get), query)
-                    }),
+                    get(
+                        move |state: State<TaskExecutor>, query: Query<HashMap<String, String>>| {
+                            handle_get(state, Path(name_get), query)
+                        },
+                    ),
                 )
                 .route(
                     &post_path,
@@ -118,8 +120,12 @@ impl ForgeServer {
                     .return_type
                     .as_ref()
                     .map(|t| {
-                        let types: Vec<String> =
-                            t.node.types.iter().map(|tn| format!("{:?}", tn.node)).collect();
+                        let types: Vec<String> = t
+                            .node
+                            .types
+                            .iter()
+                            .map(|tn| format!("{:?}", tn.node))
+                            .collect();
                         format!(" -> {}", types.join(", "))
                     })
                     .unwrap_or_default();
@@ -226,7 +232,11 @@ async fn dispatch_endpoint(
             if let Some(tracer) = executor.tracer() {
                 tracer.http_response(endpoint_name, 500, duration_ms);
             }
-            (StatusCode::INTERNAL_SERVER_ERROR, format!("runtime error: {e}")).into_response()
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("runtime error: {e}"),
+            )
+                .into_response()
         }
     }
 }

--- a/src/runtime/http_server.rs
+++ b/src/runtime/http_server.rs
@@ -1,0 +1,274 @@
+// FORGE HTTP server runtime
+// Dispatches HTTP requests to endpoint declarations. See issue #43.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::Instant;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::Router;
+use tower_http::cors::{Any, CorsLayer};
+
+use crate::config::ServerConfig;
+use crate::runtime::confidence::{ConfidentValue, Value};
+use crate::runtime::executor::TaskExecutor;
+
+// ── Server ───────────────────────────────────────────────────────────────────
+
+pub struct ForgeServer {
+    executor: TaskExecutor,
+    host: String,
+    port: u16,
+    cors_origins: Vec<String>,
+}
+
+impl ForgeServer {
+    pub fn new(executor: TaskExecutor, config: Option<&ServerConfig>) -> Self {
+        let (host, port, cors_origins) = match config {
+            Some(c) => (
+                c.host_or_default().to_string(),
+                c.port_or_default(),
+                c.cors_origins.clone().unwrap_or_default(),
+            ),
+            None => ("127.0.0.1".to_string(), 3000, Vec::new()),
+        };
+
+        Self {
+            executor,
+            host,
+            port,
+            cors_origins,
+        }
+    }
+
+    /// Override host (CLI flag takes precedence over config).
+    pub fn with_host(mut self, host: String) -> Self {
+        self.host = host;
+        self
+    }
+
+    /// Override port (CLI flag takes precedence over config).
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    /// Build the axum router from registered endpoints.
+    fn build_router(&self) -> Router {
+        let mut router = Router::new();
+
+        for name in self.executor.endpoints().keys() {
+            let get_path = format!("/{name}");
+            let post_path = get_path.clone();
+            let name_get = name.clone();
+            let name_post = name.clone();
+
+            router = router
+                .route(
+                    &get_path,
+                    get(move |state: State<TaskExecutor>, query: Query<HashMap<String, String>>| {
+                        handle_get(state, Path(name_get), query)
+                    }),
+                )
+                .route(
+                    &post_path,
+                    post(
+                        move |state: State<TaskExecutor>, body: axum::Json<serde_json::Value>| {
+                            handle_post(state, Path(name_post), body)
+                        },
+                    ),
+                );
+        }
+
+        // CORS
+        let cors = if self.cors_origins.is_empty() {
+            CorsLayer::new().allow_origin(Any)
+        } else {
+            let origins: Vec<_> = self
+                .cors_origins
+                .iter()
+                .filter_map(|o| o.parse().ok())
+                .collect();
+            CorsLayer::new().allow_origin(origins)
+        };
+
+        router
+            .fallback(fallback_handler)
+            .layer(cors)
+            .with_state(self.executor.clone())
+    }
+
+    /// Print startup banner listing registered endpoints.
+    fn print_banner(&self) {
+        println!("Listening on http://{}:{}", self.host, self.port);
+        let endpoints = self.executor.endpoints();
+        if endpoints.is_empty() {
+            println!("  (no endpoints registered)");
+        } else {
+            for (name, ep) in endpoints {
+                let params: Vec<String> = ep
+                    .params
+                    .iter()
+                    .map(|p| format!("{}=<{:?}>", p.node.name, p.node.type_name.node))
+                    .collect();
+                let ret = ep
+                    .return_type
+                    .as_ref()
+                    .map(|t| {
+                        let types: Vec<String> =
+                            t.node.types.iter().map(|tn| format!("{:?}", tn.node)).collect();
+                        format!(" -> {}", types.join(", "))
+                    })
+                    .unwrap_or_default();
+                println!("  GET  /{name}?{}{ret}", params.join("&"));
+                println!("  POST /{name}{ret}");
+            }
+        }
+    }
+
+    /// Start the HTTP server with graceful shutdown on SIGINT.
+    pub async fn run(self) -> anyhow::Result<()> {
+        self.print_banner();
+
+        let addr: SocketAddr = format!("{}:{}", self.host, self.port).parse()?;
+        let router = self.build_router();
+
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown_signal())
+            .await?;
+
+        println!("\nServer stopped.");
+        Ok(())
+    }
+
+    /// Start on a provided listener (for testing with random ports).
+    pub async fn run_on_listener(self, listener: tokio::net::TcpListener) -> anyhow::Result<()> {
+        let router = self.build_router();
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown_signal())
+            .await?;
+        Ok(())
+    }
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+async fn handle_get(
+    State(executor): State<TaskExecutor>,
+    Path(endpoint_name): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Response {
+    let args = params_to_args(params);
+    dispatch_endpoint(executor, &endpoint_name, args).await
+}
+
+async fn handle_post(
+    State(executor): State<TaskExecutor>,
+    Path(endpoint_name): Path<String>,
+    axum::Json(body): axum::Json<serde_json::Value>,
+) -> Response {
+    let params = match body.as_object() {
+        Some(map) => map
+            .iter()
+            .map(|(k, v)| {
+                let s = match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                (k.clone(), s)
+            })
+            .collect(),
+        None => HashMap::new(),
+    };
+    let args = params_to_args(params);
+    dispatch_endpoint(executor, &endpoint_name, args).await
+}
+
+fn params_to_args(params: HashMap<String, String>) -> HashMap<String, ConfidentValue> {
+    params
+        .into_iter()
+        .map(|(k, v)| (k, ConfidentValue::deterministic(Value::Text(v))))
+        .collect()
+}
+
+async fn dispatch_endpoint(
+    executor: TaskExecutor,
+    endpoint_name: &str,
+    args: HashMap<String, ConfidentValue>,
+) -> Response {
+    let start = Instant::now();
+
+    // Trace the request
+    if let Some(tracer) = executor.tracer() {
+        tracer.http_request(endpoint_name, "HTTP", &format!("/{endpoint_name}"));
+    }
+
+    match executor.exec_endpoint(endpoint_name, args).await {
+        Ok(val) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let response = value_to_response(val);
+            let status = if response.status().is_success() {
+                response.status().as_u16()
+            } else {
+                response.status().as_u16()
+            };
+            if let Some(tracer) = executor.tracer() {
+                tracer.http_response(endpoint_name, status, duration_ms);
+            }
+            response
+        }
+        Err(e) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            if let Some(tracer) = executor.tracer() {
+                tracer.http_response(endpoint_name, 500, duration_ms);
+            }
+            (StatusCode::INTERNAL_SERVER_ERROR, format!("runtime error: {e}")).into_response()
+        }
+    }
+}
+
+fn value_to_response(val: ConfidentValue) -> Response {
+    match &val.value {
+        Value::Text(s) => (StatusCode::OK, s.clone()).into_response(),
+        Value::Number(n) => (StatusCode::OK, n.to_string()).into_response(),
+        Value::Bool(b) => (StatusCode::OK, b.to_string()).into_response(),
+        Value::Unit => StatusCode::NO_CONTENT.into_response(),
+        Value::List(_) | Value::Record(_) | Value::Array(_) => {
+            let json = value_to_json(&val);
+            axum::Json(json).into_response()
+        }
+    }
+}
+
+fn value_to_json(val: &ConfidentValue) -> serde_json::Value {
+    match &val.value {
+        Value::Text(s) => serde_json::Value::String(s.clone()),
+        Value::Number(n) => serde_json::json!(n),
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Unit => serde_json::Value::Null,
+        Value::List(items) | Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(value_to_json).collect())
+        }
+        Value::Record(fields) => {
+            let map: serde_json::Map<String, serde_json::Value> = fields
+                .iter()
+                .map(|(k, v)| (k.clone(), value_to_json(v)))
+                .collect();
+            serde_json::Value::Object(map)
+        }
+    }
+}
+
+async fn fallback_handler() -> Response {
+    (StatusCode::NOT_FOUND, "not found").into_response()
+}
+
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to listen for SIGINT");
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5,6 +5,7 @@ pub mod agent;
 pub mod confidence;
 pub mod event_bus;
 pub mod executor;
+pub mod http_server;
 pub mod memory;
 pub mod pool;
 pub mod state_machine;

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -289,6 +289,30 @@ impl Tracer {
         );
     }
 
+    // ── HTTP server tracing (issue #43) ─────────────────────────────────────
+
+    pub fn http_request(&self, endpoint: &str, method: &str, path: &str) {
+        self.emit(
+            "http_request",
+            serde_json::json!({
+                "endpoint": endpoint,
+                "method": method,
+                "path": path,
+            }),
+        );
+    }
+
+    pub fn http_response(&self, endpoint: &str, status: u16, duration_ms: u64) {
+        self.emit(
+            "http_response",
+            serde_json::json!({
+                "endpoint": endpoint,
+                "status": status,
+                "duration_ms": duration_ms,
+            }),
+        );
+    }
+
     pub fn ward_action(
         &self,
         warden: &str,

--- a/tests/http_server_tests.rs
+++ b/tests/http_server_tests.rs
@@ -1,0 +1,168 @@
+// FORGE HTTP server integration tests — issue #43
+
+use std::sync::Arc;
+
+use forge::config::ServerConfig;
+use forge::llm::registry::ProviderRegistry;
+use forge::runtime::executor::TaskExecutor;
+use forge::runtime::http_server::ForgeServer;
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+fn mock_registry() -> Arc<ProviderRegistry> {
+    let config = forge::config::ForgeConfig::default_mock_config();
+    Arc::new(
+        ProviderRegistry::from_config(config).expect("mock registry should build"),
+    )
+}
+
+fn parse_and_build(source: &str) -> TaskExecutor {
+    let program = forge::parser::parse(source).expect("parse failed");
+    TaskExecutor::new(program, mock_registry(), None)
+}
+
+/// Spawn a server on a random port and return the base URL.
+async fn spawn_server(source: &str) -> String {
+    let executor = parse_and_build(source);
+    let server = ForgeServer::new(executor, None);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind failed");
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(async move {
+        server
+            .run_on_listener(listener)
+            .await
+            .expect("server failed");
+    });
+
+    // Give the server a moment to start
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    format!("http://127.0.0.1:{port}")
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+const HELLO_SERVER: &str = r#"#! boundary: server
+
+task greet
+  needs name: Text
+  gives Text
+  do
+    give "Hello, {name}!"
+
+endpoint hello(name: Text) -> Text
+  result = greet(name)
+  give result
+"#;
+
+#[tokio::test]
+async fn get_endpoint_with_query_param() {
+    let base = spawn_server(HELLO_SERVER).await;
+    let resp = reqwest::get(format!("{base}/hello?name=world"))
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "Hello, world!");
+}
+
+#[tokio::test]
+async fn post_endpoint_with_json_body() {
+    let base = spawn_server(HELLO_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/hello"))
+        .json(&serde_json::json!({"name": "world"}))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "Hello, world!");
+}
+
+#[tokio::test]
+async fn unknown_route_returns_404() {
+    let base = spawn_server(HELLO_SERVER).await;
+    let resp = reqwest::get(format!("{base}/nonexistent"))
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 404);
+}
+
+const NO_PARAMS_SERVER: &str = r#"#! boundary: server
+
+endpoint ping() -> Text
+  give "pong"
+"#;
+
+#[tokio::test]
+async fn endpoint_with_no_params() {
+    let base = spawn_server(NO_PARAMS_SERVER).await;
+    let resp = reqwest::get(format!("{base}/ping"))
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "pong");
+}
+
+#[tokio::test]
+async fn endpoint_map_populated() {
+    let executor = parse_and_build(HELLO_SERVER);
+    let endpoints = executor.endpoints();
+    assert_eq!(endpoints.len(), 1);
+    assert!(endpoints.contains_key("hello"));
+}
+
+#[tokio::test]
+async fn server_config_defaults() {
+    let config = ServerConfig {
+        host: None,
+        port: None,
+        cors_origins: None,
+    };
+    assert_eq!(config.host_or_default(), "127.0.0.1");
+    assert_eq!(config.port_or_default(), 3000);
+}
+
+#[tokio::test]
+async fn server_config_custom() {
+    let config = ServerConfig {
+        host: Some("0.0.0.0".to_string()),
+        port: Some(8080),
+        cors_origins: Some(vec!["http://localhost:3000".to_string()]),
+    };
+    assert_eq!(config.host_or_default(), "0.0.0.0");
+    assert_eq!(config.port_or_default(), 8080);
+}
+
+const MULTI_ENDPOINT_SERVER: &str = r#"#! boundary: server
+
+endpoint greet(name: Text) -> Text
+  give "Hi, {name}!"
+
+endpoint health() -> Text
+  give "ok"
+"#;
+
+#[tokio::test]
+async fn multiple_endpoints_registered() {
+    let base = spawn_server(MULTI_ENDPOINT_SERVER).await;
+
+    let resp = reqwest::get(format!("{base}/greet?name=Alice"))
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "Hi, Alice!");
+
+    let resp = reqwest::get(format!("{base}/health"))
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "ok");
+}

--- a/tests/http_server_tests.rs
+++ b/tests/http_server_tests.rs
@@ -11,9 +11,7 @@ use forge::runtime::http_server::ForgeServer;
 
 fn mock_registry() -> Arc<ProviderRegistry> {
     let config = forge::config::ForgeConfig::default_mock_config();
-    Arc::new(
-        ProviderRegistry::from_config(config).expect("mock registry should build"),
-    )
+    Arc::new(ProviderRegistry::from_config(config).expect("mock registry should build"))
 }
 
 fn parse_and_build(source: &str) -> TaskExecutor {


### PR DESCRIPTION
## Summary

- Wire up the `endpoint` keyword to a real HTTP server via **axum 0.7** + **tower-http 0.6**
- Add `forge serve <file> [--host] [--port]` CLI command
- Add `[server]` config section with host/port/cors_origins + `FORGE_HOST`/`FORGE_PORT` env overrides
- Collect endpoints in `TaskExecutor.endpoint_map`, dispatch via `exec_endpoint()`
- Add `http_request`/`http_response` trace events for Principle VIII (accountability)
- 8 new integration tests covering GET, POST JSON, 404, no-params, multi-endpoint, config

Closes #43

## Acceptance Criteria

- [x] `forge serve examples/hello_server.forge` starts an HTTP server on configured port
- [x] `curl localhost:3000/hello?name=world` returns a response
- [x] Endpoints can call tasks (including LLM-backed tasks with `reason`/`classify`)
- [x] Non-existent routes return 404 with clear error
- [x] Server reads host/port from `forge.config.toml` `[server]` section
- [x] CLI flags `--port` and `--host` override config
- [x] Graceful shutdown on SIGINT
- [x] Startup logs list all registered endpoints with their routes

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test` — 511 tests pass (503 existing + 8 new)
- [x] End-to-end smoke test: `forge serve` + curl GET/POST/404

🤖 Generated with [Claude Code](https://claude.com/claude-code)