### PR TITLE
feat: learn with category — categorized knowledge storage (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `category:` suffix on `learn` statements for categorized knowledge storage — `learn "fact" category: "boundary"`, `learn from interaction(...) category: "troubleshooting"`, `learn from document(...) category: "docs"` (#85)
 - Agent instance registry: `InstanceRegistry` tracks living agent instances at runtime for discovery and composition — register/unregister/find_by_name/find_all, shared via `Arc<RwLock>`, integrated into `WardedRuntime` and `TaskExecutor` (#82)
 - Knowledge categories: `category` field on `KnowledgeEntry`, `learn_direct_categorized()`, `export_by_category()`, `export_above_confidence()`, and `export_filtered()` for domain-specific knowledge transfer (#81)
 - `memory persistent` keyword for agents — typed memory fields survive process restarts via write-through to ACID storage (#57)

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -352,10 +352,11 @@ cancel_timer_stmt  = { "cancel" ~ _s ~ ident ~ (_s ~ "for" ~ _s ~ expr)? }
 reset_timer_stmt   = { "reset" ~ _s ~ ident }
 forward_stmt       = { "forward" ~ _s ~ expr ~ _s ~ "to" ~ _s ~ expr }
 
-learn_stmt         = { "learn" ~ _s ~ (learn_from_interaction | learn_from_document | learn_direct) }
+learn_stmt         = { "learn" ~ _s ~ (learn_from_interaction | learn_from_document | learn_direct) ~ category_clause? }
 learn_from_interaction = { "from" ~ _s ~ "interaction" ~ _s_opt ~ "(" ~ _s_opt ~ arg_list ~ _s_opt ~ ")" }
 learn_from_document    = { "from" ~ _s ~ "document" ~ _s_opt ~ "(" ~ _s_opt ~ string_arg ~ _s_opt ~ ")" }
 learn_direct           = { string_arg }
+category_clause        = { _s ~ "category" ~ _s_opt ~ ":" ~ _s_opt ~ string_arg }
 
 // --- when block (confidence-only branching) ---
 when_block = {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -585,7 +585,8 @@ pub enum Stmt {
     /// `forward expr to expr`
     Forward(Spanned<Expr>, Spanned<Expr>),
     /// `learn "fact"` / `learn from interaction(...)` / `learn from document(...)`
-    Learn(Spanned<LearnSource>),
+    /// Optional second field: `category: "name"` expression.
+    Learn(Spanned<LearnSource>, Option<Spanned<Expr>>),
     /// `match expr` with pattern arms
     Match(Box<MatchBlock>),
     /// `if`/`else if`/`else` block

--- a/src/checker/boundary_checker.rs
+++ b/src/checker/boundary_checker.rs
@@ -380,16 +380,21 @@ fn check_refs_in_stmt(
             }
             check_refs_in_expr(expr, boundary, registry, file, diagnostics);
         }
-        Stmt::Learn(source) => match &source.node {
-            LearnSource::Direct(expr) | LearnSource::FromDocument(expr) => {
-                check_refs_in_expr(expr, boundary, registry, file, diagnostics);
-            }
-            LearnSource::FromInteraction(args) => {
-                for arg in args {
-                    check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
+        Stmt::Learn(source, category) => {
+            match &source.node {
+                LearnSource::Direct(expr) | LearnSource::FromDocument(expr) => {
+                    check_refs_in_expr(expr, boundary, registry, file, diagnostics);
+                }
+                LearnSource::FromInteraction(args) => {
+                    for arg in args {
+                        check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
+                    }
                 }
             }
-        },
+            if let Some(cat_expr) = category {
+                check_refs_in_expr(cat_expr, boundary, registry, file, diagnostics);
+            }
+        }
         // No expressions to walk
         Stmt::TransitionTo(_)
         | Stmt::StartTimer { .. }

--- a/src/checker/pure_checker.rs
+++ b/src/checker/pure_checker.rs
@@ -199,7 +199,7 @@ fn check_pure_stmt(
                 check_pure_expr(fn_name, &arg.node.value, task_names, errors);
             }
         }
-        Stmt::Learn(_) => {
+        Stmt::Learn(..) => {
             errors.push(CheckError::PureUsesLlm {
                 name: fn_name.to_string(),
                 op: "learn",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -943,7 +943,8 @@ fn build_forward_stmt(pair: Pair) -> anyhow::Result<Spanned<Stmt>> {
 
 fn build_learn_stmt(pair: Pair) -> anyhow::Result<Spanned<Stmt>> {
     let span = to_span(&pair);
-    let child = pair.into_inner().next().unwrap();
+    let mut inner = pair.into_inner();
+    let child = inner.next().unwrap();
 
     let source = match child.as_rule() {
         Rule::learn_from_interaction => {
@@ -969,7 +970,18 @@ fn build_learn_stmt(pair: Pair) -> anyhow::Result<Spanned<Stmt>> {
         }
     };
 
-    Ok(Spanned::new(Stmt::Learn(Spanned::new(source, span)), span))
+    // Parse optional category clause
+    let category = if let Some(cat_pair) = inner.next() {
+        let string_arg = cat_pair.into_inner().next().unwrap();
+        Some(build_string_arg(string_arg)?)
+    } else {
+        None
+    };
+
+    Ok(Spanned::new(
+        Stmt::Learn(Spanned::new(source, span), category),
+        span,
+    ))
 }
 
 // ── Control flow statements ──────────────────────────────────

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -628,7 +628,7 @@ impl TaskExecutor {
                         return Err(RuntimeError::Unsupported("escalate outside agent".into()));
                     }
                 }
-                Stmt::Learn(source) => {
+                Stmt::Learn(source, category_expr) => {
                     if let Some(ref ctx_arc) = self.agent_context {
                         // Check knowledge store exists (quick lock/unlock)
                         {
@@ -640,13 +640,25 @@ impl TaskExecutor {
                             }
                         }
 
+                        // Evaluate optional category expression
+                        let category = if let Some(cat_expr) = category_expr {
+                            let val = self.eval_expr(cat_expr, env).await?;
+                            Some(format!("{}", val.value))
+                        } else {
+                            None
+                        };
+
                         match &source.node {
                             LearnSource::Direct(expr) => {
                                 let val = self.eval_expr(expr, env).await?;
                                 let text = format!("{}", val.value);
                                 let mut ctx = ctx_arc.lock().unwrap();
                                 if let Some(ref mut ks) = ctx.knowledge_store {
-                                    ks.learn_direct(&text);
+                                    if let Some(ref cat) = category {
+                                        ks.learn_direct_categorized(&text, cat);
+                                    } else {
+                                        ks.learn_direct(&text);
+                                    }
                                 }
                             }
                             LearnSource::FromInteraction(args) => {
@@ -672,7 +684,13 @@ impl TaskExecutor {
                                     .unwrap_or(0.5);
                                 let mut ctx = ctx_arc.lock().unwrap();
                                 if let Some(ref mut ks) = ctx.knowledge_store {
-                                    ks.learn_from_interaction(&question, &answer, confidence);
+                                    if let Some(ref cat) = category {
+                                        ks.learn_from_interaction_categorized(
+                                            &question, &answer, confidence, cat,
+                                        );
+                                    } else {
+                                        ks.learn_from_interaction(&question, &answer, confidence);
+                                    }
                                 }
                             }
                             LearnSource::FromDocument(expr) => {
@@ -680,8 +698,13 @@ impl TaskExecutor {
                                 let path = format!("{}", val.value);
                                 let mut ctx = ctx_arc.lock().unwrap();
                                 if let Some(ref mut ks) = ctx.knowledge_store {
-                                    ks.learn_from_document(&path)
-                                        .map_err(RuntimeError::Unsupported)?;
+                                    if let Some(ref cat) = category {
+                                        ks.learn_from_document_categorized(&path, cat)
+                                            .map_err(RuntimeError::Unsupported)?;
+                                    } else {
+                                        ks.learn_from_document(&path)
+                                            .map_err(RuntimeError::Unsupported)?;
+                                    }
                                 }
                             }
                         }

--- a/src/runtime/knowledge_store.rs
+++ b/src/runtime/knowledge_store.rs
@@ -108,6 +108,26 @@ impl KnowledgeStore {
     }
 
     pub fn learn_from_interaction(&mut self, question: &str, answer: &str, confidence: f32) {
+        self.learn_from_interaction_impl(question, answer, confidence, None);
+    }
+
+    pub fn learn_from_interaction_categorized(
+        &mut self,
+        question: &str,
+        answer: &str,
+        confidence: f32,
+        category: &str,
+    ) {
+        self.learn_from_interaction_impl(question, answer, confidence, Some(category.to_string()));
+    }
+
+    fn learn_from_interaction_impl(
+        &mut self,
+        question: &str,
+        answer: &str,
+        confidence: f32,
+        category: Option<String>,
+    ) {
         let content = format!("Q: {question}\nA: {answer}");
         let entry = KnowledgeEntry {
             id: Uuid::new_v4().to_string(),
@@ -118,7 +138,7 @@ impl KnowledgeStore {
                 confidence,
             },
             confidence,
-            category: None,
+            category,
             created_at: Utc::now(),
             last_accessed: Utc::now(),
             access_count: 0,
@@ -128,6 +148,22 @@ impl KnowledgeStore {
     }
 
     pub fn learn_from_document(&mut self, path: &str) -> Result<usize, String> {
+        self.learn_from_document_impl(path, None)
+    }
+
+    pub fn learn_from_document_categorized(
+        &mut self,
+        path: &str,
+        category: &str,
+    ) -> Result<usize, String> {
+        self.learn_from_document_impl(path, Some(category.to_string()))
+    }
+
+    fn learn_from_document_impl(
+        &mut self,
+        path: &str,
+        category: Option<String>,
+    ) -> Result<usize, String> {
         let content = fs::read_to_string(path)
             .map_err(|e| format!("failed to read document '{}': {}", path, e))?;
 
@@ -142,7 +178,7 @@ impl KnowledgeStore {
                     path: path.to_string(),
                 },
                 confidence: 1.0,
-                category: None,
+                category: category.clone(),
                 created_at: Utc::now(),
                 last_accessed: Utc::now(),
                 access_count: 0,

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -769,3 +769,47 @@ do
 ";
     ForgeParser::parse(Rule::do_block, src).unwrap();
 }
+
+// ============================================================
+// learn_stmt with optional category clause (#85)
+// ============================================================
+
+#[test]
+fn learn_direct_without_category() {
+    ForgeParser::parse(Rule::learn_stmt, r#"learn "some fact""#).unwrap();
+}
+
+#[test]
+fn learn_direct_with_category() {
+    ForgeParser::parse(
+        Rule::learn_stmt,
+        r#"learn "endpoints need server boundary" category: "boundary""#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn learn_from_interaction_with_category() {
+    ForgeParser::parse(
+        Rule::learn_stmt,
+        r#"learn from interaction(q, a, 0.9) category: "troubleshooting""#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn learn_from_document_with_category() {
+    ForgeParser::parse(
+        Rule::learn_stmt,
+        r#"learn from document("api.md") category: "docs""#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn learn_category_is_optional() {
+    // All three variants without category should still parse
+    ForgeParser::parse(Rule::learn_stmt, r#"learn "fact""#).unwrap();
+    ForgeParser::parse(Rule::learn_stmt, r#"learn from interaction(q, a, 0.5)"#).unwrap();
+    ForgeParser::parse(Rule::learn_stmt, r#"learn from document("f.md")"#).unwrap();
+}

--- a/tests/knowledge_tests.rs
+++ b/tests/knowledge_tests.rs
@@ -275,3 +275,52 @@ fn uncategorized_entries_excluded_from_category_export() {
     // All entries still exported with export_entries
     assert_eq!(store.export_entries().len(), 2);
 }
+
+// ── Categorized Interaction and Document Tests (#85) ────────────
+
+#[test]
+fn learn_from_interaction_with_category() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+
+    let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+
+    store.learn_from_interaction("What is FORGE?", "A language for agents", 0.9);
+    store.learn_from_interaction_categorized(
+        "How do boundaries work?",
+        "Server boundary",
+        0.85,
+        "BOUNDARY",
+    );
+
+    let boundary = store.export_by_category("BOUNDARY");
+    assert_eq!(boundary.len(), 1);
+    assert_eq!(boundary[0].category.as_deref(), Some("BOUNDARY"));
+    assert!(boundary[0].content.contains("boundaries"));
+
+    // Uncategorized interaction excluded from category export
+    assert_eq!(store.export_entries().len(), 2);
+}
+
+#[test]
+fn learn_from_document_with_category() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("knowledge").to_string_lossy().to_string();
+    let doc_path = tmp.path().join("test.txt");
+    std::fs::write(
+        &doc_path,
+        "This is a test document for categorized learning.",
+    )
+    .unwrap();
+
+    let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+
+    let count = store
+        .learn_from_document_categorized(doc_path.to_str().unwrap(), "DOCS")
+        .unwrap();
+    assert!(count > 0);
+
+    let docs = store.export_by_category("DOCS");
+    assert_eq!(docs.len(), count);
+    assert!(docs.iter().all(|e| e.category.as_deref() == Some("DOCS")));
+}


### PR DESCRIPTION
## Summary
- Adds optional `category:` suffix to all `learn` statement variants (`learn "..." category: "cat"`, `learn from interaction(...) category: "cat"`, `learn from document(...) category: "cat"`)
- Connects FORGE language syntax to the `KnowledgeStore` category support added in #81
- Adds `learn_from_interaction_categorized()` and `learn_from_document_categorized()` methods to `KnowledgeStore`

## Test plan
- [x] 5 grammar-level parse tests for learn with/without category
- [x] 2 knowledge store integration tests for categorized interaction and document
- [x] All 634 existing tests pass (backward compatible)
- [x] `cargo fmt` and `cargo clippy` clean

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)