### PR TITLE
feat: forge build — package FORGE programs as standalone CLI binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `forge build` command: package FORGE programs as standalone CLI binaries with embedded sources and runtime (#74)
+- Multi-file composition: `forge.project.toml` manifest, `merge_programs()` engine, cross-file symbol dedup, single fn main/system enforcement
+- `forge run --manifest` for multi-file execution without building a binary
+- Generated agent binaries with clap subcommands per handler, interactive REPL, and `--help`
+- Config embedding: `--embed-config` bakes a `forge.config.toml` into built binaries with runtime override support
+- `--dry-run` mode for build validation without compilation
 - `forge-sensei`: FORGE language learning agent written in FORGE, with knowledge store, mastery progression (novice→expert), conformance-based assessment, and Claude Code integration via hook + skill
 - `forge send` CLI command for non-interactive agent message dispatch
 - Agent portability: `exportable` modifier, `import ... from ... as` declaration, `.forgepkg.json` package format with SHA-256 integrity, `forge export`/`import`/`inspect` CLI commands (#72)

--- a/examples/quiz_tutor.forge
+++ b/examples/quiz_tutor.forge
@@ -26,25 +26,33 @@ task generate_question
   needs topic: Text, difficulty: Text
   gives Text
   do
-    give reason "You are a FORGE programming language tutor. Generate one quiz question about '{topic}' at {difficulty} difficulty. FORGE is a language for AI agent systems with tasks, flows, agents, confidence predicates, and composition operators. Be specific. Do not include the answer."
+    result = reason "You are a FORGE programming language tutor. Generate one quiz question about '{topic}' at {difficulty} difficulty. FORGE is a language for AI agent systems with tasks, flows, agents, confidence predicates, and composition operators. Be specific. Do not include the answer."
+    when result.sure -> give result
+    else -> give "What is a task in FORGE?"
 
 task check_answer
   needs question: Text, student_answer: Text
   gives Text
   do
-    give reason "Grade this FORGE quiz answer. Question: {question}. Answer: {student_answer}. Reply CORRECT, PARTIAL, or WRONG then a one-sentence explanation."
+    result = reason "Grade this FORGE quiz answer. Question: {question}. Answer: {student_answer}. Reply CORRECT, PARTIAL, or WRONG then a one-sentence explanation."
+    when result.sure -> give result
+    else -> give "PARTIAL — could not grade with confidence"
 
 task generate_hint
   needs question: Text, topic: Text
   gives Text
   do
-    give reason "Give a short hint (not the answer) for this FORGE question: {question}. Topic: {topic}."
+    result = reason "Give a short hint (not the answer) for this FORGE question: {question}. Topic: {topic}."
+    when result.sure -> give result
+    else -> give "Think about how FORGE handles this concept."
 
 task pick_topic
   needs difficulty: Text, previous: Text
   gives Text
   do
-    give reason "Pick one topic for a {difficulty} FORGE quiz from the appropriate list. Beginner: tasks, pure functions, say/give, template strings, types. Intermediate: flows, stages, confidence, when/else, composition, try-or. Advanced: agents, memory, stuck detection, state machines, requires guards, events, timers. Do NOT pick '{previous}'. Reply with just the topic name."
+    result = reason "Pick one topic for a {difficulty} FORGE quiz from the appropriate list. Beginner: tasks, pure functions, say/give, template strings, types. Intermediate: flows, stages, confidence, when/else, composition, try-or. Advanced: agents, memory, stuck detection, state machines, requires guards, events, timers. Do NOT pick '{previous}'. Reply with just the topic name."
+    when result.sure -> give result
+    else -> give "tasks"
 
 # ── The tutor agent ───────────────────────────────────────────
 #
@@ -76,6 +84,7 @@ agent forge_tutor
 
   on answer(student_answer: Text)
     requires memory.questions_asked > 0 on fail: give "No active question. Send 'start' first."
+    requires lifecycle == beginner or lifecycle == intermediate on fail: silent
     verdict = check_answer(memory.current_question, student_answer)
     grade = classify verdict into ["correct", "partial", "wrong"]
     when grade.sure -> say "Graded with confidence."
@@ -96,15 +105,14 @@ agent forge_tutor
       emit TopicCompleted(topic: memory.current_topic, score: memory.score)
       memory.streak = 0
       say "Topic mastered!"
-    if memory.score >= 7
+    if memory.score >= 7 and lifecycle == intermediate
       memory.level = "advanced"
       transition to advanced
       say "Level up: ADVANCED!"
-    if memory.score >= 3
-      if memory.level == "beginner"
-        memory.level = "intermediate"
-        transition to intermediate
-        say "Level up: INTERMEDIATE!"
+    if memory.score >= 3 and lifecycle == beginner
+      memory.level = "intermediate"
+      transition to intermediate
+      say "Level up: INTERMEDIATE!"
     topic = pick_topic(memory.level, memory.current_topic)
     memory.current_topic = topic
     question = generate_question(topic, memory.level)

--- a/examples/tictactoe/forge.project.toml
+++ b/examples/tictactoe/forge.project.toml
@@ -1,0 +1,13 @@
+[project]
+name = "tictactoe"
+version = "0.1.0"
+description = "Multi-agent tic-tac-toe game system"
+
+[build]
+entry = "platform.forge"
+output = "tictactoe"
+sources = [
+  "room_agent.forge",
+  "ai_opponent.forge",
+  "matchmaking.forge",
+]

--- a/examples/tictactoe/matchmaking.forge
+++ b/examples/tictactoe/matchmaking.forge
@@ -13,7 +13,8 @@ flow matchmaking
 
   stage find_opponents
     candidates = search "players near rank {request.rank}"
-    give candidates
+    when candidates.sure -> give candidates
+    else -> give "no matches"
 
   stage select_best
     needs find_opponents.candidates

--- a/examples/tictactoe/room_agent.forge
+++ b/examples/tictactoe/room_agent.forge
@@ -11,6 +11,7 @@ event MoveMade
 states GamePhase
   waiting -> playing when player_count == 2
   playing -> finished
+  finished -> waiting
 
 type GameResult
   winner: Text

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,786 @@
+// FORGE build pipeline — package .forge programs as standalone CLI binaries
+// See issue #74 for specification
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::compose::{self, ProgramKind, SourceFile};
+use crate::manifest::ProjectManifest;
+
+// ── Build pipeline ────────────────────────────────────────────
+
+pub struct BuildPipeline {
+    manifest: ProjectManifest,
+    base_dir: PathBuf,
+    dry_run: bool,
+    output_dir: Option<PathBuf>,
+    embed_config: Option<PathBuf>,
+    release: bool,
+}
+
+/// Result of a successful build.
+pub struct BuildResult {
+    pub binary_path: PathBuf,
+    pub program_kind: ProgramKind,
+}
+
+/// Result of a dry run (validation only).
+pub struct DryRunResult {
+    pub program_kind: ProgramKind,
+    pub source_count: usize,
+    pub symbol_count: usize,
+}
+
+impl BuildPipeline {
+    pub fn new(manifest: ProjectManifest, base_dir: PathBuf) -> Self {
+        Self {
+            manifest,
+            base_dir,
+            dry_run: false,
+            output_dir: None,
+            embed_config: None,
+            release: true,
+        }
+    }
+
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
+        self.dry_run = dry_run;
+        self
+    }
+
+    pub fn output_dir(mut self, dir: Option<PathBuf>) -> Self {
+        self.output_dir = dir;
+        self
+    }
+
+    pub fn embed_config(mut self, path: Option<PathBuf>) -> Self {
+        self.embed_config = path;
+        self
+    }
+
+    pub fn release(mut self, release: bool) -> Self {
+        self.release = release;
+        self
+    }
+
+    /// Run the full build pipeline.
+    pub fn build(&self) -> anyhow::Result<BuildResult> {
+        // Step 1: Resolve source files
+        let source_paths = self.manifest.resolve_sources(&self.base_dir)?;
+        eprintln!("  sources: {} file(s)", source_paths.len());
+
+        // Step 2: Parse all source files
+        let mut source_files = Vec::new();
+        let mut source_texts = Vec::new();
+        for path in &source_paths {
+            let source = std::fs::read_to_string(path)
+                .map_err(|e| anyhow::anyhow!("cannot read {}: {}", path.display(), e))?;
+            let fname = path.display().to_string();
+            let program = crate::parser::parse(&source).map_err(|e| {
+                let diag = e.to_diagnostic(&fname);
+                diag.render(&source);
+                anyhow::anyhow!("parse error in {}", fname)
+            })?;
+            source_texts.push((fname.clone(), source.clone()));
+            source_files.push(SourceFile {
+                path: fname,
+                source,
+                program,
+            });
+        }
+
+        // Step 3: Per-file validation
+        let mut diagnostics = Vec::new();
+        for sf in &source_files {
+            let ctx = crate::resolver::CheckContext::new(&sf.path);
+            if let Err(errors) = ctx.check(&sf.program) {
+                let registry = crate::resolver::CapabilityRegistry::builtin();
+                diagnostics.extend(errors.iter().map(|e| e.to_diagnostic(&sf.path, &registry)));
+            }
+            diagnostics.extend(crate::checker::check_all(&sf.program, &sf.path));
+        }
+
+        // Step 4: Cross-file boundary check (on pre-merge programs)
+        let boundary_refs: Vec<_> = source_files
+            .iter()
+            .map(|sf| (&sf.program, sf.path.as_str()))
+            .collect();
+        diagnostics.extend(crate::checker::boundary_checker::check(&boundary_refs));
+
+        // Render all diagnostics, but only fail on errors
+        if !diagnostics.is_empty() {
+            for diag in &diagnostics {
+                if let Some(sf) = source_files.iter().find(|sf| sf.path == diag.file) {
+                    diag.render(&sf.source);
+                }
+            }
+            let error_count = diagnostics
+                .iter()
+                .filter(|d| d.kind == crate::diagnostic::DiagnosticKind::Error)
+                .count();
+            if error_count > 0 {
+                anyhow::bail!("validation failed with {} error(s)", error_count);
+            }
+        }
+
+        // Step 5: Merge programs
+        let composed = compose::merge_programs(&source_files).map_err(|errs| {
+            anyhow::anyhow!(
+                "composition failed:\n{}",
+                errs.iter()
+                    .map(|e| format!("  {}", e))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        })?;
+
+        // Step 6: Detect program kind
+        let kind = compose::detect_kind(&composed.program).ok_or_else(|| {
+            anyhow::anyhow!("no entry point found (fn main, agent, endpoint, or system)")
+        })?;
+
+        eprintln!("  kind: {:?}", kind);
+
+        if kind == ProgramKind::System {
+            anyhow::bail!(
+                "system binaries are not yet supported — system runtime is under development"
+            );
+        }
+
+        // Dry run: stop here
+        if self.dry_run {
+            let symbol_count = composed
+                .program
+                .items
+                .iter()
+                .filter(|i| compose::top_level_has_name(&i.node))
+                .count();
+            eprintln!("  dry run: validation passed");
+            eprintln!("  symbols: {}", symbol_count);
+            // Return a dummy result — caller checks dry_run flag
+            return Ok(BuildResult {
+                binary_path: PathBuf::from("<dry-run>"),
+                program_kind: kind,
+            });
+        }
+
+        // Step 7: Resolve embedded config
+        let embed_config_content = self.resolve_embed_config()?;
+
+        // Step 8: Generate temporary Rust crate
+        let crate_dir =
+            self.generate_crate(&source_paths, kind, embed_config_content.as_deref())?;
+        eprintln!("  crate: {}", crate_dir.display());
+
+        // Step 9: cargo build
+        let binary_path = self.cargo_build(&crate_dir, kind)?;
+        eprintln!("  binary: {}", binary_path.display());
+
+        // Step 10: Clean up temp crate
+        let _ = std::fs::remove_dir_all(&crate_dir);
+
+        Ok(BuildResult {
+            binary_path,
+            program_kind: kind,
+        })
+    }
+
+    fn resolve_embed_config(&self) -> anyhow::Result<Option<String>> {
+        // CLI flag takes precedence over manifest
+        let config_path = self.embed_config.clone().or_else(|| {
+            self.manifest
+                .resolve_embedded_config(&self.base_dir)
+                .ok()
+                .flatten()
+        });
+
+        if let Some(path) = config_path {
+            let content = std::fs::read_to_string(&path)
+                .map_err(|e| anyhow::anyhow!("cannot read config {}: {}", path.display(), e))?;
+            Ok(Some(content))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn generate_crate(
+        &self,
+        source_paths: &[PathBuf],
+        kind: ProgramKind,
+        embed_config: Option<&str>,
+    ) -> anyhow::Result<PathBuf> {
+        // Create temp directory
+        let crate_dir = std::env::temp_dir().join(format!("forge_build_{}", std::process::id()));
+        let src_dir = crate_dir.join("src");
+        let sources_dir = crate_dir.join("sources");
+        std::fs::create_dir_all(&src_dir)?;
+        std::fs::create_dir_all(&sources_dir)?;
+
+        // Copy .forge source files into sources/
+        let mut source_entries = Vec::new();
+        for path in source_paths {
+            let filename = path
+                .file_name()
+                .ok_or_else(|| anyhow::anyhow!("invalid source path: {}", path.display()))?
+                .to_string_lossy()
+                .to_string();
+            std::fs::copy(path, sources_dir.join(&filename))?;
+            source_entries.push(format!(
+                "    (\"{}\", include_str!(\"../sources/{}\"))",
+                filename, filename
+            ));
+        }
+
+        // Generate Cargo.toml
+        let forge_dep = forge_dependency_spec();
+        let cargo_toml = format!(
+            r#"[package]
+name = "{name}"
+version = "{version}"
+edition = "2021"
+
+[dependencies]
+forge = {forge_dep}
+tokio = {{ version = "1", features = ["full"] }}
+clap = {{ version = "4", features = ["derive"] }}
+anyhow = "1"
+dirs = "6"
+"#,
+            name = self.manifest.project.name,
+            version = self.manifest.project.version.as_deref().unwrap_or("0.1.0"),
+            forge_dep = forge_dep,
+        );
+        std::fs::write(crate_dir.join("Cargo.toml"), cargo_toml)?;
+
+        // Generate src/main.rs based on program kind
+        let main_rs = match kind {
+            ProgramKind::Executable => generate_executable_main(&source_entries, embed_config),
+            ProgramKind::AgentCli => {
+                // Need to read the agent info for codegen
+                let agent_info = self.extract_agent_info(source_paths)?;
+                generate_agent_cli_main(&source_entries, embed_config, &agent_info)
+            }
+            ProgramKind::Server => generate_server_main(&source_entries, embed_config),
+            ProgramKind::System => unreachable!("system kind rejected earlier"),
+        };
+        std::fs::write(src_dir.join("main.rs"), main_rs)?;
+
+        Ok(crate_dir)
+    }
+
+    fn extract_agent_info(&self, source_paths: &[PathBuf]) -> anyhow::Result<AgentInfo> {
+        // Parse all files and find the agent declaration
+        for path in source_paths {
+            let source = std::fs::read_to_string(path)?;
+            let program = crate::parser::parse(&source).map_err(|e| {
+                anyhow::anyhow!(
+                    "parse error: {}",
+                    e.to_diagnostic(&path.display().to_string()).message
+                )
+            })?;
+            if let Some(agent) = compose::find_agent(&program, None) {
+                let handlers: Vec<HandlerInfo> = agent
+                    .handlers
+                    .iter()
+                    .map(|h| {
+                        let params: Vec<(String, String)> = h
+                            .node
+                            .params
+                            .iter()
+                            .map(|p| (p.node.name.clone(), format!("{:?}", p.node.type_name.node)))
+                            .collect();
+                        HandlerInfo {
+                            event: h.node.event.node.clone(),
+                            params,
+                        }
+                    })
+                    .collect();
+
+                return Ok(AgentInfo {
+                    name: agent.name.node.clone(),
+                    handlers,
+                });
+            }
+        }
+        anyhow::bail!("no agent declaration found in source files")
+    }
+
+    fn cargo_build(&self, crate_dir: &Path, _kind: ProgramKind) -> anyhow::Result<PathBuf> {
+        let mut cmd = Command::new("cargo");
+        cmd.arg("build");
+        if self.release {
+            cmd.arg("--release");
+        }
+        cmd.current_dir(crate_dir);
+
+        eprintln!("  compiling...");
+        let output = cmd
+            .output()
+            .map_err(|e| anyhow::anyhow!("failed to run cargo: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("cargo build failed:\n{}", stderr);
+        }
+
+        // Find the built binary (cargo names it after [package].name)
+        let profile = if self.release { "release" } else { "debug" };
+        let crate_name = &self.manifest.project.name;
+        let built_binary = crate_dir.join("target").join(profile).join(crate_name);
+
+        if !built_binary.exists() {
+            anyhow::bail!(
+                "expected binary at {} but it doesn't exist",
+                built_binary.display()
+            );
+        }
+
+        // Copy to output location (using manifest output name, which may differ from crate name)
+        let output_name = self.manifest.output_name();
+        let output_path = self
+            .output_dir
+            .as_ref()
+            .map(|d| d.join(output_name))
+            .unwrap_or_else(|| PathBuf::from(output_name));
+
+        // Create output directory if it doesn't exist
+        if let Some(parent) = output_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+
+        std::fs::copy(&built_binary, &output_path)?;
+
+        // Make executable on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&output_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&output_path, perms)?;
+        }
+
+        Ok(output_path)
+    }
+}
+
+// ── Agent codegen info ────────────────────────────────────────
+
+struct AgentInfo {
+    name: String,
+    handlers: Vec<HandlerInfo>,
+}
+
+struct HandlerInfo {
+    event: String,
+    params: Vec<(String, String)>, // (name, type_debug_string)
+}
+
+fn to_pascal_case(s: &str) -> String {
+    s.split(['_', '.'])
+        .map(|part| {
+            let mut c = part.chars();
+            match c.next() {
+                None => String::new(),
+                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+            }
+        })
+        .collect()
+}
+
+// ── Forge dependency resolution ───────────────────────────────
+
+fn forge_dependency_spec() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let cargo_toml = Path::new(manifest_dir).join("Cargo.toml");
+    if cargo_toml.exists() {
+        format!("{{ path = \"{}\" }}", manifest_dir)
+    } else {
+        format!("\"{}\"", env!("CARGO_PKG_VERSION"))
+    }
+}
+
+// ── Template: config resolution ───────────────────────────────
+
+fn config_resolution_code(embed_config: Option<&str>) -> String {
+    // For embedded config, we use r##"..."## (double-hash) to avoid conflicts
+    // with TOML content that may contain `"#`
+    let embedded_block = if let Some(config_toml) = embed_config {
+        let mut s = String::from("const EMBEDDED_CONFIG: Option<&str> = Some(r##\"");
+        s.push_str(config_toml);
+        s.push_str("\"##);\n");
+        s
+    } else {
+        "const EMBEDDED_CONFIG: Option<&str> = None;\n".to_string()
+    };
+
+    let mut code = embedded_block;
+    code.push_str(
+        r#"
+fn resolve_config() -> forge::config::ForgeConfig {
+    // Standard load checks FORGE_CONFIG env, ./forge.config.toml, ~/.forge/config.toml
+    let config = forge::config::ForgeConfig::load_or_default();
+
+    // If standard load found a real config, use it
+    if std::env::var("FORGE_CONFIG").is_ok()
+        || std::path::Path::new("forge.config.toml").exists()
+        || dirs::home_dir()
+            .map(|h| h.join(".forge/config.toml").exists())
+            .unwrap_or(false)
+    {
+        return config;
+    }
+
+    // Fall back to embedded config
+    if let Some(toml_str) = EMBEDDED_CONFIG {
+        if let Ok(cfg) = forge::config::ForgeConfig::from_toml_str(toml_str) {
+            return cfg;
+        }
+    }
+
+    config
+}
+"#,
+    );
+    code
+}
+
+// ── Template: Executable ──────────────────────────────────────
+
+fn generate_executable_main(source_entries: &[String], embed_config: Option<&str>) -> String {
+    let sources_array = source_entries.join(",\n    ");
+    let config_code = config_resolution_code(embed_config);
+
+    format!(
+        r#"use std::sync::Arc;
+
+const SOURCES: &[(&str, &str)] = &[
+{sources}
+];
+
+{config}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {{
+    let program = forge::compose::parse_and_merge_sources(SOURCES)
+        .map_err(|e| anyhow::anyhow!("{{}}", e))?;
+    let config = resolve_config();
+    let registry = forge::llm::registry::ProviderRegistry::from_config(config)
+        .map_err(|e| anyhow::anyhow!("provider setup failed: {{}}", e))?;
+    let executor = forge::runtime::executor::TaskExecutor::new(
+        program, Arc::new(registry), None,
+    );
+    match executor.run().await {{
+        Ok(_) => Ok(()),
+        Err(e) => {{
+            eprintln!("runtime error: {{}}", e);
+            std::process::exit(1);
+        }}
+    }}
+}}
+"#,
+        sources = sources_array,
+        config = config_code,
+    )
+}
+
+// ── Template: Agent CLI ───────────────────────────────────────
+
+fn generate_agent_cli_main(
+    source_entries: &[String],
+    embed_config: Option<&str>,
+    agent: &AgentInfo,
+) -> String {
+    let sources_array = source_entries.join(",\n    ");
+    let config_code = config_resolution_code(embed_config);
+
+    // Generate subcommand variants
+    let mut variants = Vec::new();
+    let mut match_arms = Vec::new();
+
+    for handler in &agent.handlers {
+        let variant = to_pascal_case(&handler.event);
+
+        if handler.params.is_empty() {
+            variants.push(format!(
+                "    /// Handler: {event}\n    {variant},",
+                event = handler.event,
+                variant = variant,
+            ));
+            match_arms.push(format!(
+                r#"        Command::{variant} => {{
+            let params = std::collections::HashMap::new();
+            dispatch(&agent, "{event}", params).await?;
+        }}"#,
+                variant = variant,
+                event = handler.event,
+            ));
+        } else {
+            let fields: Vec<String> = handler
+                .params
+                .iter()
+                .map(|(name, _)| format!("        {}: String,", name))
+                .collect();
+            variants.push(format!(
+                "    /// Handler: {event}\n    {variant} {{\n{fields}\n    }},",
+                event = handler.event,
+                variant = variant,
+                fields = fields.join("\n"),
+            ));
+
+            let param_inserts: Vec<String> = handler
+                .params
+                .iter()
+                .map(|(name, _)| {
+                    format!(
+                        r#"            params.insert("{name}".to_string(), forge::runtime::confidence::ConfidentValue::deterministic(forge::runtime::confidence::Value::Text({name})));"#,
+                        name = name,
+                    )
+                })
+                .collect();
+
+            let destructure_fields: Vec<String> = handler
+                .params
+                .iter()
+                .map(|(name, _)| name.clone())
+                .collect();
+
+            match_arms.push(format!(
+                r#"        Command::{variant} {{ {destructure} }} => {{
+            let mut params = std::collections::HashMap::new();
+{inserts}
+            dispatch(&agent, "{event}", params).await?;
+        }}"#,
+                variant = variant,
+                event = handler.event,
+                destructure = destructure_fields.join(", "),
+                inserts = param_inserts.join("\n"),
+            ));
+        }
+    }
+
+    // Add Repl variant
+    variants.push("    /// Start interactive REPL session\n    Repl,".to_string());
+    match_arms.push(
+        r#"        Command::Repl => {
+            run_repl(&agent, &agent_decl).await?;
+        }"#
+        .to_string(),
+    );
+
+    format!(
+        r#"use clap::{{Parser, Subcommand}};
+use std::sync::Arc;
+use std::collections::HashMap;
+
+const SOURCES: &[(&str, &str)] = &[
+{sources}
+];
+
+{config}
+
+#[derive(Parser)]
+#[command(name = "{agent_name}", about = "FORGE agent: {agent_name}")]
+struct Cli {{
+    #[command(subcommand)]
+    command: Command,
+}}
+
+#[derive(Subcommand)]
+enum Command {{
+{variants}
+}}
+
+async fn dispatch(
+    agent: &forge::runtime::agent::AgentProcess,
+    event: &str,
+    params: HashMap<String, forge::runtime::confidence::ConfidentValue>,
+) -> anyhow::Result<()> {{
+    match agent.dispatch(event, params).await {{
+        Ok(Some(val)) => println!("{{}}", val.value),
+        Ok(None) => {{}},
+        Err(e) => {{
+            eprintln!("error: {{}}", e);
+            std::process::exit(1);
+        }}
+    }}
+    Ok(())
+}}
+
+async fn run_repl(
+    agent: &forge::runtime::agent::AgentProcess,
+    agent_decl: &forge::ast::AgentDecl,
+) -> anyhow::Result<()> {{
+    use std::io::{{BufRead, Write}};
+
+    let handler_names: Vec<String> = agent_decl
+        .handlers
+        .iter()
+        .map(|h| h.node.event.node.clone())
+        .collect();
+    println!("handlers: {{}}", handler_names.join(", "));
+    println!("type 'quit' to exit\n");
+
+    let stdin = std::io::stdin();
+    loop {{
+        print!("> ");
+        std::io::stdout().flush()?;
+
+        let mut line = String::new();
+        if stdin.lock().read_line(&mut line)? == 0 {{
+            break;
+        }}
+        let line = line.trim();
+        if line.is_empty() {{
+            continue;
+        }}
+        if line == "quit" || line == "exit" {{
+            break;
+        }}
+
+        let parts: Vec<&str> = line.splitn(2, ' ').collect();
+        let event = parts[0];
+        let args_str = parts.get(1).unwrap_or(&"");
+
+        // Simple arg parsing: split on spaces, respecting quotes
+        let args = parse_args(args_str);
+        let handler = agent_decl.handlers.iter().find(|h| h.node.event.node == event);
+        let mut params = HashMap::new();
+        if let Some(handler) = handler {{
+            for (i, param) in handler.node.params.iter().enumerate() {{
+                if let Some(arg) = args.get(i) {{
+                    params.insert(
+                        param.node.name.clone(),
+                        forge::runtime::confidence::ConfidentValue::deterministic(
+                            forge::runtime::confidence::Value::Text(arg.clone()),
+                        ),
+                    );
+                }}
+            }}
+        }}
+
+        match agent.dispatch(event, params).await {{
+            Ok(Some(val)) => println!("{{}}", val.value),
+            Ok(None) => {{}},
+            Err(e) => eprintln!("error: {{}}", e),
+        }}
+    }}
+    Ok(())
+}}
+
+fn parse_args(s: &str) -> Vec<String> {{
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    for ch in s.chars() {{
+        match ch {{
+            '"' => in_quotes = !in_quotes,
+            ' ' if !in_quotes => {{
+                if !current.is_empty() {{
+                    args.push(std::mem::take(&mut current));
+                }}
+            }}
+            _ => current.push(ch),
+        }}
+    }}
+    if !current.is_empty() {{
+        args.push(current);
+    }}
+    args
+}}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {{
+    let cli = Cli::parse();
+    let program = forge::compose::parse_and_merge_sources(SOURCES)
+        .map_err(|e| anyhow::anyhow!("{{}}", e))?;
+    let config = resolve_config();
+    let registry = forge::llm::registry::ProviderRegistry::from_config(config)
+        .map_err(|e| anyhow::anyhow!("provider setup failed: {{}}", e))?;
+
+    let agent_decl = forge::compose::find_agent(&program, Some("{agent_name}"))
+        .ok_or_else(|| anyhow::anyhow!("agent '{agent_name}' not found in program"))?;
+    let lifecycle_name = agent_decl.lifecycle.as_ref().map(|l| l.node.as_str());
+    let states_decl = forge::compose::find_states(&program, lifecycle_name);
+
+    let agent = forge::runtime::agent::AgentProcess::new(
+        agent_decl.clone(),
+        states_decl.as_ref(),
+        Arc::new(registry),
+        None,
+        program,
+    );
+
+    match cli.command {{
+{match_arms}
+    }}
+    Ok(())
+}}
+"#,
+        sources = sources_array,
+        config = config_code,
+        agent_name = agent.name,
+        variants = variants.join("\n"),
+        match_arms = match_arms.join("\n"),
+    )
+}
+
+// ── Template: Server ──────────────────────────────────────────
+
+fn generate_server_main(source_entries: &[String], embed_config: Option<&str>) -> String {
+    let sources_array = source_entries.join(",\n    ");
+    let config_code = config_resolution_code(embed_config);
+
+    format!(
+        r#"use clap::Parser;
+use std::sync::Arc;
+
+const SOURCES: &[(&str, &str)] = &[
+{sources}
+];
+
+{config}
+
+#[derive(Parser)]
+#[command(name = "{name}", about = "FORGE server")]
+struct Cli {{
+    #[arg(long, default_value = "127.0.0.1")]
+    host: String,
+    #[arg(long, default_value = "3000")]
+    port: u16,
+}}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {{
+    let cli = Cli::parse();
+    let program = forge::compose::parse_and_merge_sources(SOURCES)
+        .map_err(|e| anyhow::anyhow!("{{}}", e))?;
+    let mut config = resolve_config();
+
+    // Apply CLI overrides
+    if let Some(ref mut server) = config.server {{
+        server.host = Some(cli.host);
+        server.port = Some(cli.port);
+    }} else {{
+        config.server = Some(forge::config::ServerConfig {{
+            host: Some(cli.host),
+            port: Some(cli.port),
+            cors_origins: None,
+        }});
+    }}
+
+    let registry = forge::llm::registry::ProviderRegistry::from_config(config.clone())
+        .map_err(|e| anyhow::anyhow!("provider setup failed: {{}}", e))?;
+    let executor = forge::runtime::executor::TaskExecutor::new(
+        program, Arc::new(registry), None,
+    );
+    let server = forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref());
+    server.run().await
+}}
+"#,
+        sources = sources_array,
+        config = config_code,
+        name = "forge-server",
+    )
+}

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -1,0 +1,349 @@
+// FORGE multi-file composition engine
+// See issue #74 for specification
+
+use std::collections::HashMap;
+
+use crate::ast::{AgentDecl, Program, Spanned, StatesDecl, TopLevel};
+
+// ── Types ─────────────────────────────────────────────────────
+
+/// A parsed source file ready for composition.
+pub struct SourceFile {
+    pub path: String,
+    pub source: String,
+    pub program: Program,
+}
+
+/// Result of merging multiple source files into one program.
+#[derive(Debug)]
+pub struct ComposedProgram {
+    pub program: Program,
+    /// File path → source text, for diagnostic rendering.
+    pub sources: HashMap<String, String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ComposeError {
+    #[error("duplicate symbol `{name}` defined in {file1} and {file2}")]
+    DuplicateSymbol {
+        name: String,
+        file1: String,
+        file2: String,
+    },
+
+    #[error("multiple `fn main` blocks found: {file1} and {file2}")]
+    MultipleFnMain { file1: String, file2: String },
+
+    #[error("multiple `system` declarations found: {file1} and {file2}")]
+    MultipleSystem { file1: String, file2: String },
+}
+
+// ── Core merge ────────────────────────────────────────────────
+
+/// Merge multiple parsed programs into a single program.
+///
+/// Rules:
+/// - At most one `fn main` across all files
+/// - At most one `system` declaration across all files
+/// - No duplicate top-level symbol names (task, pure, flow, agent, pool, etc.)
+/// - `use` declarations pass through (resolver validates per-file)
+/// - Merged program has `boundary: None` (boundary checker runs on pre-merge programs)
+pub fn merge_programs(files: &[SourceFile]) -> Result<ComposedProgram, Vec<ComposeError>> {
+    let mut errors = Vec::new();
+    let mut symbols: HashMap<String, &str> = HashMap::new(); // name → origin file
+    let mut fn_main_file: Option<&str> = None;
+    let mut system_file: Option<&str> = None;
+    let mut all_items: Vec<Spanned<TopLevel>> = Vec::new();
+    let mut sources = HashMap::new();
+
+    for file in files {
+        sources.insert(file.path.clone(), file.source.clone());
+
+        for item in &file.program.items {
+            // Check singletons
+            match &item.node {
+                TopLevel::FnMain(_) => {
+                    if let Some(prev) = fn_main_file {
+                        errors.push(ComposeError::MultipleFnMain {
+                            file1: prev.to_string(),
+                            file2: file.path.clone(),
+                        });
+                    } else {
+                        fn_main_file = Some(&file.path);
+                    }
+                }
+                TopLevel::System(_) => {
+                    if let Some(prev) = system_file {
+                        errors.push(ComposeError::MultipleSystem {
+                            file1: prev.to_string(),
+                            file2: file.path.clone(),
+                        });
+                    } else {
+                        system_file = Some(&file.path);
+                    }
+                }
+                _ => {}
+            }
+
+            // Check named symbols for duplicates (skip Use, FnMain, Import)
+            if let Some(name) = top_level_name(&item.node) {
+                check_symbol(name, &file.path, &mut symbols, &mut errors);
+            }
+
+            all_items.push(item.clone());
+        }
+    }
+
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    let program = Program {
+        boundary: None,
+        items: all_items,
+    };
+
+    Ok(ComposedProgram { program, sources })
+}
+
+fn check_symbol<'a>(
+    name: &str,
+    file: &'a str,
+    symbols: &mut HashMap<String, &'a str>,
+    errors: &mut Vec<ComposeError>,
+) {
+    if let Some(prev_file) = symbols.get(name) {
+        errors.push(ComposeError::DuplicateSymbol {
+            name: name.to_string(),
+            file1: prev_file.to_string(),
+            file2: file.to_string(),
+        });
+    } else {
+        symbols.insert(name.to_string(), file);
+    }
+}
+
+/// Check whether a top-level item has a named symbol (used for counting).
+pub fn top_level_has_name(item: &TopLevel) -> bool {
+    top_level_name(item).is_some()
+}
+
+/// Extract the name of a top-level declaration, if it's a named symbol.
+/// Returns None for Use, FnMain, and Import (which don't participate in symbol dedup).
+fn top_level_name(item: &TopLevel) -> Option<&str> {
+    match item {
+        TopLevel::Task(d) => Some(&d.name.node),
+        TopLevel::Pure(d) => Some(&d.name.node),
+        TopLevel::Flow(d) => Some(&d.name.node),
+        TopLevel::Agent(d) => Some(&d.name.node),
+        TopLevel::Pool(d) => Some(&d.name.node),
+        TopLevel::Event(d) => Some(&d.name.node),
+        TopLevel::States(d) => Some(&d.name.node),
+        TopLevel::TypeDef(d) => Some(&d.name.node),
+        TopLevel::Endpoint(d) => Some(&d.name.node),
+        TopLevel::Contract(d) => Some(&d.name.node),
+        TopLevel::Warden(d) => Some(&d.name.node),
+        TopLevel::System(d) => Some(&d.name.node),
+        TopLevel::Use(_) | TopLevel::FnMain(_) | TopLevel::Import(_) => None,
+    }
+}
+
+// ── Public helpers for generated binaries ─────────────────────
+
+/// Parse embedded (filename, content) pairs and merge into a single Program.
+/// Used by generated binaries that embed .forge sources via `include_str!`.
+pub fn parse_and_merge_sources(sources: &[(&str, &str)]) -> Result<Program, String> {
+    let mut files = Vec::with_capacity(sources.len());
+
+    for (name, content) in sources {
+        let program = crate::parser::parse(content)
+            .map_err(|e| format!("parse error in {}: {}", name, e.to_diagnostic(name).message))?;
+        files.push(SourceFile {
+            path: name.to_string(),
+            source: content.to_string(),
+            program,
+        });
+    }
+
+    let composed = merge_programs(&files).map_err(|errs| {
+        errs.iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    })?;
+
+    Ok(composed.program)
+}
+
+/// Find the (first or named) agent declaration in a merged program.
+pub fn find_agent(program: &Program, name: Option<&str>) -> Option<AgentDecl> {
+    program.items.iter().find_map(|item| match &item.node {
+        TopLevel::Agent(a) => {
+            if let Some(n) = name {
+                if a.name.node == n {
+                    Some(a.as_ref().clone())
+                } else {
+                    None
+                }
+            } else {
+                Some(a.as_ref().clone())
+            }
+        }
+        _ => None,
+    })
+}
+
+/// Find a states declaration by name, or the first one if no name given.
+pub fn find_states(program: &Program, name: Option<&str>) -> Option<StatesDecl> {
+    program.items.iter().find_map(|item| match &item.node {
+        TopLevel::States(s) => {
+            if let Some(n) = name {
+                if s.name.node == n {
+                    Some(s.clone())
+                } else {
+                    None
+                }
+            } else {
+                Some(s.clone())
+            }
+        }
+        _ => None,
+    })
+}
+
+// ── Program kind detection ────────────────────────────────────
+
+/// The detected execution mode of a merged FORGE program.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgramKind {
+    /// Has `fn main` — standard executable.
+    Executable,
+    /// Has agent(s) but no `fn main` — agent CLI with handler subcommands.
+    AgentCli,
+    /// Has endpoint(s) — HTTP server.
+    Server,
+    /// Has `system` declaration.
+    System,
+}
+
+/// Detect the program kind from a (merged) program's top-level declarations.
+///
+/// Priority: fn main → system → endpoints → agent.
+pub fn detect_kind(program: &Program) -> Option<ProgramKind> {
+    let mut has_fn_main = false;
+    let mut has_system = false;
+    let mut has_endpoints = false;
+    let mut has_agent = false;
+
+    for item in &program.items {
+        match &item.node {
+            TopLevel::FnMain(_) => has_fn_main = true,
+            TopLevel::System(_) => has_system = true,
+            TopLevel::Endpoint(_) => has_endpoints = true,
+            TopLevel::Agent(_) => has_agent = true,
+            _ => {}
+        }
+    }
+
+    if has_fn_main {
+        Some(ProgramKind::Executable)
+    } else if has_system && !has_agent && !has_endpoints {
+        // Pure system declarations (no fallback to agent/server mode)
+        Some(ProgramKind::System)
+    } else if has_endpoints {
+        Some(ProgramKind::Server)
+    } else if has_agent {
+        Some(ProgramKind::AgentCli)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_source(name: &str, source: &str) -> SourceFile {
+        let program = crate::parser::parse(source).expect("parse failed");
+        SourceFile {
+            path: name.to_string(),
+            source: source.to_string(),
+            program,
+        }
+    }
+
+    #[test]
+    fn merge_two_files() {
+        let a = parse_source(
+            "a.forge",
+            "use\n  llm.reason\n\ntask greet\n  needs name: Text\n  gives Text\n  do\n    result = reason \"Say hello to {name}\"\n    give result\n",
+        );
+        let b = parse_source(
+            "b.forge",
+            "use\n  llm.reason\n\npure double\n  needs n: Number\n  gives Number\n  do\n    give n * 2\n",
+        );
+
+        let composed = merge_programs(&[a, b]).expect("merge should succeed");
+        // Both files' items present
+        let names: Vec<_> = composed
+            .program
+            .items
+            .iter()
+            .filter_map(|i| top_level_name(&i.node))
+            .collect();
+        assert!(names.contains(&"greet"));
+        assert!(names.contains(&"double"));
+    }
+
+    #[test]
+    fn rejects_duplicate_symbols() {
+        let a = parse_source(
+            "a.forge",
+            "use\n  llm.reason\n\ntask greet\n  needs name: Text\n  gives Text\n  do\n    result = reason \"hello {name}\"\n    give result\n",
+        );
+        let b = parse_source(
+            "b.forge",
+            "use\n  llm.reason\n\ntask greet\n  needs name: Text\n  gives Text\n  do\n    result = reason \"hi {name}\"\n    give result\n",
+        );
+
+        let err = merge_programs(&[a, b]).unwrap_err();
+        assert_eq!(err.len(), 1);
+        assert!(err[0].to_string().contains("duplicate symbol `greet`"));
+    }
+
+    #[test]
+    fn rejects_multiple_fn_main() {
+        let a = parse_source("a.forge", "fn main\n  say \"hello\"\n");
+        let b = parse_source("b.forge", "fn main\n  say \"world\"\n");
+
+        let err = merge_programs(&[a, b]).unwrap_err();
+        assert!(err
+            .iter()
+            .any(|e| matches!(e, ComposeError::MultipleFnMain { .. })));
+    }
+
+    #[test]
+    fn detect_kind_executable() {
+        let f = parse_source("test.forge", "fn main\n  say \"hello\"\n");
+        assert_eq!(detect_kind(&f.program), Some(ProgramKind::Executable));
+    }
+
+    #[test]
+    fn detect_kind_agent_cli() {
+        let f = parse_source(
+            "test.forge",
+            "use\n  llm.reason\n\nagent bot\n  on greet(name: Text)\n    result = reason \"hello {name}\"\n    say result\n",
+        );
+        assert_eq!(detect_kind(&f.program), Some(ProgramKind::AgentCli));
+    }
+
+    #[test]
+    fn single_file_merge() {
+        let f = parse_source("hello.forge", "fn main\n  say \"hello world\"\n");
+        let composed = merge_programs(&[f]).expect("single file merge should work");
+        assert_eq!(
+            detect_kind(&composed.program),
+            Some(ProgramKind::Executable)
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,14 @@ pub struct CapabilityOverride {
 }
 
 impl ForgeConfig {
+    /// Parse a ForgeConfig from a TOML string (used by embedded configs in built binaries).
+    pub fn from_toml_str(s: &str) -> Result<Self, ConfigError> {
+        let config: ForgeConfig =
+            toml::from_str(s).map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
         let content = std::fs::read_to_string(path)
             .map_err(|e| ConfigError::FileNotFound(path.display().to_string(), e.to_string()))?;

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,7 +1,7 @@
 use ariadne::{Color, Label, Report, ReportKind, Source};
 use std::ops::Range;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiagnosticKind {
     Error,
     Warning,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 pub mod ast;
+pub mod build;
 pub mod checker;
+pub mod compose;
 pub mod config;
 pub mod cost_estimator;
 pub mod diagnostic;
 pub mod fleet;
 pub mod llm;
+pub mod manifest;
 pub mod parser;
 pub mod planner;
 pub mod portability;

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,10 @@ enum Command {
     /// Execute a .forge program
     Run {
         /// Path to the .forge source file
-        file: PathBuf,
+        file: Option<PathBuf>,
+        /// Path to a forge.project.toml manifest for multi-file execution
+        #[arg(long, conflicts_with = "file")]
+        manifest: Option<PathBuf>,
     },
     /// Execute with full JSON trace output to stderr
     Trace {
@@ -123,6 +126,27 @@ enum Command {
         /// Arguments for the event handler (positional, matching handler params)
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
+    },
+    /// Build a standalone binary from a .forge project
+    Build {
+        /// Path to a .forge file or directory containing forge.project.toml
+        #[arg(default_value = ".")]
+        path: PathBuf,
+        /// Output binary name
+        #[arg(long, short)]
+        output: Option<String>,
+        /// Path to forge.project.toml (overrides auto-detection)
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+        /// Build with optimizations
+        #[arg(long)]
+        release: bool,
+        /// Embed a forge.config.toml as default config
+        #[arg(long)]
+        embed_config: Option<PathBuf>,
+        /// Validate without compiling
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Generate skeleton FORGE code from a plain-text system description
     Fleet {
@@ -194,8 +218,14 @@ async fn main() -> anyhow::Result<()> {
                 std::process::exit(1);
             }
         }
-        Command::Run { file } => {
-            run_program(&file, false).await?;
+        Command::Run { file, manifest } => {
+            if let Some(manifest_path) = manifest {
+                run_manifest(&manifest_path, false).await?;
+            } else if let Some(file) = file {
+                run_program(&file, false).await?;
+            } else {
+                anyhow::bail!("either a .forge file or --manifest is required");
+            }
         }
         Command::Trace { file } => {
             run_program(&file, true).await?;
@@ -362,6 +392,24 @@ async fn main() -> anyhow::Result<()> {
         Command::Send { file, event, args } => {
             send_to_agent(&file, &event, args).await?;
         }
+        Command::Build {
+            path,
+            output,
+            manifest,
+            release,
+            embed_config,
+            dry_run,
+        } => {
+            build_program(
+                &path,
+                output.as_deref(),
+                manifest.as_deref(),
+                release,
+                embed_config,
+                dry_run,
+            )
+            .await?;
+        }
         Command::Fleet { spec, output } => {
             let result = forge::fleet::generate(&spec)?;
             match output {
@@ -441,6 +489,181 @@ async fn run_program(file: &PathBuf, trace: bool) -> anyhow::Result<()> {
             eprintln!("runtime error: {}", e);
             std::process::exit(1);
         }
+    }
+
+    Ok(())
+}
+
+async fn run_manifest(manifest_path: &Path, trace: bool) -> anyhow::Result<()> {
+    let manifest = forge::manifest::ProjectManifest::load(manifest_path)?;
+    let base_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+    let source_paths = manifest.resolve_sources(base_dir)?;
+
+    // Parse all source files
+    let mut source_files = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for path in &source_paths {
+        let source = read_source(&path.to_path_buf())?;
+        let fname = path.display().to_string();
+        let program = parse_or_exit(&source, path);
+
+        // Per-file validation
+        let ctx = forge::resolver::CheckContext::new(&fname);
+        if let Err(errors) = ctx.check(&program) {
+            let registry = forge::resolver::CapabilityRegistry::builtin();
+            diagnostics.extend(errors.iter().map(|e| e.to_diagnostic(&fname, &registry)));
+        }
+        diagnostics.extend(forge::checker::check_all(&program, &fname));
+
+        source_files.push(forge::compose::SourceFile {
+            path: fname,
+            source,
+            program,
+        });
+    }
+
+    // Cross-file boundary check
+    let boundary_refs: Vec<_> = source_files
+        .iter()
+        .map(|sf| (&sf.program, sf.path.as_str()))
+        .collect();
+    diagnostics.extend(forge::checker::boundary_checker::check(&boundary_refs));
+
+    if !diagnostics.is_empty() {
+        for diag in &diagnostics {
+            if let Some(sf) = source_files.iter().find(|sf| sf.path == diag.file) {
+                diag.render(&sf.source);
+            }
+        }
+        std::process::exit(1);
+    }
+
+    // Merge and execute
+    let composed = forge::compose::merge_programs(&source_files).map_err(|errs| {
+        anyhow::anyhow!(
+            "{}",
+            errs.iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    })?;
+
+    let config = forge::config::ForgeConfig::load_or_default();
+    let registry = forge::llm::registry::ProviderRegistry::from_config(config)
+        .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
+
+    let tracer = if trace
+        || std::env::var("FORGE_TRACE")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    {
+        Some(forge::tracer::Tracer::new())
+    } else {
+        None
+    };
+
+    let executor =
+        forge::runtime::executor::TaskExecutor::new(composed.program, Arc::new(registry), tracer);
+
+    match executor.run().await {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("runtime error: {}", e);
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+async fn build_program(
+    path: &Path,
+    output: Option<&str>,
+    manifest_path: Option<&Path>,
+    release: bool,
+    embed_config: Option<PathBuf>,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    // Resolve manifest: explicit path, directory with forge.project.toml, or single file
+    let (mut manifest, base_dir) = if let Some(mp) = manifest_path {
+        let manifest = forge::manifest::ProjectManifest::load(mp)?;
+        let base = mp.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+        (manifest, base)
+    } else if path.is_file() && path.extension().map(|e| e == "forge").unwrap_or(false) {
+        // Single-file shortcut — use file stem for crate name, not the output path
+        let manifest = forge::manifest::ProjectManifest::from_single_file(path, None);
+        let base = path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        (manifest, base)
+    } else if path.is_dir() {
+        let manifest_file = path.join("forge.project.toml");
+        if !manifest_file.exists() {
+            anyhow::bail!("no forge.project.toml found in {}", path.display());
+        }
+        let manifest = forge::manifest::ProjectManifest::load(&manifest_file)?;
+        (manifest, path.to_path_buf())
+    } else {
+        anyhow::bail!(
+            "expected a .forge file, directory with forge.project.toml, or --manifest flag"
+        );
+    };
+
+    // Resolve output: if -o is a path with dir, split into dir + name
+    let (output_dir, output_name_override) = if let Some(out) = output {
+        let out_path = Path::new(out);
+        if let Some(parent) = out_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                (
+                    Some(parent.to_path_buf()),
+                    out_path
+                        .file_name()
+                        .map(|f| f.to_string_lossy().to_string()),
+                )
+            } else {
+                (None, Some(out.to_string()))
+            }
+        } else {
+            (None, Some(out.to_string()))
+        }
+    } else {
+        (None, None)
+    };
+
+    // Override the manifest output name if -o was given
+    if let Some(name) = &output_name_override {
+        if let Some(ref mut build) = manifest.build {
+            build.output = Some(name.clone());
+        } else {
+            manifest.build = Some(forge::manifest::BuildConfig {
+                entry: None,
+                output: Some(name.clone()),
+                sources: None,
+            });
+        }
+    }
+
+    let output_display = manifest.output_name();
+    eprintln!("building {} ...", output_display);
+
+    let pipeline = forge::build::BuildPipeline::new(manifest, base_dir)
+        .dry_run(dry_run)
+        .release(release)
+        .embed_config(embed_config)
+        .output_dir(output_dir);
+
+    let result = pipeline.build()?;
+
+    if dry_run {
+        eprintln!(
+            "dry run complete — validation passed ({:?})",
+            result.program_kind
+        );
+    } else {
+        eprintln!("done: {}", result.binary_path.display());
     }
 
     Ok(())

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,215 @@
+// FORGE project manifest (forge.project.toml) parser
+// See issue #74 for specification
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+// ── Manifest types ────────────────────────────────────────────
+
+/// Top-level forge.project.toml structure.
+#[derive(Debug, Deserialize)]
+pub struct ProjectManifest {
+    pub project: ProjectMeta,
+    pub build: Option<BuildConfig>,
+    pub config: Option<ConfigEmbed>,
+}
+
+/// [project] section — required.
+#[derive(Debug, Deserialize)]
+pub struct ProjectMeta {
+    pub name: String,
+    pub version: Option<String>,
+    pub description: Option<String>,
+}
+
+/// [build] section — optional, controls compilation behavior.
+#[derive(Debug, Deserialize)]
+pub struct BuildConfig {
+    /// Entry point file (must contain fn main, agent, or system).
+    pub entry: Option<String>,
+    /// Output binary name (defaults to project name).
+    pub output: Option<String>,
+    /// Additional source files beyond entry.
+    pub sources: Option<Vec<String>>,
+}
+
+/// [config] section — optional, embeds a forge.config.toml at build time.
+#[derive(Debug, Deserialize)]
+pub struct ConfigEmbed {
+    /// Path to a forge.config.toml to embed in the binary.
+    pub embed: Option<String>,
+}
+
+// ── Loading and resolution ────────────────────────────────────
+
+impl ProjectManifest {
+    /// Load a manifest from a TOML file.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("cannot read {}: {}", path.display(), e))?;
+        let manifest: ProjectManifest = toml::from_str(&content)
+            .map_err(|e| anyhow::anyhow!("invalid manifest {}: {}", path.display(), e))?;
+        Ok(manifest)
+    }
+
+    /// Output binary name — from [build].output, or project name.
+    pub fn output_name(&self) -> &str {
+        self.build
+            .as_ref()
+            .and_then(|b| b.output.as_deref())
+            .unwrap_or(&self.project.name)
+    }
+
+    /// Resolve all source file paths relative to the manifest's parent directory.
+    /// Returns (entry, all_sources) where entry is the first file.
+    pub fn resolve_sources(&self, base_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+        let mut paths = Vec::new();
+
+        if let Some(build) = &self.build {
+            // Add entry point first, if specified
+            if let Some(entry) = &build.entry {
+                let p = base_dir.join(entry);
+                if !p.exists() {
+                    anyhow::bail!("entry file not found: {}", p.display());
+                }
+                paths.push(p);
+            }
+
+            // Add additional sources
+            if let Some(sources) = &build.sources {
+                for src in sources {
+                    let p = base_dir.join(src);
+                    if !p.exists() {
+                        anyhow::bail!("source file not found: {}", p.display());
+                    }
+                    paths.push(p);
+                }
+            }
+        }
+
+        if paths.is_empty() {
+            anyhow::bail!("no source files specified in manifest");
+        }
+
+        Ok(paths)
+    }
+
+    /// Resolve the embedded config file path, if specified.
+    pub fn resolve_embedded_config(&self, base_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
+        if let Some(cfg) = &self.config {
+            if let Some(embed) = &cfg.embed {
+                let p = base_dir.join(embed);
+                if !p.exists() {
+                    anyhow::bail!("embedded config not found: {}", p.display());
+                }
+                return Ok(Some(p));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Create a virtual manifest for single-file builds (no forge.project.toml needed).
+    pub fn from_single_file(file: &Path, output: Option<&str>) -> Self {
+        let name = output
+            .map(|s| s.to_string())
+            .or_else(|| file.file_stem().map(|s| s.to_string_lossy().to_string()))
+            .unwrap_or_else(|| "forge-program".to_string());
+
+        let entry = file
+            .file_name()
+            .map(|f| f.to_string_lossy().to_string())
+            .unwrap_or_else(|| file.display().to_string());
+
+        ProjectManifest {
+            project: ProjectMeta {
+                name: name.clone(),
+                version: Some("0.1.0".to_string()),
+                description: None,
+            },
+            build: Some(BuildConfig {
+                entry: Some(entry),
+                output: Some(name),
+                sources: None,
+            }),
+            config: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_manifest() {
+        let toml = r#"
+[project]
+name = "hello"
+"#;
+        let manifest: ProjectManifest = toml::from_str(toml).unwrap();
+        assert_eq!(manifest.project.name, "hello");
+        assert!(manifest.build.is_none());
+        assert!(manifest.config.is_none());
+    }
+
+    #[test]
+    fn parse_full_manifest() {
+        let toml = r#"
+[project]
+name = "tictactoe"
+version = "0.1.0"
+
+[build]
+entry = "platform.forge"
+output = "tictactoe"
+sources = [
+  "room_agent.forge",
+  "ai_opponent.forge",
+  "matchmaking.forge",
+]
+
+[config]
+embed = "forge.config.toml"
+"#;
+        let manifest: ProjectManifest = toml::from_str(toml).unwrap();
+        assert_eq!(manifest.project.name, "tictactoe");
+        assert_eq!(manifest.output_name(), "tictactoe");
+        let build = manifest.build.as_ref().unwrap();
+        assert_eq!(build.entry.as_deref(), Some("platform.forge"));
+        assert_eq!(build.sources.as_ref().unwrap().len(), 3);
+        assert_eq!(
+            manifest.config.as_ref().unwrap().embed.as_deref(),
+            Some("forge.config.toml")
+        );
+    }
+
+    #[test]
+    fn output_name_defaults_to_project() {
+        let toml = r#"
+[project]
+name = "myapp"
+
+[build]
+entry = "main.forge"
+"#;
+        let manifest: ProjectManifest = toml::from_str(toml).unwrap();
+        assert_eq!(manifest.output_name(), "myapp");
+    }
+
+    #[test]
+    fn single_file_virtual_manifest() {
+        let manifest = ProjectManifest::from_single_file(Path::new("examples/hello.forge"), None);
+        assert_eq!(manifest.project.name, "hello");
+        assert_eq!(manifest.output_name(), "hello");
+    }
+
+    #[test]
+    fn single_file_with_output_override() {
+        let manifest = ProjectManifest::from_single_file(
+            Path::new("examples/quiz_tutor.forge"),
+            Some("forge-tutor"),
+        );
+        assert_eq!(manifest.project.name, "forge-tutor");
+        assert_eq!(manifest.output_name(), "forge-tutor");
+    }
+}

--- a/tests/build_tests.rs
+++ b/tests/build_tests.rs
@@ -1,0 +1,245 @@
+// Integration tests for forge build pipeline
+// See issue #74
+
+use forge::compose::{self, SourceFile};
+
+fn parse_source(name: &str, source: &str) -> SourceFile {
+    let program = forge::parser::parse(source).expect("parse failed");
+    SourceFile {
+        path: name.to_string(),
+        source: source.to_string(),
+        program,
+    }
+}
+
+// ── Composition tests ─────────────────────────────────────────
+
+#[test]
+fn compose_merges_two_files() {
+    let a = parse_source(
+        "a.forge",
+        "use\n  llm.reason\n\ntask greet\n  needs name: Text\n  gives Text\n  do\n    result = reason \"Say hello to {name}\"\n    give result\n",
+    );
+    let b = parse_source(
+        "b.forge",
+        "use\n  llm.reason\n\npure double\n  needs n: Number\n  gives Number\n  do\n    give n * 2\n",
+    );
+
+    let composed = compose::merge_programs(&[a, b]).expect("merge should succeed");
+    assert_eq!(composed.sources.len(), 2);
+
+    let kind = compose::detect_kind(&composed.program);
+    assert_eq!(kind, None); // no fn main, no agent, no endpoint
+}
+
+#[test]
+fn compose_merges_with_fn_main() {
+    let a = parse_source(
+        "lib.forge",
+        "use\n  llm.reason\n\ntask greet\n  needs name: Text\n  gives Text\n  do\n    result = reason \"hello {name}\"\n    give result\n",
+    );
+    let b = parse_source("main.forge", "fn main\n  say \"hello\"\n");
+
+    let composed = compose::merge_programs(&[a, b]).expect("merge should succeed");
+    assert_eq!(
+        compose::detect_kind(&composed.program),
+        Some(compose::ProgramKind::Executable)
+    );
+}
+
+#[test]
+fn compose_rejects_duplicate_task_names() {
+    let a = parse_source(
+        "a.forge",
+        "use\n  llm.reason\n\ntask greet\n  needs name: Text\n  gives Text\n  do\n    result = reason \"hello {name}\"\n    give result\n",
+    );
+    let b = parse_source(
+        "b.forge",
+        "use\n  llm.reason\n\ntask greet\n  needs x: Text\n  gives Text\n  do\n    result = reason \"hi {x}\"\n    give result\n",
+    );
+
+    let err = compose::merge_programs(&[a, b]).unwrap_err();
+    assert_eq!(err.len(), 1);
+    assert!(err[0].to_string().contains("duplicate symbol `greet`"));
+}
+
+#[test]
+fn compose_rejects_multiple_fn_main() {
+    let a = parse_source("a.forge", "fn main\n  say \"hello\"\n");
+    let b = parse_source("b.forge", "fn main\n  say \"world\"\n");
+
+    let err = compose::merge_programs(&[a, b]).unwrap_err();
+    assert!(err.iter().any(|e| e.to_string().contains("fn main")));
+}
+
+#[test]
+fn compose_single_file_works() {
+    let f = parse_source("hello.forge", "fn main\n  say \"hello world\"\n");
+    let composed = compose::merge_programs(&[f]).expect("should work");
+    assert_eq!(
+        compose::detect_kind(&composed.program),
+        Some(compose::ProgramKind::Executable)
+    );
+}
+
+// ── Program kind detection ────────────────────────────────────
+
+#[test]
+fn detect_kind_executable() {
+    let f = parse_source("test.forge", "fn main\n  say \"hello\"\n");
+    assert_eq!(
+        compose::detect_kind(&f.program),
+        Some(compose::ProgramKind::Executable)
+    );
+}
+
+#[test]
+fn detect_kind_agent_cli() {
+    let f = parse_source(
+        "test.forge",
+        "use\n  llm.reason\n\nagent bot\n  on greet(name: Text)\n    result = reason \"hello {name}\"\n    say result\n",
+    );
+    assert_eq!(
+        compose::detect_kind(&f.program),
+        Some(compose::ProgramKind::AgentCli)
+    );
+}
+
+#[test]
+fn detect_kind_server() {
+    let f = parse_source(
+        "test.forge",
+        "#! boundary: server\n\nendpoint health() -> Text\n  give \"ok\"\n",
+    );
+    assert_eq!(
+        compose::detect_kind(&f.program),
+        Some(compose::ProgramKind::Server)
+    );
+}
+
+#[test]
+fn detect_kind_none_for_pure_library() {
+    let f = parse_source(
+        "lib.forge",
+        "pure add\n  needs a: Number, b: Number\n  gives Number\n  do\n    give a + b\n",
+    );
+    assert_eq!(compose::detect_kind(&f.program), None);
+}
+
+// ── parse_and_merge_sources ───────────────────────────────────
+
+#[test]
+fn parse_and_merge_sources_works() {
+    let sources: &[(&str, &str)] = &[
+        ("main.forge", "fn main\n  say \"hello\"\n"),
+        (
+            "lib.forge",
+            "pure add\n  needs a: Number, b: Number\n  gives Number\n  do\n    give a + b\n",
+        ),
+    ];
+
+    let program = compose::parse_and_merge_sources(sources).expect("should merge");
+    assert_eq!(
+        compose::detect_kind(&program),
+        Some(compose::ProgramKind::Executable)
+    );
+}
+
+#[test]
+fn parse_and_merge_sources_rejects_invalid() {
+    let sources: &[(&str, &str)] = &[("bad.forge", "this is not valid forge")];
+    assert!(compose::parse_and_merge_sources(sources).is_err());
+}
+
+// ── Manifest tests ────────────────────────────────────────────
+
+#[test]
+fn manifest_from_single_file() {
+    let manifest = forge::manifest::ProjectManifest::from_single_file(
+        std::path::Path::new("examples/hello.forge"),
+        None,
+    );
+    assert_eq!(manifest.project.name, "hello");
+    assert_eq!(manifest.output_name(), "hello");
+}
+
+#[test]
+fn manifest_tictactoe_parses() {
+    let manifest = forge::manifest::ProjectManifest::load(std::path::Path::new(
+        "examples/tictactoe/forge.project.toml",
+    ))
+    .expect("should load");
+    assert_eq!(manifest.project.name, "tictactoe");
+    assert_eq!(manifest.output_name(), "tictactoe");
+
+    let sources = manifest
+        .resolve_sources(std::path::Path::new("examples/tictactoe"))
+        .expect("should resolve");
+    assert_eq!(sources.len(), 4); // entry + 3 sources
+}
+
+// ── Compose tictactoe files ───────────────────────────────────
+
+#[test]
+fn compose_tictactoe_parses_and_merges() {
+    let files = [
+        "examples/tictactoe/platform.forge",
+        "examples/tictactoe/room_agent.forge",
+        "examples/tictactoe/ai_opponent.forge",
+        "examples/tictactoe/matchmaking.forge",
+    ];
+
+    let source_files: Vec<SourceFile> = files
+        .iter()
+        .map(|path| {
+            let source = std::fs::read_to_string(path).expect("read file");
+            let program = forge::parser::parse(&source).expect("parse");
+            SourceFile {
+                path: path.to_string(),
+                source,
+                program,
+            }
+        })
+        .collect();
+
+    // Merge should succeed (composition doesn't run checkers)
+    let composed = compose::merge_programs(&source_files)
+        .expect("tictactoe should merge without symbol conflicts");
+
+    // Detects as AgentCli (has agents; system kind deferred while system runtime is unimplemented)
+    let kind = compose::detect_kind(&composed.program);
+    assert_eq!(kind, Some(compose::ProgramKind::AgentCli));
+}
+
+// ── find_agent / find_states ──────────────────────────────────
+
+#[test]
+fn find_agent_in_merged_program() {
+    let f = parse_source(
+        "agent.forge",
+        "use\n  llm.reason\n\nagent mybot\n  on hello(name: Text)\n    say \"hi {name}\"\n",
+    );
+    let composed = compose::merge_programs(&[f]).unwrap();
+    let agent = compose::find_agent(&composed.program, None);
+    assert!(agent.is_some());
+    assert_eq!(agent.unwrap().name.node, "mybot");
+}
+
+#[test]
+fn find_agent_by_name() {
+    let f = parse_source(
+        "agents.forge",
+        "use\n  llm.reason\n\nagent alpha\n  on greet\n    say \"alpha\"\n\nagent beta\n  on greet\n    say \"beta\"\n",
+    );
+
+    let alpha = compose::find_agent(&f.program, Some("alpha"));
+    assert!(alpha.is_some());
+    assert_eq!(alpha.unwrap().name.node, "alpha");
+
+    let beta = compose::find_agent(&f.program, Some("beta"));
+    assert!(beta.is_some());
+    assert_eq!(beta.unwrap().name.node, "beta");
+
+    let gamma = compose::find_agent(&f.program, Some("gamma"));
+    assert!(gamma.is_none());
+}


### PR DESCRIPTION
## Summary

- **Multi-file composition engine** (`src/compose.rs`): merges multiple `.forge` ASTs into one program with cross-file symbol dedup, single `fn main`/`system` enforcement
- **Project manifest** (`src/manifest.rs`): `forge.project.toml` parser with entry point, sources, output name, and embedded config support
- **Build pipeline** (`src/build.rs`): generates temporary Rust crates with `include_str!`-embedded sources, compiles via `cargo build`, produces standalone binaries
- **CLI commands**: `forge build` (single-file, directory, or manifest), `forge run --manifest` for multi-file execution
- **Agent CLI generation**: handler introspection → clap subcommands + interactive REPL
- **Example fixes**: quiz_tutor.forge and tictactoe examples updated to pass all checkers (unguarded transitions, unhandled uncertain values)

Closes #74

## Acceptance Criteria Verified

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `forge build hello.forge -o hello` → binary prints greeting | Pass |
| 2 | `forge build quiz_tutor.forge -o forge-tutor` → agent subcommands | Pass |
| 3 | Multi-file tictactoe build via `forge.project.toml` | Pass |
| 4 | Cross-file symbol resolution | Pass |
| 5 | Cross-file boundary enforcement | Pass |
| 6 | Config embedding (`--embed-config`) | Implemented |
| 7 | `--dry-run` validates without compiling | Pass |
| 8 | Zero-config single file build | Pass |
| 9 | Agent binary `--help` lists handlers as subcommands | Pass |

## Test plan

- [x] `cargo test` — 562 tests pass, 0 failures
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [x] `forge build examples/hello.forge -o hello && FORGE_MOCK=1 ./hello` → "Hello, World!"
- [x] `forge build examples/quiz_tutor.forge -o forge-tutor && ./forge-tutor --help` → 6 handlers + repl
- [x] `forge build examples/tictactoe/ -o tictactoe && ./tictactoe --help` → 3 handlers + repl
- [x] `forge build --dry-run examples/hello.forge` → validates, no compilation
- [x] 16 new integration tests in `tests/build_tests.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)