### PR TITLE
feat: progressive learning agents — knowledge, recall, learn primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Progressive learning agents: `knowledge`, `recall`, and `learn` language primitives for persistent, searchable knowledge stores that enable agents to accumulate expertise through use
 - Development lifecycle workflow spec (`workflows/dev-cycle.forge`) — dogfoods FORGE to model the issue-to-merge cycle with 5 expert agents, 2 state machines, and warden supervision
 - `CLAUDE.md` with project development rules (branching, changelog, release conventions)
 - Pre-commit workflow gate hook (`scripts/check-workflow.sh`) — enforces branch ancestry, changelog staged, and tests passing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,10 +354,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "forge"
@@ -375,10 +387,12 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",
  "tower-http",
+ "uuid",
 ]
 
 [[package]]
@@ -455,9 +469,31 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -684,6 +720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,7 +753,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -755,6 +799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +818,12 @@ checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -949,6 +1005,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1092,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1135,6 +1207,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1271,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1358,6 +1449,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1581,6 +1685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1721,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1757,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1693,6 +1823,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1953,6 +2117,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,11 @@ ariadne = "0.6"
 thiserror = "2"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["v4"] }
 toml = "0.8"
 dirs = "6"
 axum = "0.7"
 tower-http = { version = "0.6", features = ["cors"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/conformance/checker/knowledge_agent_compile_ok.json
+++ b/conformance/checker/knowledge_agent_compile_ok.json
@@ -1,0 +1,9 @@
+{
+  "name": "knowledge_agent_compile_ok",
+  "category": "checker",
+  "description": "Agent with knowledge store, proper recall dispatch, and learn compiles cleanly",
+  "input": "use\n  llm.reason\n\nagent learner\n  memory\n    count: Number\n  knowledge store: \".forge-knowledge/test\"\n    max_entries: 1000\n\n  on query(q: Text)\n    prior = recall \"{q}\"\n    when prior.sure -> give prior\n    else -> escalate to human\n\n  on train(fact: Text)\n    learn \"{fact}\"\n    say \"Learned\"\n",
+  "expected": {
+    "outcome": "compile_ok"
+  }
+}

--- a/conformance/checker/pure_no_learn.json
+++ b/conformance/checker/pure_no_learn.json
@@ -1,0 +1,11 @@
+{
+  "name": "pure_no_learn",
+  "category": "checker",
+  "subcategory": "pure",
+  "description": "Pure function cannot use learn (side effect forbidden in pure context)",
+  "input": "pure bad\n  needs fact: Text\n  gives Text\n  do\n    learn \"{fact}\"\n    give fact\n",
+  "expected": {
+    "outcome": "compile_error",
+    "error_contains": ["cannot use", "learn"]
+  }
+}

--- a/conformance/checker/pure_no_recall.json
+++ b/conformance/checker/pure_no_recall.json
@@ -1,0 +1,11 @@
+{
+  "name": "pure_no_recall",
+  "category": "checker",
+  "subcategory": "pure",
+  "description": "Pure function cannot use recall (knowledge retrieval is non-deterministic)",
+  "input": "pure bad\n  needs q: Text\n  gives Text\n  do\n    give recall \"{q}\"\n",
+  "expected": {
+    "outcome": "compile_error",
+    "error_contains": ["cannot use", "recall"]
+  }
+}

--- a/conformance/checker/recall_returns_uncertain.json
+++ b/conformance/checker/recall_returns_uncertain.json
@@ -1,0 +1,11 @@
+{
+  "name": "recall_returns_uncertain",
+  "category": "checker",
+  "subcategory": "uncertain",
+  "description": "Tainted value from recall passed to give without when/match is rejected",
+  "input": "use\n  llm.reason\n\nagent learner\n  knowledge store: \".forge-knowledge/test\"\n\n  on query(q: Text)\n    prior = recall \"{q}\"\n    give prior\n",
+  "expected": {
+    "outcome": "compile_error",
+    "error_contains": ["unhandled uncertain"]
+  }
+}

--- a/conformance/parser/valid_knowledge_agent.json
+++ b/conformance/parser/valid_knowledge_agent.json
@@ -1,0 +1,9 @@
+{
+  "name": "valid_knowledge_agent",
+  "category": "parser",
+  "description": "Agent with knowledge store, recall expression, and learn statements parses successfully",
+  "input": "use\n  llm.reason\n\nagent learner\n  memory\n    count: Number\n  knowledge store: \".forge-knowledge/learner\"\n    max_entries: 5000\n    retention: 90d\n\n  on query(question: Text)\n    prior = recall \"{question}\"\n    when prior.sure -> give prior\n    else -> escalate to human\n\n  on train(fact: Text)\n    learn \"{fact}\"\n    say \"Learned: {fact}\"\n\n  on ingest(path: Text)\n    learn from document(path)\n    say \"Ingested\"\n\n  on record(q: Text, a: Text)\n    learn from interaction(q, a, 0.9)\n    say \"Recorded\"\n",
+  "expected": {
+    "outcome": "parse_ok"
+  }
+}

--- a/examples/learning_agent.forge
+++ b/examples/learning_agent.forge
@@ -1,0 +1,39 @@
+use
+  llm.reason
+
+states LearningPhase
+  novice -> competent when score >= 30
+  competent -> expert when score >= 70
+  expert -> expert
+
+agent research_assistant
+  lifecycle: LearningPhase
+  memory
+    interaction_count: Number
+    success_count: Number
+  knowledge store: ".forge-knowledge/research"
+    max_entries: 5000
+    retention: 90d
+
+  on query(question: Text)
+    prior = recall "{question}"
+    when prior.sure -> give prior
+    else -> escalate to human
+
+  on query_and_learn(question: Text)
+    answer = reason "Answer: {question}"
+    when answer.sure -> learn from interaction(question, answer, 0.9)
+    when answer.unsure -> learn from interaction(question, answer, 0.5)
+    else -> escalate to human
+    memory.interaction_count = memory.interaction_count + 1
+
+  on ingest(document_path: Text)
+    learn from document(document_path)
+    say "Ingested: {document_path}"
+
+  on train(fact: Text)
+    learn "{fact}"
+    say "Learned: {fact}"
+
+  if stuck for 3 turns
+    escalate to human

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -53,7 +53,7 @@ keyword = @{
     | "pure" | "event" | "states" | "timer" | "endpoint" | "type"
     | "requires" | "emit" | "forward" | "subscribe" | "transition"
     | "start" | "cancel" | "reset" | "for" | "in" | "not" | "and"
-    | "match" )
+    | "match" | "recall" | "learn" )
     ~ !(ASCII_ALPHANUMERIC | "_")
 }
 
