### PR TITLE
fix: sensei hook uses wrong protocol key, never fires

### DIFF
--- a/scripts/consult-sensei.sh
+++ b/scripts/consult-sensei.sh
@@ -18,7 +18,7 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
-inp = data.get('input', {})
+inp = data.get('tool_input', {})
 print(inp.get('file_path', ''))
 " 2>/dev/null || echo "")
 
@@ -31,7 +31,7 @@ fi
 CONTENT=$(echo "$INPUT" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
-inp = data.get('input', {})
+inp = data.get('tool_input', {})
 text = inp.get('new_string', inp.get('content', ''))
 print(text[:500])
 " 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- The `consult-sensei.sh` PreToolUse hook read `data.get('input', {})` but the Claude Code hook protocol passes tool parameters under `tool_input`
- This caused the hook to silently short-circuit on **every** invocation — sensei was never actually consulted during `.forge` file edits
- Fixed both Python snippets (file path extraction + content extraction) to use `tool_input`

## Test plan
- [x] Verified: `.forge` file edit triggers sensei review and returns advice
- [x] Verified: non-`.forge` file edit silently exits (no false triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)