### PR TITLE
feat: build forge-sensei as standalone binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/bin
 .worktrees/
 .claude/
 .forge-security-allow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config embedding: `--embed-config` bakes a `forge.config.toml` into built binaries with runtime override support
 - `--dry-run` mode for build validation without compilation
 - `forge-sensei`: FORGE language learning agent written in FORGE, with knowledge store, mastery progression (novice→expert), conformance-based assessment, and Claude Code integration via hook + skill
+- `scripts/build-sensei.sh` convenience script to build the forge-sensei binary
+
+### Changed
+- forge-sensei now runs as a standalone binary (`bin/forge-sensei`) instead of `cargo run -- send` — faster hook, pre-training, and assessment (#77)
 - `forge send` CLI command for non-interactive agent message dispatch
 - Agent portability: `exportable` modifier, `import ... from ... as` declaration, `.forgepkg.json` package format with SHA-256 integrity, `forge export`/`import`/`inspect` CLI commands (#72)
 - Progressive learning agents: `knowledge`, `recall`, and `learn` language primitives for persistent, searchable knowledge stores that enable agents to accumulate expertise through use

--- a/scripts/build-sensei.sh
+++ b/scripts/build-sensei.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# build-sensei.sh — Build the forge-sensei agent as a standalone binary
+set -euo pipefail
+
+FORGE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+mkdir -p "$FORGE_ROOT/bin"
+
+echo "Building forge-sensei..."
+cargo run --manifest-path "$FORGE_ROOT/Cargo.toml" -- build \
+  "$FORGE_ROOT/workflows/forge-sensei.forge" \
+  -o "$FORGE_ROOT/bin/forge-sensei"
+
+echo ""
+echo "Binary ready: bin/forge-sensei"
+echo "Run: bin/forge-sensei --help"

--- a/scripts/consult-sensei.sh
+++ b/scripts/consult-sensei.sh
@@ -4,7 +4,12 @@
 set -euo pipefail
 
 FORGE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SENSEI="$FORGE_ROOT/workflows/forge-sensei.forge"
+SENSEI_BIN="$FORGE_ROOT/bin/forge-sensei"
+
+# Skip if binary not built yet
+if [ ! -x "$SENSEI_BIN" ]; then
+  exit 0
+fi
 
 # Read the hook input JSON from stdin
 INPUT=$(cat)
@@ -36,7 +41,7 @@ if [ -z "$CONTENT" ]; then
 fi
 
 # Query sensei for advice on this code
-ADVICE=$(cargo run -- send "$SENSEI" review "$CONTENT" 2>/dev/null || echo "")
+ADVICE=$("$SENSEI_BIN" review "$CONTENT" 2>/dev/null || echo "")
 
 if [ -n "$ADVICE" ] && [ "$ADVICE" != "null" ]; then
   # Inject sensei's advice as a non-blocking note

--- a/scripts/pretrain-sensei.sh
+++ b/scripts/pretrain-sensei.sh
@@ -4,14 +4,19 @@
 set -euo pipefail
 
 FORGE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SENSEI="$FORGE_ROOT/workflows/forge-sensei.forge"
-FORGE="${FORGE_BIN:-cargo run --}"
+SENSEI_BIN="${SENSEI_BIN:-$FORGE_ROOT/bin/forge-sensei}"
 COUNT=0
+
+if [ ! -x "$SENSEI_BIN" ]; then
+  echo "Error: forge-sensei binary not found at $SENSEI_BIN"
+  echo "Run: bash scripts/build-sensei.sh"
+  exit 1
+fi
 
 ingest() {
   local path="$1"
   if [ -f "$path" ]; then
-    $FORGE send "$SENSEI" ingest "$path" 2>/dev/null || true
+    "$SENSEI_BIN" ingest "$path" 2>/dev/null || true
     COUNT=$((COUNT + 1))
     echo "  [$COUNT] $path"
   fi
@@ -20,7 +25,7 @@ ingest() {
 ingest_fact() {
   local category="$1"
   local fact="$2"
-  $FORGE send "$SENSEI" ingest_fact "$category" "$fact" 2>/dev/null || true
+  "$SENSEI_BIN" ingest-fact "$category" "$fact" 2>/dev/null || true
   COUNT=$((COUNT + 1))
 }
 

--- a/workflows/forge-sensei.forge
+++ b/workflows/forge-sensei.forge
@@ -198,9 +198,8 @@ warden sensei_warden
     after 1: escalate
   max_retries 3 per 1h then escalate
 
-# ── Entry Point ───────────────────────────────────────────────
-
-fn main
-  say "=== forge-sensei: FORGE Language Learning Agent ==="
-  say "Use 'forge send' to interact non-interactively."
-  say "Use 'forge agent' for interactive REPL mode."
+# ── Usage ─────────────────────────────────────────────────────
+# Build:  forge build workflows/forge-sensei.forge -o bin/forge-sensei
+# Run:    bin/forge-sensei query "how do flows work?"
+# REPL:   bin/forge-sensei repl
+# Help:   bin/forge-sensei --help


### PR DESCRIPTION
## Summary

- Remove `fn main` from `workflows/forge-sensei.forge` so `forge build` produces an AgentCli binary with handler subcommands
- Add `scripts/build-sensei.sh` convenience script → produces `bin/forge-sensei`
- Update `scripts/consult-sensei.sh` (PreToolUse hook) to use binary; gracefully skips if not built
- Update `scripts/pretrain-sensei.sh` to use binary for all ingestion
- Update skill (`SKILL.md`) and assessment (`assess.sh`) to use binary
- Add `bin/` to `.gitignore`

Closes #77

## Test plan

- [x] `bash scripts/build-sensei.sh` — builds successfully
- [x] `bin/forge-sensei --help` — lists 9 handler subcommands + repl
- [x] `FORGE_MOCK=1 bin/forge-sensei status` — returns status
- [x] `cargo test` — all 562 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)