@@ -175,6 +175,7 @@ agent_decl = {
     "agent" ~ _s ~ ident ~ nl ~
     (i1 ~ lifecycle_clause ~ nl)? ~
     (i1 ~ memory_block)? ~
+    (i1 ~ knowledge_block)? ~
     (i1 ~ timer_field ~ nl)* ~
     (i1 ~ subscribe_line ~ nl)* ~
     (i1 ~ warden_override_block)? ~
@@ -187,6 +188,15 @@ lifecycle_clause = { "lifecycle" ~ _s_opt ~ ":" ~ _s_opt ~ ident }
 memory_block = {
     "memory" ~ nl ~
     (i2 ~ ident ~ _s_opt ~ ":" ~ _s_opt ~ type_name ~ nl)+
+}
+
+knowledge_block = {
+    "knowledge" ~ _s ~ "store" ~ _s_opt ~ ":" ~ _s_opt ~ template_string ~ nl ~
+    (i2 ~ knowledge_option ~ nl)*
+}
+knowledge_option = {
+    "max_entries" ~ _s_opt ~ ":" ~ _s_opt ~ number_lit
+  | "retention" ~ _s_opt ~ ":" ~ _s_opt ~ duration
 }
 
 timer_field = { "timer" ~ _s ~ ident ~ _s_opt ~ ":" ~ _s_opt ~ duration }
@@ -236,7 +246,7 @@ pool_strategy = {
   | "quorum(" ~ _s_opt ~ number_lit ~ _s_opt ~ ")"
   | "first(" ~ _s_opt ~ number_lit ~ _s_opt ~ ")"
 }
-duration = @{ ASCII_DIGIT+ ~ ("min" | "s" | "m" | "h") }
+duration = @{ ASCII_DIGIT+ ~ ("min" | "s" | "m" | "h" | "d") }
 
 // --- warden declaration ---
 warden_decl = {
@@ -305,6 +315,7 @@ statement = {
   | give_stmt
   | say_stmt
   | emit_stmt
+  | learn_stmt
   | transition_stmt
   | start_timer_stmt
   | cancel_timer_stmt
@@ -332,6 +343,11 @@ cancel_timer_stmt  = { "cancel" ~ _s ~ ident ~ (_s ~ "for" ~ _s ~ expr)? }
 reset_timer_stmt   = { "reset" ~ _s ~ ident }
 forward_stmt       = { "forward" ~ _s ~ expr ~ _s ~ "to" ~ _s ~ expr }
 
+learn_stmt         = { "learn" ~ _s ~ (learn_from_interaction | learn_from_document | learn_direct) }
+learn_from_interaction = { "from" ~ _s ~ "interaction" ~ _s_opt ~ "(" ~ _s_opt ~ arg_list ~ _s_opt ~ ")" }
+learn_from_document    = { "from" ~ _s ~ "document" ~ _s_opt ~ "(" ~ _s_opt ~ string_arg ~ _s_opt ~ ")" }
+learn_direct           = { string_arg }
+
 // --- when block (confidence-only branching) ---
 when_block = {
     when_clause ~
@@ -349,7 +365,7 @@ else_clause = { "else" ~ _s_opt ~ "->" ~ _s_opt ~ statement_inline }
 
 statement_inline = {
     give_stmt | say_stmt | escalate_stmt
-  | emit_stmt | transition_stmt
+  | emit_stmt | learn_stmt | transition_stmt
   | start_timer_stmt | cancel_timer_stmt | reset_timer_stmt
   | forward_stmt | expr_stmt
 }
@@ -400,6 +416,7 @@ statement_i3 = {
   | give_stmt
   | say_stmt
   | emit_stmt
+  | learn_stmt
   | transition_stmt
   | start_timer_stmt
   | cancel_timer_stmt
@@ -442,6 +459,7 @@ statement_i4 = {
     give_stmt
   | say_stmt
   | emit_stmt
+  | learn_stmt
   | transition_stmt
   | start_timer_stmt
   | cancel_timer_stmt
@@ -498,6 +516,7 @@ pipe_term = {
     reason_expr
   | classify_expr
   | search_expr
+  | recall_expr
   | try_or_expr
   | constructor_expr
   | call_expr
@@ -507,6 +526,7 @@ pipe_term = {
 reason_expr   = { "reason" ~ _s ~ string_arg }
 classify_expr = { "classify" ~ _s ~ atom ~ _s ~ "into" ~ _s ~ label_list }
 search_expr   = { "search" ~ _s ~ string_arg }
+recall_expr   = { "recall" ~ _s ~ string_arg }
 try_or_expr   = { "try" ~ _s ~ and_expr ~ _s ~ "or" ~ _s ~ expr }
 
 string_arg = { template_string | ident }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -191,11 +191,33 @@ pub struct AgentDecl {
     pub name: Spanned<String>,
     pub lifecycle: Option<Spanned<String>>,
     pub memory: Vec<Spanned<FieldDef>>,
+    pub knowledge: Option<Spanned<KnowledgeDecl>>,
     pub timers: Vec<Spanned<TimerField>>,
     pub subscriptions: Vec<Spanned<SubscribeDecl>>,
     pub warden_override: Vec<Spanned<WardPolicy>>,
     pub handlers: Vec<Spanned<OnHandler>>,
     pub stuck_policy: Option<Spanned<StuckPolicy>>,
+}
+
+// ── knowledge ────────────────────────────────────────────────
+
+/// Persistent searchable knowledge store declaration inside an agent.
+#[derive(Debug, Clone)]
+pub struct KnowledgeDecl {
+    pub store_path: Spanned<Expr>,
+    pub max_entries: Option<Spanned<f64>>,
+    pub retention: Option<Spanned<Duration>>,
+}
+
+/// Source for a `learn` statement.
+#[derive(Debug, Clone)]
+pub enum LearnSource {
+    /// `learn "fact"`
+    Direct(Spanned<Expr>),
+    /// `learn from interaction(question, answer, confidence)`
+    FromInteraction(Vec<Spanned<CallArg>>),
+    /// `learn from document("path")`
+    FromDocument(Spanned<Expr>),
 }
 
 /// Timer declaration inside an agent.
@@ -275,6 +297,7 @@ pub enum DurationUnit {
     Seconds,
     Minutes,
     Hours,
+    Days,
 }
 
 // ── warden ───────────────────────────────────────────────────
@@ -426,6 +449,8 @@ pub enum Expr {
     Classify(ClassifyExpr),
     /// `search "query"`
     Search(Box<Spanned<Expr>>),
+    /// `recall "query"` — retrieve from agent knowledge store
+    Recall(Box<Spanned<Expr>>),
     /// `try expr or expr`
     TryOr(Box<Spanned<Expr>>, Box<Spanned<Expr>>),
     /// `A >> B >> C` — composition chain
@@ -540,6 +565,8 @@ pub enum Stmt {
     ResetTimer(Spanned<String>),
     /// `forward expr to expr`
     Forward(Spanned<Expr>, Spanned<Expr>),
+    /// `learn "fact"` / `learn from interaction(...)` / `learn from document(...)`
+    Learn(Spanned<LearnSource>),
     /// `match expr` with pattern arms
     Match(Box<MatchBlock>),
     /// `if`/`else if`/`else` block

--- a/src/checker/boundary_checker.rs
+++ b/src/checker/boundary_checker.rs
@@ -4,8 +4,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
-    BoundaryKind, Expr, FieldDef, Program, Spanned, Stmt, TaskBody, TemplatePart, TopLevel,
-    TypeName,
+    BoundaryKind, Expr, FieldDef, LearnSource, Program, Spanned, Stmt, TaskBody, TemplatePart,
+    TopLevel, TypeName,
 };
 use crate::diagnostic::Diagnostic;
 
@@ -379,6 +379,16 @@ fn check_refs_in_stmt(
             }
             check_refs_in_expr(expr, boundary, registry, file, diagnostics);
         }
+        Stmt::Learn(source) => match &source.node {
+            LearnSource::Direct(expr) | LearnSource::FromDocument(expr) => {
+                check_refs_in_expr(expr, boundary, registry, file, diagnostics);
+            }
+            LearnSource::FromInteraction(args) => {
+                for arg in args {
+                    check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
+                }
+            }
+        },
         // No expressions to walk
         Stmt::TransitionTo(_)
         | Stmt::StartTimer { .. }
@@ -436,7 +446,7 @@ fn check_refs_in_expr(
                 check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
             }
         }
-        Expr::Reason(inner) | Expr::Search(inner) => {
+        Expr::Reason(inner) | Expr::Search(inner) | Expr::Recall(inner) => {
             check_refs_in_expr(inner, boundary, registry, file, diagnostics);
         }
         Expr::Classify(c) => {

--- a/src/checker/pure_checker.rs
+++ b/src/checker/pure_checker.rs
@@ -199,6 +199,14 @@ fn check_pure_stmt(
                 check_pure_expr(fn_name, &arg.node.value, task_names, errors);
             }
         }
+        Stmt::Learn(_) => {
+            errors.push(CheckError::PureUsesLlm {
+                name: fn_name.to_string(),
+                op: "learn",
+                span_start: stmt.span.start,
+                span_end: stmt.span.end,
+            });
+        }
         _ => {}
     }
 }
@@ -230,6 +238,14 @@ fn check_pure_expr(
             errors.push(CheckError::PureUsesLlm {
                 name: fn_name.to_string(),
                 op: "search",
+                span_start: expr.span.start,
+                span_end: expr.span.end,
+            });
+        }
+        Expr::Recall(_) => {
+            errors.push(CheckError::PureUsesLlm {
+                name: fn_name.to_string(),
+                op: "recall",
                 span_start: expr.span.start,
                 span_end: expr.span.end,
             });

--- a/src/checker/requires_checker.rs
+++ b/src/checker/requires_checker.rs
@@ -80,6 +80,17 @@ fn check_requires_expr(
                 .with_help("use a `pure` function instead"),
             );
         }
+        Expr::Recall(_) => {
+            diagnostics.push(
+                Diagnostic::warning(
+                    file,
+                    "requires clause uses knowledge operation `recall`",
+                    expr.span.start..expr.span.end,
+                    "knowledge retrieval is non-deterministic — preconditions should be deterministic",
+                )
+                .with_help("use a `pure` function instead"),
+            );
+        }
         Expr::TryOr(a, b) => {
             diagnostics.push(
                 Diagnostic::warning(

--- a/src/checker/uncertain_checker.rs
+++ b/src/checker/uncertain_checker.rs
@@ -134,7 +134,7 @@ fn check_stmt(
 fn expr_is_oracle(expr: &Spanned<Expr>) -> bool {
     matches!(
         &expr.node,
-        Expr::Reason(_) | Expr::Classify(_) | Expr::Search(_)
+        Expr::Reason(_) | Expr::Classify(_) | Expr::Search(_) | Expr::Recall(_)
     )
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -191,6 +191,8 @@ fn build_duration(pair: Pair) -> anyhow::Result<Spanned<Duration>> {
         (stripped.parse::<u64>()?, DurationUnit::Hours)
     } else if let Some(stripped) = s.strip_suffix('m') {
         (stripped.parse::<u64>()?, DurationUnit::Minutes)
+    } else if let Some(stripped) = s.strip_suffix('d') {
+        (stripped.parse::<u64>()?, DurationUnit::Days)
     } else if let Some(stripped) = s.strip_suffix('s') {
         (stripped.parse::<u64>()?, DurationUnit::Seconds)
     } else {
@@ -208,6 +210,45 @@ fn build_field_def(ident_pair: Pair, type_pair: Pair) -> anyhow::Result<Spanned<
     Ok(Spanned::new(
         FieldDef { name, type_name },
         Span { start, end },
+    ))
+}
+
+fn build_knowledge_block(pair: Pair) -> anyhow::Result<Spanned<KnowledgeDecl>> {
+    let span = to_span(&pair);
+    let mut inner = pair.into_inner();
+    let store_path_pair = inner.next().unwrap();
+    let store_path = {
+        let sp = to_span(&store_path_pair);
+        let parts = build_template_string(store_path_pair)?;
+        Spanned::new(Expr::Template(parts), sp)
+    };
+
+    let mut max_entries = None;
+    let mut retention = None;
+
+    for child in inner {
+        if child.as_rule() == Rule::knowledge_option {
+            let opt_inner = child.into_inner().next().unwrap();
+            match opt_inner.as_rule() {
+                Rule::number_lit => {
+                    let val = build_number_lit(opt_inner.clone())?;
+                    max_entries = Some(spanned(val, &opt_inner));
+                }
+                Rule::duration => {
+                    retention = Some(build_duration(opt_inner)?);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(Spanned::new(
+        KnowledgeDecl {
+            store_path,
+            max_entries,
+            retention,
+        },
+        span,
     ))
 }
 
@@ -392,6 +433,13 @@ fn build_search_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     Ok(Spanned::new(Expr::Search(Box::new(arg)), span))
 }
 
+fn build_recall_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
+    let span = to_span(&pair);
+    let inner = pair.into_inner().next().unwrap();
+    let arg = build_string_arg(inner)?;
+    Ok(Spanned::new(Expr::Recall(Box::new(arg)), span))
+}
+
 fn build_classify_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     let span = to_span(&pair);
     let mut inner = pair.into_inner();
@@ -431,6 +479,7 @@ fn build_pipe_term(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
         Rule::reason_expr => build_reason_expr(inner),
         Rule::classify_expr => build_classify_expr(inner),
         Rule::search_expr => build_search_expr(inner),
+        Rule::recall_expr => build_recall_expr(inner),
         Rule::try_or_expr => build_try_or_expr(inner),
         Rule::constructor_expr => build_constructor_expr(inner),
         Rule::call_expr => build_call_expr(inner),
@@ -840,6 +889,37 @@ fn build_forward_stmt(pair: Pair) -> anyhow::Result<Spanned<Stmt>> {
     Ok(Spanned::new(Stmt::Forward(what, to), span))
 }
 
+fn build_learn_stmt(pair: Pair) -> anyhow::Result<Spanned<Stmt>> {
+    let span = to_span(&pair);
+    let child = pair.into_inner().next().unwrap();
+
+    let source = match child.as_rule() {
+        Rule::learn_from_interaction => {
+            let arg_list = child.into_inner().next().unwrap();
+            let args = build_arg_list(arg_list)?;
+            LearnSource::FromInteraction(args)
+        }
+        Rule::learn_from_document => {
+            let string_arg = child.into_inner().next().unwrap();
+            let expr = build_string_arg(string_arg)?;
+            LearnSource::FromDocument(expr)
+        }
+        Rule::learn_direct => {
+            let string_arg = child.into_inner().next().unwrap();
+            let expr = build_string_arg(string_arg)?;
+            LearnSource::Direct(expr)
+        }
+        _ => {
+            return Err(parse_error(
+                &child,
+                &format!("unexpected learn rule: {:?}", child.as_rule()),
+            ));
+        }
+    };
+
+    Ok(Spanned::new(Stmt::Learn(Spanned::new(source, span)), span))
+}
+
 // ── Control flow statements ──────────────────────────────────
 
 fn build_when_clause(pair: Pair) -> anyhow::Result<Spanned<WhenClause>> {
@@ -1066,6 +1146,7 @@ fn build_statement(pair: Pair) -> anyhow::Result<Spanned<Stmt>> {
         Rule::escalate_stmt => build_escalate_stmt(inner),
         Rule::memory_update_stmt => build_memory_update_stmt(inner),
         Rule::emit_stmt => build_emit_stmt(inner),
+        Rule::learn_stmt => build_learn_stmt(inner),
         Rule::transition_stmt => build_transition_stmt(inner),
         Rule::start_timer_stmt => build_start_timer_stmt(inner),
         Rule::cancel_timer_stmt => build_cancel_timer_stmt(inner),
@@ -1491,6 +1572,7 @@ fn build_agent_decl(pair: Pair) -> anyhow::Result<Spanned<TopLevel>> {
 
     let mut lifecycle = None;
     let mut memory = Vec::new();
+    let mut knowledge = None;
     let mut timers = Vec::new();
     let mut subscriptions = Vec::new();
     let mut warden_override = Vec::new();
@@ -1505,6 +1587,9 @@ fn build_agent_decl(pair: Pair) -> anyhow::Result<Spanned<TopLevel>> {
             Rule::lifecycle_clause => {
                 let lc_ident = child.into_inner().next().unwrap();
                 lifecycle = Some(spanned(lc_ident.as_str().to_string(), &lc_ident));
+            }
+            Rule::knowledge_block => {
+                knowledge = Some(build_knowledge_block(child)?);
             }
             Rule::memory_block => {
                 let mem_children: Vec<Pair> = child.into_inner().collect();
@@ -1583,6 +1668,7 @@ fn build_agent_decl(pair: Pair) -> anyhow::Result<Spanned<TopLevel>> {
             name,
             lifecycle,
             memory,
+            knowledge,
             timers,
             subscriptions,
             warden_override,

--- a/src/runtime/agent.rs
+++ b/src/runtime/agent.rs
@@ -12,6 +12,7 @@ use crate::llm::registry::ProviderRegistry;
 use crate::runtime::confidence::{ConfidentValue, Value};
 use crate::runtime::event_bus::{EventPayload, SharedEventBus};
 use crate::runtime::executor::{Env, RuntimeError, TaskExecutor};
+use crate::runtime::knowledge_store::KnowledgeStore;
 use crate::runtime::memory::AgentMemory;
 use crate::runtime::state_machine::StateMachine;
 use crate::runtime::timer_engine::{TimerEngine, TimerFired};
@@ -214,6 +215,7 @@ pub(crate) fn jaccard_similarity(a: &str, b: &str) -> f64 {
 #[derive(Debug, Clone)]
 pub struct AgentContext {
     pub memory: AgentMemory,
+    pub knowledge_store: Option<KnowledgeStore>,
     pub state_machine: Option<StateMachine>,
     pub timer_manager: TimerManager,
     pub event_sink: EventSink,
@@ -223,12 +225,14 @@ pub struct AgentContext {
 impl AgentContext {
     pub fn new(
         memory: AgentMemory,
+        knowledge_store: Option<KnowledgeStore>,
         state_machine: Option<StateMachine>,
         timer_manager: TimerManager,
         stuck_threshold: usize,
     ) -> Self {
         Self {
             memory,
+            knowledge_store,
             state_machine,
             timer_manager,
             event_sink: EventSink::new(),
@@ -269,8 +273,37 @@ impl AgentProcess {
             .and_then(|sp| sp.node.turns)
             .unwrap_or(3) as usize;
 
+        // Initialize knowledge store if declared
+        let knowledge_store = decl.knowledge.as_ref().map(|kd| {
+            let store_path = match &kd.node.store_path.node {
+                Expr::Template(parts) => {
+                    // Extract plain text from template (no interpolation at init time)
+                    parts
+                        .iter()
+                        .filter_map(|p| match &p.node {
+                            TemplatePart::Text(t) => Some(t.as_str()),
+                            _ => None,
+                        })
+                        .collect::<String>()
+                }
+                _ => ".forge-knowledge/default".to_string(),
+            };
+            let max_entries = kd.node.max_entries.as_ref().map(|m| m.node as usize);
+            let retention_days = kd.node.retention.as_ref().map(|r| {
+                let dur = &r.node;
+                match dur.unit {
+                    DurationUnit::Days => dur.value,
+                    DurationUnit::Hours => dur.value / 24,
+                    DurationUnit::Minutes => dur.value / (24 * 60),
+                    DurationUnit::Seconds => dur.value / (24 * 60 * 60),
+                }
+            });
+            KnowledgeStore::new(&store_path, max_entries, retention_days)
+        });
+
         let context = Arc::new(Mutex::new(AgentContext::new(
             memory,
+            knowledge_store,
             state_machine,
             timer_manager,
             stuck_threshold,

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -588,6 +588,67 @@ impl TaskExecutor {
                         return Err(RuntimeError::Unsupported("escalate outside agent".into()));
                     }
                 }
+                Stmt::Learn(source) => {
+                    if let Some(ref ctx_arc) = self.agent_context {
+                        // Check knowledge store exists (quick lock/unlock)
+                        {
+                            let ctx = ctx_arc.lock().unwrap();
+                            if ctx.knowledge_store.is_none() {
+                                return Err(RuntimeError::Unsupported(
+                                    "learn requires agent with knowledge store".into(),
+                                ));
+                            }
+                        }
+
+                        match &source.node {
+                            LearnSource::Direct(expr) => {
+                                let val = self.eval_expr(expr, env).await?;
+                                let text = format!("{}", val.value);
+                                let mut ctx = ctx_arc.lock().unwrap();
+                                if let Some(ref mut ks) = ctx.knowledge_store {
+                                    ks.learn_direct(&text);
+                                }
+                            }
+                            LearnSource::FromInteraction(args) => {
+                                let mut arg_vals = Vec::new();
+                                for arg in args {
+                                    let val = self.eval_expr(&arg.node.value, env).await?;
+                                    arg_vals.push(val);
+                                }
+                                let question = arg_vals
+                                    .first()
+                                    .map(|v| format!("{}", v.value))
+                                    .unwrap_or_default();
+                                let answer = arg_vals
+                                    .get(1)
+                                    .map(|v| format!("{}", v.value))
+                                    .unwrap_or_default();
+                                let confidence = arg_vals
+                                    .get(2)
+                                    .and_then(|v| match &v.value {
+                                        Value::Number(n) => Some(*n as f32),
+                                        _ => None,
+                                    })
+                                    .unwrap_or(0.5);
+                                let mut ctx = ctx_arc.lock().unwrap();
+                                if let Some(ref mut ks) = ctx.knowledge_store {
+                                    ks.learn_from_interaction(&question, &answer, confidence);
+                                }
+                            }
+                            LearnSource::FromDocument(expr) => {
+                                let val = self.eval_expr(expr, env).await?;
+                                let path = format!("{}", val.value);
+                                let mut ctx = ctx_arc.lock().unwrap();
+                                if let Some(ref mut ks) = ctx.knowledge_store {
+                                    ks.learn_from_document(&path)
+                                        .map_err(RuntimeError::Unsupported)?;
+                                }
+                            }
+                        }
+                    } else {
+                        return Err(RuntimeError::Unsupported("learn outside agent".into()));
+                    }
+                }
             }
             Ok(())
         })
@@ -1098,6 +1159,26 @@ impl TaskExecutor {
                 }
 
                 Expr::Search(_) => Ok(ConfidentValue::deterministic(Value::List(vec![]))),
+
+                Expr::Recall(query_expr) => {
+                    let query_val = self.eval_expr(query_expr, env).await?;
+                    let query_text = format!("{}", query_val.value);
+
+                    if let Some(ref ctx_arc) = self.agent_context {
+                        let mut ctx = ctx_arc.lock().unwrap();
+                        if let Some(ref mut ks) = ctx.knowledge_store {
+                            // Default token budget for recall: 2000 tokens
+                            let result = ks.recall(&query_text, 2000);
+                            Ok(result)
+                        } else {
+                            Err(RuntimeError::Unsupported(
+                                "recall requires agent with knowledge store".into(),
+                            ))
+                        }
+                    } else {
+                        Err(RuntimeError::Unsupported("recall outside agent".into()))
+                    }
+                }
 
                 // ── Composition ───────────────────────────────────────────────
                 Expr::TryOr(primary, fallback) => match self.eval_expr(primary, env).await {

--- a/src/runtime/knowledge_store.rs
+++ b/src/runtime/knowledge_store.rs
@@ -1,0 +1,454 @@
+// FORGE knowledge store — progressive learning agent support
+// Persistent, searchable knowledge store for agents.
+// Uses TF-IDF for retrieval (v1), JSON for persistence.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::runtime::confidence::{ConfidentValue, Value};
+use crate::types::ConfidenceSource;
+
+// ── Knowledge Entry ────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KnowledgeEntry {
+    pub id: String,
+    pub content: String,
+    pub source: KnowledgeSource,
+    pub confidence: f32,
+    pub created_at: DateTime<Utc>,
+    pub last_accessed: DateTime<Utc>,
+    pub access_count: u64,
+    pub success_associations: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum KnowledgeSource {
+    Direct,
+    Interaction {
+        question: String,
+        answer: String,
+        confidence: f32,
+    },
+    Document {
+        path: String,
+    },
+    AgentTransfer {
+        source_agent: String,
+    },
+}
+
+// ── Knowledge Store ────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct KnowledgeStore {
+    store_path: String,
+    entries: Vec<KnowledgeEntry>,
+    max_entries: usize,
+    retention_days: Option<u64>,
+    /// Inverted index: term -> list of (entry_index, term_frequency)
+    tf_index: HashMap<String, Vec<(usize, f32)>>,
+    /// Document count for IDF calculation
+    doc_count: usize,
+}
+
+impl KnowledgeStore {
+    pub fn new(store_path: &str, max_entries: Option<usize>, retention_days: Option<u64>) -> Self {
+        let mut store = KnowledgeStore {
+            store_path: store_path.to_string(),
+            entries: Vec::new(),
+            max_entries: max_entries.unwrap_or(10_000),
+            retention_days,
+            tf_index: HashMap::new(),
+            doc_count: 0,
+        };
+        store.load();
+        store.evict_expired();
+        store.rebuild_index();
+        store
+    }
+
+    // ── Learn ──────────────────────────────────────────────
+
+    pub fn learn_direct(&mut self, content: &str) {
+        let entry = KnowledgeEntry {
+            id: Uuid::new_v4().to_string(),
+            content: content.to_string(),
+            source: KnowledgeSource::Direct,
+            confidence: 1.0,
+            created_at: Utc::now(),
+            last_accessed: Utc::now(),
+            access_count: 0,
+            success_associations: 0,
+        };
+        self.add_entry(entry);
+    }
+
+    pub fn learn_from_interaction(&mut self, question: &str, answer: &str, confidence: f32) {
+        let content = format!("Q: {question}\nA: {answer}");
+        let entry = KnowledgeEntry {
+            id: Uuid::new_v4().to_string(),
+            content,
+            source: KnowledgeSource::Interaction {
+                question: question.to_string(),
+                answer: answer.to_string(),
+                confidence,
+            },
+            confidence,
+            created_at: Utc::now(),
+            last_accessed: Utc::now(),
+            access_count: 0,
+            success_associations: 0,
+        };
+        self.add_entry(entry);
+    }
+
+    pub fn learn_from_document(&mut self, path: &str) -> Result<usize, String> {
+        let content = fs::read_to_string(path)
+            .map_err(|e| format!("failed to read document '{}': {}", path, e))?;
+
+        let chunks = chunk_text(&content, 500);
+        let count = chunks.len();
+
+        for chunk in chunks {
+            let entry = KnowledgeEntry {
+                id: Uuid::new_v4().to_string(),
+                content: chunk,
+                source: KnowledgeSource::Document {
+                    path: path.to_string(),
+                },
+                confidence: 1.0,
+                created_at: Utc::now(),
+                last_accessed: Utc::now(),
+                access_count: 0,
+                success_associations: 0,
+            };
+            self.add_entry(entry);
+        }
+
+        Ok(count)
+    }
+
+    fn add_entry(&mut self, entry: KnowledgeEntry) {
+        // Evict LRU if at capacity
+        while self.entries.len() >= self.max_entries {
+            self.evict_lru();
+        }
+
+        self.entries.push(entry);
+        self.rebuild_index();
+        self.save();
+    }
+
+    // ── Recall (TF-IDF search) ─────────────────────────────
+
+    pub fn recall(&mut self, query: &str, token_budget: usize) -> ConfidentValue {
+        if self.entries.is_empty() {
+            return ConfidentValue {
+                value: Value::Text(String::new()),
+                confidence: 0.0,
+                source: ConfidenceSource::KnowledgeRecall(0.0),
+            };
+        }
+
+        let query_terms = tokenize(query);
+        let mut scores: Vec<(usize, f32)> = Vec::new();
+
+        for (idx, _entry) in self.entries.iter().enumerate() {
+            let score = self.tfidf_score(&query_terms, idx);
+            if score > 0.0 {
+                scores.push((idx, score));
+            }
+        }
+
+        // Sort by score descending
+        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Collect entries within token budget
+        let mut result_parts = Vec::new();
+        let mut tokens_used = 0;
+        let mut best_score = 0.0_f32;
+
+        for (idx, score) in &scores {
+            let entry = &self.entries[*idx];
+            let entry_tokens = estimate_tokens(&entry.content);
+
+            if tokens_used + entry_tokens > token_budget && !result_parts.is_empty() {
+                break;
+            }
+
+            result_parts.push(entry.content.clone());
+            tokens_used += entry_tokens;
+            best_score = best_score.max(*score);
+
+            // Update access metadata
+            self.entries[*idx].last_accessed = Utc::now();
+            self.entries[*idx].access_count += 1;
+        }
+
+        if result_parts.is_empty() {
+            return ConfidentValue {
+                value: Value::Text(String::new()),
+                confidence: 0.0,
+                source: ConfidenceSource::KnowledgeRecall(0.0),
+            };
+        }
+
+        // Normalize score to 0.0-1.0 confidence range
+        let confidence = best_score.clamp(0.0, 1.0);
+        let text = result_parts.join("\n---\n");
+
+        self.save();
+
+        ConfidentValue {
+            value: Value::Text(text),
+            confidence,
+            source: ConfidenceSource::KnowledgeRecall(confidence),
+        }
+    }
+
+    fn tfidf_score(&self, query_terms: &[String], doc_idx: usize) -> f32 {
+        let mut score = 0.0;
+
+        for term in query_terms {
+            if let Some(postings) = self.tf_index.get(term) {
+                let df = postings.len() as f32;
+                let idf = ((self.doc_count as f32) / df).ln() + 1.0;
+
+                for &(idx, tf) in postings {
+                    if idx == doc_idx {
+                        score += tf * idf;
+                    }
+                }
+            }
+        }
+
+        score
+    }
+
+    // ── Persistence ────────────────────────────────────────
+
+    fn save(&self) {
+        let dir = Path::new(&self.store_path);
+        if let Some(parent) = dir.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let _ = fs::create_dir_all(dir);
+
+        let json_path = dir.join("knowledge.json");
+        if let Ok(json) = serde_json::to_string_pretty(&self.entries) {
+            let _ = fs::write(json_path, json);
+        }
+    }
+
+    fn load(&mut self) {
+        let json_path = Path::new(&self.store_path).join("knowledge.json");
+        if json_path.exists() {
+            if let Ok(data) = fs::read_to_string(&json_path) {
+                if let Ok(entries) = serde_json::from_str::<Vec<KnowledgeEntry>>(&data) {
+                    self.entries = entries;
+                }
+            }
+        }
+    }
+
+    // ── Index management ───────────────────────────────────
+
+    fn rebuild_index(&mut self) {
+        self.tf_index.clear();
+        self.doc_count = self.entries.len();
+
+        for (idx, entry) in self.entries.iter().enumerate() {
+            let terms = tokenize(&entry.content);
+            let total = terms.len() as f32;
+            if total == 0.0 {
+                continue;
+            }
+
+            let mut term_counts: HashMap<&str, usize> = HashMap::new();
+            for term in &terms {
+                *term_counts.entry(term.as_str()).or_insert(0) += 1;
+            }
+
+            for (term, count) in term_counts {
+                let tf = count as f32 / total;
+                self.tf_index
+                    .entry(term.to_string())
+                    .or_default()
+                    .push((idx, tf));
+            }
+        }
+    }
+
+    // ── Eviction ───────────────────────────────────────────
+
+    fn evict_expired(&mut self) {
+        if let Some(days) = self.retention_days {
+            let cutoff = Utc::now() - chrono::Duration::days(days as i64);
+            self.entries.retain(|e| e.created_at > cutoff);
+        }
+    }
+
+    fn evict_lru(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+
+        let mut oldest_idx = 0;
+        let mut oldest_time = self.entries[0].last_accessed;
+
+        for (i, entry) in self.entries.iter().enumerate().skip(1) {
+            if entry.last_accessed < oldest_time {
+                oldest_time = entry.last_accessed;
+                oldest_idx = i;
+            }
+        }
+
+        self.entries.remove(oldest_idx);
+    }
+
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+// ── Utilities ──────────────────────────────────────────────
+
+fn tokenize(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|s| s.len() > 1)
+        .map(String::from)
+        .collect()
+}
+
+fn estimate_tokens(text: &str) -> usize {
+    // Rough estimate: ~4 chars per token
+    text.len().div_ceil(4)
+}
+
+fn chunk_text(text: &str, max_words: usize) -> Vec<String> {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.len() <= max_words {
+        return vec![text.to_string()];
+    }
+
+    words
+        .chunks(max_words)
+        .map(|chunk| chunk.join(" "))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_learn_and_recall() {
+        let tmp = TempDir::new().unwrap();
+        let store_path = tmp
+            .path()
+            .join("test_knowledge")
+            .to_string_lossy()
+            .to_string();
+        let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+
+        store.learn_direct("Rust is a systems programming language");
+        store.learn_direct("Python is great for data science");
+        store.learn_direct("FORGE is built with Rust");
+
+        let result = store.recall("Rust programming", 1000);
+        assert!(result.confidence > 0.0);
+
+        let text = format!("{}", result.value);
+        assert!(text.contains("Rust"));
+    }
+
+    #[test]
+    fn test_learn_from_interaction() {
+        let tmp = TempDir::new().unwrap();
+        let store_path = tmp
+            .path()
+            .join("test_knowledge")
+            .to_string_lossy()
+            .to_string();
+        let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+
+        store.learn_from_interaction(
+            "How do I search GPU offers?",
+            "Use vastai search offers",
+            0.9,
+        );
+
+        let result = store.recall("GPU offers search", 1000);
+        assert!(result.confidence > 0.0);
+    }
+
+    #[test]
+    fn test_persistence() {
+        let tmp = TempDir::new().unwrap();
+        let store_path = tmp
+            .path()
+            .join("test_knowledge")
+            .to_string_lossy()
+            .to_string();
+
+        {
+            let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+            store.learn_direct("persistent fact");
+        }
+
+        // Reload
+        let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+        assert_eq!(store.entry_count(), 1);
+
+        let result = store.recall("persistent", 1000);
+        assert!(result.confidence > 0.0);
+    }
+
+    #[test]
+    fn test_max_entries_eviction() {
+        let tmp = TempDir::new().unwrap();
+        let store_path = tmp
+            .path()
+            .join("test_knowledge")
+            .to_string_lossy()
+            .to_string();
+        let mut store = KnowledgeStore::new(&store_path, Some(3), None);
+
+        store.learn_direct("fact one");
+        store.learn_direct("fact two");
+        store.learn_direct("fact three");
+        store.learn_direct("fact four");
+
+        assert_eq!(store.entry_count(), 3);
+    }
+
+    #[test]
+    fn test_empty_recall() {
+        let tmp = TempDir::new().unwrap();
+        let store_path = tmp
+            .path()
+            .join("test_knowledge")
+            .to_string_lossy()
+            .to_string();
+        let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+
+        let result = store.recall("anything", 1000);
+        assert_eq!(result.confidence, 0.0);
+    }
+
+    #[test]
+    fn test_tokenize() {
+        let tokens = tokenize("Hello, World! How are you?");
+        assert!(tokens.contains(&"hello".to_string()));
+        assert!(tokens.contains(&"world".to_string()));
+        assert!(tokens.contains(&"how".to_string()));
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -6,6 +6,7 @@ pub mod confidence;
 pub mod event_bus;
 pub mod executor;
 pub mod http_server;
+pub mod knowledge_store;
 pub mod memory;
 pub mod pool;
 pub mod state_machine;

--- a/src/runtime/pool.rs
+++ b/src/runtime/pool.rs
@@ -424,6 +424,7 @@ fn ast_duration_to_tokio(d: &Duration) -> tokio::time::Duration {
         DurationUnit::Seconds => d.value,
         DurationUnit::Minutes => d.value * 60,
         DurationUnit::Hours => d.value * 3600,
+        DurationUnit::Days => d.value * 86400,
     };
     tokio::time::Duration::from_secs(secs)
 }
@@ -433,6 +434,7 @@ fn format_duration(d: &Duration) -> String {
         DurationUnit::Seconds => format!("{}s", d.value),
         DurationUnit::Minutes => format!("{}m", d.value),
         DurationUnit::Hours => format!("{}h", d.value),
+        DurationUnit::Days => format!("{}d", d.value),
     }
 }
 

--- a/src/runtime/timer_engine.rs
+++ b/src/runtime/timer_engine.rs
@@ -43,6 +43,7 @@ fn ast_duration_to_std(dur: &crate::ast::Duration) -> std::time::Duration {
         DurationUnit::Seconds => dur.value,
         DurationUnit::Minutes => dur.value * 60,
         DurationUnit::Hours => dur.value * 3600,
+        DurationUnit::Days => dur.value * 86400,
     };
     std::time::Duration::from_secs(secs)
 }

--- a/src/runtime/warden.rs
+++ b/src/runtime/warden.rs
@@ -194,5 +194,6 @@ fn duration_to_ms(d: &Duration) -> u64 {
         DurationUnit::Seconds => d.value * 1000,
         DurationUnit::Minutes => d.value * 60 * 1000,
         DurationUnit::Hours => d.value * 3600 * 1000,
+        DurationUnit::Days => d.value * 86400 * 1000,
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -80,6 +80,8 @@ pub enum ConfidenceSource {
     ConsensusAgreement(f32),
     /// Propagated from upstream
     Derived(f32),
+    /// Retrieved from knowledge store (confidence = retrieval relevance)
+    KnowledgeRecall(f32),
 }
 
 // ── Conversions ──────────────────────────────────────────────

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -40,6 +40,7 @@ fn simple_agent(
         name: spanned("test_agent".into()),
         lifecycle: None,
         memory: memory_fields,
+        knowledge: None,
         timers: vec![],
         subscriptions: vec![],
         warden_override: Vec::new(),

--- a/tests/ast_tests.rs
+++ b/tests/ast_tests.rs
@@ -416,6 +416,7 @@ fn ast_agent() {
                 type_name: sp(TypeName::Profile),
             }),
         ],
+        knowledge: None,
         timers: vec![],
         subscriptions: vec![],
         handlers: vec![
@@ -982,6 +983,7 @@ fn ast_agent_v3() {
                 type_name: sp(TypeName::Number),
             }),
         ],
+        knowledge: None,
         timers: vec![sp(TimerField {
             name: sp("reconnect_window".into()),
             duration: sp(Duration {

--- a/tests/event_bus_tests.rs
+++ b/tests/event_bus_tests.rs
@@ -61,6 +61,7 @@ fn subscribing_agent(name: &str, event_name: &str, filter: Option<Spanned<Expr>>
         name: spanned(name.into()),
         lifecycle: None,
         memory: vec![],
+        knowledge: None,
         timers: vec![],
         subscriptions: vec![spanned(SubscribeDecl {
             event_name: spanned(event_name.into()),
@@ -89,6 +90,7 @@ fn emitting_agent(name: &str, trigger_event: &str, emit_event: &str) -> AgentDec
         name: spanned(name.into()),
         lifecycle: None,
         memory: vec![],
+        knowledge: None,
         timers: vec![],
         subscriptions: vec![],
         handlers: vec![spanned(OnHandler {
@@ -348,6 +350,7 @@ async fn multi_agent_event_flow() {
             name: "player_count".into(),
             type_name: spanned(TypeName::Number),
         })],
+        knowledge: None,
         timers: vec![],
         subscriptions: vec![],
         handlers: vec![spanned(OnHandler {

--- a/tests/knowledge_tests.rs
+++ b/tests/knowledge_tests.rs
@@ -1,0 +1,170 @@
+// FORGE knowledge store integration tests
+// Tests the full pipeline: parse → check → runtime for knowledge/recall/learn.
+
+use tempfile::TempDir;
+
+use forge::runtime::knowledge_store::KnowledgeStore;
+
+// ── Knowledge Store Unit-Level Integration ──────────────────────────
+
+#[test]
+fn knowledge_persists_across_restarts() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+
+    // Session 1: learn facts
+    {
+        let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+        store.learn_direct("FORGE is a language for oracle-augmented computation");
+        store.learn_direct("Agents are first-class in FORGE");
+        store.learn_from_interaction("What is FORGE?", "A language for AI agents", 0.95);
+        assert_eq!(store.entry_count(), 3);
+    }
+
+    // Session 2: reload and verify
+    {
+        let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+        assert_eq!(store.entry_count(), 3);
+
+        let result = store.recall("FORGE language", 1000);
+        assert!(
+            result.confidence > 0.0,
+            "recall should find persisted entries"
+        );
+
+        let text = format!("{}", result.value);
+        assert!(
+            text.contains("FORGE"),
+            "recalled text should contain 'FORGE', got: {}",
+            text
+        );
+    }
+}
+
+#[test]
+fn recall_respects_token_budget() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+
+    let mut store = KnowledgeStore::new(&store_path, Some(1000), None);
+
+    // Insert many entries with the search term
+    for i in 0..50 {
+        store.learn_direct(&format!(
+            "Fact number {} about Rust programming language and systems design",
+            i
+        ));
+    }
+
+    // Very small budget — should only return a few entries
+    let small = store.recall("Rust programming", 20);
+    let small_text = format!("{}", small.value);
+
+    // Large budget — should return more entries
+    let large = store.recall("Rust programming", 5000);
+    let large_text = format!("{}", large.value);
+
+    assert!(
+        large_text.len() >= small_text.len(),
+        "larger budget should return at least as much text"
+    );
+}
+
+#[test]
+fn max_entries_evicts_lru() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+
+    let mut store = KnowledgeStore::new(&store_path, Some(5), None);
+
+    // Fill to capacity
+    store.learn_direct("alpha fact");
+    store.learn_direct("beta fact");
+    store.learn_direct("gamma fact");
+    store.learn_direct("delta fact");
+    store.learn_direct("epsilon fact");
+    assert_eq!(store.entry_count(), 5);
+
+    // Access "alpha" so it's recently accessed
+    let _ = store.recall("alpha", 1000);
+
+    // Add one more — should evict LRU (beta, since alpha was just accessed)
+    store.learn_direct("zeta fact");
+    assert_eq!(store.entry_count(), 5);
+
+    // Alpha should still be findable (it was recently accessed)
+    let result = store.recall("alpha", 1000);
+    let text = format!("{}", result.value);
+    assert!(
+        text.contains("alpha"),
+        "recently accessed entry should survive eviction"
+    );
+}
+
+#[test]
+fn learn_from_document_creates_entries() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+
+    // Create a test document
+    let doc_path = tmp.path().join("test_doc.md");
+    std::fs::write(
+        &doc_path,
+        "# FORGE Reference\n\nFORGE is a programming language for oracle-augmented computation.\n\nAgents are first-class primitives with memory and lifecycle.\n\nThe recall keyword retrieves from knowledge stores.",
+    )
+    .unwrap();
+
+    let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+    let count = store
+        .learn_from_document(doc_path.to_str().unwrap())
+        .expect("document ingestion should succeed");
+
+    assert!(count > 0, "should create at least one entry from document");
+    assert_eq!(store.entry_count(), count);
+
+    // Recall should find document content
+    let result = store.recall("recall keyword knowledge", 1000);
+    assert!(
+        result.confidence > 0.0,
+        "should find relevant content from ingested document"
+    );
+}
+
+#[test]
+fn learn_from_missing_document_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+
+    let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+    let result = store.learn_from_document("/nonexistent/path/doc.md");
+
+    assert!(result.is_err(), "missing document should return error");
+}
+
+#[test]
+fn empty_store_recall_returns_zero_confidence() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+
+    let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+    let result = store.recall("anything", 1000);
+
+    assert_eq!(result.confidence, 0.0);
+    let text = format!("{}", result.value);
+    assert!(text.is_empty(), "empty store should return empty text");
+}
+
+#[test]
+fn interaction_learning_tracks_source() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+
+    let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+    store.learn_from_interaction("How do I search GPUs?", "Use vastai search offers", 0.85);
+
+    let result = store.recall("search GPUs vastai", 1000);
+    assert!(result.confidence > 0.0);
+
+    let text = format!("{}", result.value);
+    assert!(text.contains("vastai"), "should recall interaction content");
+}

--- a/tests/timer_tests.rs
+++ b/tests/timer_tests.rs
@@ -53,6 +53,7 @@ fn simple_agent_with_timers(
         name: spanned("test_agent".into()),
         lifecycle: None,
         memory: vec![],
+        knowledge: None,
         timers,
         subscriptions: vec![],
         handlers,

--- a/tests/warded_tests.rs
+++ b/tests/warded_tests.rs
@@ -24,6 +24,7 @@ fn simple_agent(name: &str) -> AgentDecl {
         name: sp(name.to_string()),
         lifecycle: None,
         memory: vec![],
+        knowledge: None,
         timers: vec![],
         subscriptions: vec![],
         warden_override: vec![],
@@ -47,6 +48,7 @@ fn crashing_agent(name: &str) -> AgentDecl {
         name: sp(name.to_string()),
         lifecycle: None,
         memory: vec![],
+        knowledge: None,
         timers: vec![],
         subscriptions: vec![sp(SubscribeDecl {
             event_name: sp("trigger".to_string()),


### PR DESCRIPTION
## Summary

- Adds three new FORGE language primitives (`knowledge`, `recall`, `learn`) that enable agents to build expertise through persistent, searchable knowledge stores
- Knowledge store uses TF-IDF retrieval with JSON persistence, LRU eviction, and token-budget-aware recall
- `recall` returns `uncertain<T>` — all existing principle enforcement (honesty, purity, determinism boundary) applies automatically

## Changes

**Grammar & Parser:** `knowledge_block`, `recall_expr`, `learn_stmt` (3 forms: direct, interaction, document)
**AST:** `KnowledgeDecl`, `Expr::Recall`, `Stmt::Learn(LearnSource)`, `DurationUnit::Days`
**Checkers:** Extended uncertain (oracle detection), pure (forbidden), boundary (ref walking), requires (warning)
**Runtime:** New `knowledge_store.rs` with TF-IDF search, JSON persistence, LRU eviction, retention
**Executor:** `Expr::Recall` and `Stmt::Learn` handling, `AgentContext.knowledge_store` wiring

## Test plan

- [x] 6 knowledge store unit tests (learn, recall, persistence, eviction, empty, tokenize)
- [x] 7 integration tests (persistence across restarts, token budget, LRU eviction, document ingestion, error handling)
- [x] 5 conformance tests (parse ok, recall uncertain, pure no recall, pure no learn, compile ok)
- [x] All 128+ existing tests pass
- [x] `forge parse` and `forge check` work on `examples/learning_agent.forge`
- [x] `cargo fmt --check` clean, `cargo clippy` no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)