### PR TITLE
feat: multi-hop recall for forge-sensei (100% conformance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - forge-sensei now runs as a standalone binary (`bin/forge-sensei`) instead of `cargo run -- send` — faster hook, pre-training, and assessment (#77)
+- forge-sensei uses multi-hop recall: `categorize_for_recall` task identifies relevant knowledge categories before `recall`, improving retrieval accuracy from 97% to 100% on conformance tests (#79)
 - `forge send` CLI command for non-interactive agent message dispatch
 - Agent portability: `exportable` modifier, `import ... from ... as` declaration, `.forgepkg.json` package format with SHA-256 integrity, `forge export`/`import`/`inspect` CLI commands (#72)
 - Progressive learning agents: `knowledge`, `recall`, and `learn` language primitives for persistent, searchable knowledge stores that enable agents to accumulate expertise through use

--- a/workflows/forge-sensei.forge
+++ b/workflows/forge-sensei.forge
@@ -95,6 +95,14 @@ task evaluate_conformance
     when result.unsure -> give result
     else -> give "GAP: insufficient knowledge to evaluate this test"
 
+task categorize_for_recall
+  needs context: Text
+  gives Text
+  do
+    result = reason "Given this FORGE-related input, identify the most relevant knowledge categories. Pick 1-3 from: SYNTAX, TASKS, FLOWS, CONTROL, AGENTS, KNOWLEDGE, SUPERVISION, PRINCIPLES, PATTERNS, ERRORS, CONFORMANCE, BOUNDARY. Reply with ONLY the category names separated by spaces.\n\nInput: {context}"
+    when result.sure -> give result
+    else -> give "CONFORMANCE SYNTAX"
+
 # ── The Sensei Agent ──────────────────────────────────────────
 #
 # A self-referential learning agent: written in FORGE to teach FORGE.
@@ -134,7 +142,8 @@ exportable agent forge_sensei
 
   on query(question: Text)
     memory.interaction_count = memory.interaction_count + 1
-    prior = recall "{question}"
+    categories = categorize_for_recall(question)
+    prior = recall "{categories} {question}"
     answer = answer_forge_question(question, prior)
     learn from interaction(question, answer, 0.7)
     emit LearnedInsight(category: "interactions", content: answer, source: "query", confidence: 0.7)
@@ -144,7 +153,8 @@ exportable agent forge_sensei
 
   on review(code: Text)
     memory.interaction_count = memory.interaction_count + 1
-    prior = recall "FORGE syntax patterns errors"
+    categories = categorize_for_recall(code)
+    prior = recall "{categories} FORGE syntax patterns errors"
     result = review_forge_code(code, prior)
     give result
 
@@ -160,7 +170,8 @@ exportable agent forge_sensei
 
   on assess_detailed(test_input: Text, expected: Text)
     memory.interaction_count = memory.interaction_count + 1
-    prior = recall "{test_input}"
+    categories = categorize_for_recall("{test_input} expects {expected}")
+    prior = recall "{categories} {test_input} {expected}"
     result = evaluate_conformance(test_input, expected, prior)
     give result
 


### PR DESCRIPTION
## Summary

- Add `categorize_for_recall` task that identifies relevant knowledge categories (BOUNDARY, SYNTAX, FLOWS, etc.) before `recall`
- Update `assess_detailed`, `query`, and `review` handlers to 2-hop: categorize → recall → reason
- Category terms injected into the recall query give TF-IDF the keywords it needs to surface the right entries

This is the RLM (Recursive Language Model) pattern applied at the FORGE program level — the first hop reasons about *what to search for*, the second hop does the actual retrieval.

Closes #79

## Results

Assessment improved from 97% (34/35) to **100% (35/35)** — expert level, perfect score.

The previously failing test (`boundary_endpoint_in_shared`) now passes because the categorize step identifies "BOUNDARY" as relevant, which gives the TF-IDF recall the keyword overlap it needs.

## Test plan

- [x] `bash scripts/build-sensei.sh` — binary builds
- [x] Assessment: 35/35 (100%) expert
- [x] `cargo test` — all tests pass (no Rust changes)
- [x] Only `.forge` file changed — zero risk to compiler/runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)