### PR TITLE
feat: find expression — discover agent instances at runtime (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `find` expression for runtime agent instance discovery — `find "alias"` returns a single Record, `find all template` returns an Array, `find all template where lifecycle == state` filters by lifecycle state; queries `InstanceRegistry`, forbidden in `pure` functions (#84)
 - `spawn` statement for creating agent instances at runtime — `child = spawn agent as "alias"` with `with knowledge where category == "X"`, `with confidence_cap: 0.8`, `with memory field: value` options; registers in instance registry, transfers filtered knowledge with confidence decay (Principle I), warns on missing failure policy (Principle VII) (#83)
 - `category:` suffix on `learn` statements for categorized knowledge storage — `learn "fact" category: "boundary"`, `learn from interaction(...) category: "troubleshooting"`, `learn from document(...) category: "docs"` (#85)
 - Agent instance registry: `InstanceRegistry` tracks living agent instances at runtime for discovery and composition — register/unregister/find_by_name/find_all, shared via `Arc<RwLock>`, integrated into `WardedRuntime` and `TaskExecutor` (#82)

--- a/conformance/checker/pure_no_find.json
+++ b/conformance/checker/pure_no_find.json
@@ -1,0 +1,11 @@
+{
+  "name": "pure_no_find",
+  "category": "checker",
+  "description": "Find is forbidden inside pure functions (reads shared runtime state)",
+  "input": "pure no_find\n  do\n    bot = find \"room_42\"\n",
+  "expected": {
+    "outcome": "compile_error",
+    "error_contains": ["find"],
+    "error_kind": "error"
+  }
+}

--- a/conformance/parser/valid_find.json
+++ b/conformance/parser/valid_find.json
@@ -1,0 +1,9 @@
+{
+  "name": "valid_find_expression",
+  "category": "parser",
+  "description": "Find expressions: by alias, all by template, and filtered by lifecycle",
+  "input": "task discover\n  do\n    bot = find \"room_42_bot\"\n    all_bots = find all forge_sensei\n    experts = find all forge_sensei where lifecycle == expert\n",
+  "expected": {
+    "outcome": "parse_ok"
+  }
+}

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -54,7 +54,7 @@ keyword = @{
     | "pure" | "event" | "states" | "timer" | "endpoint" | "type"
     | "requires" | "emit" | "forward" | "subscribe" | "transition"
     | "start" | "cancel" | "reset" | "for" | "in" | "not" | "and"
-    | "match" | "recall" | "learn" | "spawn"
+    | "match" | "recall" | "learn" | "spawn" | "find"
     | "exportable" | "import" | "from" | "as" )
     ~ !(ASCII_ALPHANUMERIC | "_")
 }
@@ -544,7 +544,8 @@ postfix_op   = {
 }
 
 pipe_term = {
-    reason_expr
+    find_expr
+  | reason_expr
   | classify_expr
   | search_expr
   | recall_expr
@@ -552,6 +553,12 @@ pipe_term = {
   | constructor_expr
   | call_expr
   | atom
+}
+
+// --- find expression (discover agent instances at runtime, issue #84) ---
+find_expr = {
+    "find" ~ _s ~ "all" ~ _s ~ ident ~ (_s ~ "where" ~ _s ~ "lifecycle" ~ _s_opt ~ "==" ~ _s_opt ~ ident)?
+  | "find" ~ _s ~ string_arg
 }
 
 reason_expr   = { "reason" ~ _s ~ string_arg }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -470,6 +470,8 @@ pub enum Expr {
     Search(Box<Spanned<Expr>>),
     /// `recall "query"` — retrieve from agent knowledge store
     Recall(Box<Spanned<Expr>>),
+    /// `find "alias"` / `find all template [where lifecycle == state]`
+    Find(Box<FindExpr>),
     /// `try expr or expr`
     TryOr(Box<Spanned<Expr>>, Box<Spanned<Expr>>),
     /// `A >> B >> C` — composition chain
@@ -678,6 +680,25 @@ pub enum SpawnOption {
     ConfidenceCap(Spanned<Expr>),
     /// `with memory field: value`
     MemoryInit(Spanned<String>, Spanned<Expr>),
+}
+
+// ── Find expression (runtime instance discovery, issue #84) ─
+
+/// `find "alias"` or `find all template [where lifecycle == state]`
+#[derive(Debug, Clone)]
+pub struct FindExpr {
+    pub kind: FindKind,
+}
+
+/// The kind of find query.
+#[derive(Debug, Clone)]
+pub enum FindKind {
+    /// `find "alias"` — single lookup by alias
+    ByAlias(Spanned<Expr>),
+    /// `find all template` — all instances of a template
+    AllByTemplate(Spanned<String>),
+    /// `find all template where lifecycle == state`
+    AllByTemplateFiltered(Spanned<String>, Spanned<String>),
 }
 
 // ── Give metadata ────────────────────────────────────────────

--- a/src/checker/boundary_checker.rs
+++ b/src/checker/boundary_checker.rs
@@ -4,8 +4,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
-    BoundaryKind, Expr, FieldDef, LearnSource, Program, Spanned, SpawnOption, Stmt, TaskBody,
-    TemplatePart, TopLevel, TypeName,
+    BoundaryKind, Expr, FieldDef, FindKind, LearnSource, Program, Spanned, SpawnOption, Stmt,
+    TaskBody, TemplatePart, TopLevel, TypeName,
 };
 use crate::diagnostic::Diagnostic;
 
@@ -503,6 +503,11 @@ fn check_refs_in_expr(
                 if let TemplatePart::Interp(inner) = &part.node {
                     check_refs_in_expr(inner, boundary, registry, file, diagnostics);
                 }
+            }
+        }
+        Expr::Find(f) => {
+            if let FindKind::ByAlias(inner) = &f.kind {
+                check_refs_in_expr(inner, boundary, registry, file, diagnostics);
             }
         }
         // Leaves: literals, type access — no symbol references

--- a/src/checker/pure_checker.rs
+++ b/src/checker/pure_checker.rs
@@ -315,6 +315,14 @@ fn check_pure_expr(
                 }
             }
         }
+        Expr::Find(_) => {
+            errors.push(CheckError::PureUsesLlm {
+                name: fn_name.to_string(),
+                op: "find",
+                span_start: expr.span.start,
+                span_end: expr.span.end,
+            });
+        }
         // Leaves: literals, idents, type access — always pure
         Expr::NumberLit(_) | Expr::BoolLit(_) | Expr::Ident(_) | Expr::TypeAccess(_, _) => {}
     }

--- a/src/checker/requires_checker.rs
+++ b/src/checker/requires_checker.rs
@@ -158,6 +158,17 @@ fn check_requires_expr(
                 }
             }
         }
+        Expr::Find(_) => {
+            diagnostics.push(
+                Diagnostic::warning(
+                    file,
+                    "requires clause uses `find` which queries runtime state",
+                    expr.span.start..expr.span.end,
+                    "runtime state is non-deterministic — preconditions should be deterministic",
+                )
+                .with_help("use a `pure` function instead"),
+            );
+        }
         // Leaves: literals, idents, type access — always deterministic
         Expr::NumberLit(_) | Expr::BoolLit(_) | Expr::Ident(_) | Expr::TypeAccess(_, _) => {}
     }

--- a/src/checker/spawn_checker.rs
+++ b/src/checker/spawn_checker.rs
@@ -91,6 +91,10 @@ fn check_stmt(
                 }
             }
         }
+        // Check find expressions in bind statements
+        Stmt::Bind(_, expr) | Stmt::ExprStmt(expr) => {
+            check_find_in_expr(expr, agents, file, diagnostics);
+        }
         // Recurse into nested statement bodies
         Stmt::IfElse(ie) => {
             check_stmts(&ie.then_body, agents, file, diagnostics);
@@ -105,5 +109,33 @@ fn check_stmt(
             check_stmts(&f.body, agents, file, diagnostics);
         }
         _ => {}
+    }
+}
+
+/// Warn when `find all X` references an unknown agent template.
+fn check_find_in_expr(
+    expr: &Spanned<Expr>,
+    agents: &HashMap<&str, &AgentDecl>,
+    file: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if let Expr::Find(f) = &expr.node {
+        let template = match &f.kind {
+            FindKind::AllByTemplate(t) | FindKind::AllByTemplateFiltered(t, _) => Some(t),
+            FindKind::ByAlias(_) => None,
+        };
+        if let Some(t) = template {
+            if !agents.contains_key(t.node.as_str()) {
+                diagnostics.push(
+                    Diagnostic::warning(
+                        file,
+                        format!("find references unknown agent template `{}`", t.node),
+                        t.span.start..t.span.end,
+                        "no agent declaration with this name exists in the program",
+                    )
+                    .with_help("check the agent name or ensure it is declared"),
+                );
+            }
+        }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -528,6 +528,7 @@ fn build_try_or_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
 fn build_pipe_term(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     let inner = pair.into_inner().next().unwrap();
     match inner.as_rule() {
+        Rule::find_expr => build_find_expr(inner),
         Rule::reason_expr => build_reason_expr(inner),
         Rule::classify_expr => build_classify_expr(inner),
         Rule::search_expr => build_search_expr(inner),
@@ -539,6 +540,43 @@ fn build_pipe_term(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
         _ => Err(parse_error(
             &inner,
             &format!("unexpected pipe_term rule: {:?}", inner.as_rule()),
+        )),
+    }
+}
+
+fn build_find_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
+    let span = to_span(&pair);
+    let mut inner = pair.into_inner();
+    let first = inner.next().unwrap();
+
+    // If the first child is an ident, this is `find all <template> [where lifecycle == <state>]`
+    // If the first child is a string_arg, this is `find <alias>`
+    match first.as_rule() {
+        Rule::ident => {
+            // `find all <template>` — first ident is the template name
+            let template = spanned(first.as_str().to_string(), &first);
+            let kind = if let Some(state_pair) = inner.next() {
+                // `find all <template> where lifecycle == <state>`
+                let state = spanned(state_pair.as_str().to_string(), &state_pair);
+                FindKind::AllByTemplateFiltered(template, state)
+            } else {
+                FindKind::AllByTemplate(template)
+            };
+            Ok(Spanned::new(Expr::Find(Box::new(FindExpr { kind })), span))
+        }
+        Rule::string_arg => {
+            // `find <alias>`
+            let alias = build_string_arg(first)?;
+            Ok(Spanned::new(
+                Expr::Find(Box::new(FindExpr {
+                    kind: FindKind::ByAlias(alias),
+                })),
+                span,
+            ))
+        }
+        _ => Err(parse_error(
+            &first,
+            &format!("unexpected find_expr child: {:?}", first.as_rule()),
         )),
     }
 }

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -10,6 +10,7 @@ use crate::llm::registry::ProviderRegistry;
 use crate::llm::CompletionRequest;
 use crate::runtime::agent::{AgentContext, EmittedEvent};
 use crate::runtime::confidence::{ConfidentValue, Value};
+use crate::runtime::instance_registry::{InstanceInfo, InstanceStatus};
 use crate::runtime::timer_engine::TimerEngine;
 use crate::tracer::{LLMResponseInfo, Tracer};
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -866,8 +867,13 @@ impl TaskExecutor {
                     }
 
                     // 8. Register in instance registry
+                    let alias = if instance_name != *template_name {
+                        Some(instance_name.as_str())
+                    } else {
+                        None
+                    };
                     let instance_id = if let Some(ref ir) = self.instance_registry {
-                        let id = ir.write().await.register(&instance_name);
+                        let id = ir.write().await.register(template_name, alias);
                         Some(id)
                     } else {
                         None
@@ -1420,6 +1426,44 @@ impl TaskExecutor {
                     }
                 }
 
+                // ── Find (instance discovery, issue #84) ─────────────────────
+                Expr::Find(find) => {
+                    let ir = self.instance_registry.as_ref().ok_or_else(|| {
+                        RuntimeError::Unsupported("find requires instance registry".into())
+                    })?;
+                    let registry = ir.read().await;
+                    match &find.kind {
+                        FindKind::ByAlias(alias_expr) => {
+                            let alias_val = self.eval_expr(alias_expr, env).await?;
+                            let alias_str = format!("{}", alias_val.value);
+                            match registry.find_by_alias(&alias_str) {
+                                Some(info) => Ok(instance_info_to_record(&info)),
+                                None => Err(RuntimeError::FlowError(format!(
+                                    "no agent instance found with alias \"{}\"",
+                                    alias_str
+                                ))),
+                            }
+                        }
+                        FindKind::AllByTemplate(template) => {
+                            let instances = registry.find_by_name(&template.node);
+                            let records: Vec<ConfidentValue> =
+                                instances.iter().map(instance_info_to_record).collect();
+                            Ok(ConfidentValue::deterministic(Value::Array(records)))
+                        }
+                        FindKind::AllByTemplateFiltered(template, state) => {
+                            let instances = registry.find_by_name(&template.node);
+                            let records: Vec<ConfidentValue> = instances
+                                .iter()
+                                .filter(|info| {
+                                    info.lifecycle_state.as_deref() == Some(state.node.as_str())
+                                })
+                                .map(instance_info_to_record)
+                                .collect();
+                            Ok(ConfidentValue::deterministic(Value::Array(records)))
+                        }
+                    }
+                }
+
                 // ── Composition ───────────────────────────────────────────────
                 Expr::TryOr(primary, fallback) => match self.eval_expr(primary, env).await {
                     Ok(val) => Ok(val),
@@ -1688,6 +1732,41 @@ impl TaskExecutor {
 }
 
 // ── Helper functions ──────────────────────────────────────────────────────────
+
+/// Convert an `InstanceInfo` into a deterministic `Value::Record` for the `find` expression.
+fn instance_info_to_record(info: &InstanceInfo) -> ConfidentValue {
+    let mut fields = HashMap::new();
+    fields.insert(
+        "id".to_string(),
+        ConfidentValue::deterministic(Value::Text(info.instance_id.to_string())),
+    );
+    fields.insert(
+        "name".to_string(),
+        ConfidentValue::deterministic(Value::Text(info.agent_name.clone())),
+    );
+    fields.insert(
+        "alias".to_string(),
+        match &info.alias {
+            Some(a) => ConfidentValue::deterministic(Value::Text(a.clone())),
+            None => ConfidentValue::deterministic(Value::Unit),
+        },
+    );
+    fields.insert(
+        "status".to_string(),
+        ConfidentValue::deterministic(Value::Text(match info.status {
+            InstanceStatus::Running => "running".to_string(),
+            InstanceStatus::Stopping => "stopping".to_string(),
+        })),
+    );
+    fields.insert(
+        "lifecycle".to_string(),
+        match &info.lifecycle_state {
+            Some(s) => ConfidentValue::deterministic(Value::Text(s.clone())),
+            None => ConfidentValue::deterministic(Value::Unit),
+        },
+    );
+    ConfidentValue::deterministic(Value::Record(fields))
+}
 
 fn truthy(cv: &ConfidentValue) -> bool {
     truthy_val(&cv.value)

--- a/src/runtime/instance_registry.rs
+++ b/src/runtime/instance_registry.rs
@@ -24,16 +24,19 @@ pub enum InstanceStatus {
 pub struct InstanceInfo {
     pub instance_id: Uuid,
     pub agent_name: String,
+    pub alias: Option<String>,
+    pub lifecycle_state: Option<String>,
     pub spawned_at: Instant,
     pub status: InstanceStatus,
 }
 
 // ── Instance Registry ───────────────────────────────────────────────────────
 
-/// Registry of all living agent instances, supporting lookup by ID or name.
+/// Registry of all living agent instances, supporting lookup by ID, name, or alias.
 pub struct InstanceRegistry {
     by_id: HashMap<Uuid, InstanceInfo>,
     by_name: HashMap<String, Vec<Uuid>>,
+    by_alias: HashMap<String, Uuid>,
 }
 
 /// Thread-safe shared reference to the instance registry.
@@ -50,15 +53,18 @@ impl InstanceRegistry {
         Self {
             by_id: HashMap::new(),
             by_name: HashMap::new(),
+            by_alias: HashMap::new(),
         }
     }
 
-    /// Register a new agent instance. Returns the generated instance ID.
-    pub fn register(&mut self, agent_name: &str) -> Uuid {
+    /// Register a new agent instance with an optional alias. Returns the generated instance ID.
+    pub fn register(&mut self, agent_name: &str, alias: Option<&str>) -> Uuid {
         let id = Uuid::new_v4();
         let info = InstanceInfo {
             instance_id: id,
             agent_name: agent_name.to_string(),
+            alias: alias.map(|s| s.to_string()),
+            lifecycle_state: None,
             spawned_at: Instant::now(),
             status: InstanceStatus::Running,
         };
@@ -67,10 +73,13 @@ impl InstanceRegistry {
             .entry(agent_name.to_string())
             .or_default()
             .push(id);
+        if let Some(a) = alias {
+            self.by_alias.insert(a.to_string(), id);
+        }
         id
     }
 
-    /// Unregister an agent instance by ID. Cleans up both maps.
+    /// Unregister an agent instance by ID. Cleans up all maps.
     pub fn unregister(&mut self, instance_id: &Uuid) {
         if let Some(info) = self.by_id.remove(instance_id) {
             if let Some(ids) = self.by_name.get_mut(&info.agent_name) {
@@ -79,6 +88,23 @@ impl InstanceRegistry {
                     self.by_name.remove(&info.agent_name);
                 }
             }
+            if let Some(ref alias) = info.alias {
+                self.by_alias.remove(alias);
+            }
+        }
+    }
+
+    /// Find a single instance by its alias.
+    pub fn find_by_alias(&self, alias: &str) -> Option<InstanceInfo> {
+        self.by_alias
+            .get(alias)
+            .and_then(|id| self.by_id.get(id).cloned())
+    }
+
+    /// Update the lifecycle state of an instance.
+    pub fn update_lifecycle(&mut self, instance_id: &Uuid, state: &str) {
+        if let Some(info) = self.by_id.get_mut(instance_id) {
+            info.lifecycle_state = Some(state.to_string());
         }
     }
 
@@ -130,7 +156,7 @@ mod tests {
     #[test]
     fn register_and_find_by_name() {
         let mut reg = InstanceRegistry::new();
-        let id = reg.register("greeter");
+        let id = reg.register("greeter", None);
 
         let found = reg.find_by_name("greeter");
         assert_eq!(found.len(), 1);
@@ -142,8 +168,8 @@ mod tests {
     #[test]
     fn register_multiple_same_name() {
         let mut reg = InstanceRegistry::new();
-        let id1 = reg.register("worker");
-        let id2 = reg.register("worker");
+        let id1 = reg.register("worker", None);
+        let id2 = reg.register("worker", None);
         assert_ne!(id1, id2);
 
         let found = reg.find_by_name("worker");
@@ -154,8 +180,8 @@ mod tests {
     #[test]
     fn unregister_cleans_both_maps() {
         let mut reg = InstanceRegistry::new();
-        let id1 = reg.register("worker");
-        let id2 = reg.register("worker");
+        let id1 = reg.register("worker", None);
+        let id2 = reg.register("worker", None);
 
         reg.unregister(&id1);
         assert_eq!(reg.len(), 1);
@@ -170,7 +196,7 @@ mod tests {
     #[test]
     fn unregister_last_removes_name_entry() {
         let mut reg = InstanceRegistry::new();
-        let id = reg.register("solo");
+        let id = reg.register("solo", None);
 
         reg.unregister(&id);
         assert!(reg.is_empty());
@@ -186,17 +212,58 @@ mod tests {
     #[test]
     fn find_all_returns_all_instances() {
         let mut reg = InstanceRegistry::new();
-        reg.register("alpha");
-        reg.register("beta");
-        reg.register("alpha");
+        reg.register("alpha", None);
+        reg.register("beta", None);
+        reg.register("alpha", None);
 
         assert_eq!(reg.find_all().len(), 3);
     }
 
     #[test]
+    fn register_with_alias() {
+        let mut reg = InstanceRegistry::new();
+        let id = reg.register("worker", Some("room_42_bot"));
+
+        let found = reg.find_by_alias("room_42_bot");
+        assert!(found.is_some());
+        let info = found.unwrap();
+        assert_eq!(info.instance_id, id);
+        assert_eq!(info.alias.as_deref(), Some("room_42_bot"));
+    }
+
+    #[test]
+    fn find_by_alias_not_found() {
+        let reg = InstanceRegistry::new();
+        assert!(reg.find_by_alias("nonexistent").is_none());
+    }
+
+    #[test]
+    fn unregister_cleans_alias() {
+        let mut reg = InstanceRegistry::new();
+        let id = reg.register("worker", Some("my_alias"));
+        assert!(reg.find_by_alias("my_alias").is_some());
+
+        reg.unregister(&id);
+        assert!(reg.find_by_alias("my_alias").is_none());
+    }
+
+    #[test]
+    fn update_lifecycle() {
+        let mut reg = InstanceRegistry::new();
+        let id = reg.register("worker", None);
+        assert!(reg.get(&id).unwrap().lifecycle_state.is_none());
+
+        reg.update_lifecycle(&id, "expert");
+        assert_eq!(
+            reg.get(&id).unwrap().lifecycle_state.as_deref(),
+            Some("expert")
+        );
+    }
+
+    #[test]
     fn unregister_nonexistent_is_noop() {
         let mut reg = InstanceRegistry::new();
-        reg.register("a");
+        reg.register("a", None);
         reg.unregister(&Uuid::new_v4());
         assert_eq!(reg.len(), 1);
     }

--- a/src/runtime/warded.rs
+++ b/src/runtime/warded.rs
@@ -165,7 +165,7 @@ impl WardedRuntime {
 
         process = process.with_event_bus(self.event_bus.clone()).await;
 
-        let instance_id = self.instance_registry.write().await.register(name);
+        let instance_id = self.instance_registry.write().await.register(name, None);
 
         let handle = tokio::spawn(async move { process.run().await });
 

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -869,3 +869,46 @@ fn spawn_with_memory_init_only() {
     let src = "task run_it\n  do\n    spawn helper\n      with memory level: 3\n";
     ForgeParser::parse(Rule::task_decl, src).unwrap();
 }
+
+// find_expr (#84)
+
+#[test]
+fn find_by_alias() {
+    ForgeParser::parse(Rule::find_expr, r#"find "room_42_bot""#).unwrap();
+}
+
+#[test]
+fn find_by_alias_ident() {
+    ForgeParser::parse(Rule::find_expr, "find name").unwrap();
+}
+
+#[test]
+fn find_all_by_template() {
+    ForgeParser::parse(Rule::find_expr, "find all forge_sensei").unwrap();
+}
+
+#[test]
+fn find_all_with_lifecycle_filter() {
+    ForgeParser::parse(
+        Rule::find_expr,
+        "find all forge_sensei where lifecycle == expert",
+    )
+    .unwrap();
+}
+
+#[test]
+fn find_keyword_rejected_as_ident() {
+    assert!(ForgeParser::parse(Rule::ident, "find").is_err());
+}
+
+#[test]
+fn find_in_task_binding() {
+    let src = "task lookup\n  do\n    bot = find \"room_42_bot\"\n";
+    ForgeParser::parse(Rule::task_decl, src).unwrap();
+}
+
+#[test]
+fn find_all_in_task_binding() {
+    let src = "task lookup\n  do\n    experts = find all sensei where lifecycle == expert\n";
+    ForgeParser::parse(Rule::task_decl, src).unwrap();
+}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1082,3 +1082,72 @@ fn parse_spawn_knowledge_filter_only() {
         other => panic!("expected Spawn, got {:?}", other),
     }
 }
+
+// ── Find expression tests (#84) ─────────────────────────────
+
+#[test]
+fn parse_find_by_alias() {
+    let prog = parse_task_with(r#"bot = find "room_42_bot""#);
+    let expr = bind_expr(first_stmt(&prog));
+    match expr {
+        Expr::Find(f) => match &f.kind {
+            FindKind::ByAlias(alias) => match &alias.node {
+                Expr::Template(parts) => {
+                    assert_eq!(parts.len(), 1);
+                    match &parts[0].node {
+                        TemplatePart::Text(s) => assert_eq!(s, "room_42_bot"),
+                        other => panic!("expected Text, got {:?}", other),
+                    }
+                }
+                other => panic!("expected Template, got {:?}", other),
+            },
+            other => panic!("expected ByAlias, got {:?}", other),
+        },
+        other => panic!("expected Find, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_find_by_alias_ident() {
+    let prog = parse_task_with("bot = find name");
+    let expr = bind_expr(first_stmt(&prog));
+    match expr {
+        Expr::Find(f) => match &f.kind {
+            FindKind::ByAlias(alias) => match &alias.node {
+                Expr::Ident(s) => assert_eq!(s, "name"),
+                other => panic!("expected Ident, got {:?}", other),
+            },
+            other => panic!("expected ByAlias, got {:?}", other),
+        },
+        other => panic!("expected Find, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_find_all_by_template() {
+    let prog = parse_task_with("experts = find all forge_sensei");
+    let expr = bind_expr(first_stmt(&prog));
+    match expr {
+        Expr::Find(f) => match &f.kind {
+            FindKind::AllByTemplate(t) => assert_eq!(t.node, "forge_sensei"),
+            other => panic!("expected AllByTemplate, got {:?}", other),
+        },
+        other => panic!("expected Find, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_find_all_with_lifecycle_filter() {
+    let prog = parse_task_with("experts = find all forge_sensei where lifecycle == expert");
+    let expr = bind_expr(first_stmt(&prog));
+    match expr {
+        Expr::Find(f) => match &f.kind {
+            FindKind::AllByTemplateFiltered(t, s) => {
+                assert_eq!(t.node, "forge_sensei");
+                assert_eq!(s.node, "expert");
+            }
+            other => panic!("expected AllByTemplateFiltered, got {:?}", other),
+        },
+        other => panic!("expected Find, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary
- Add `find` expression with three forms: `find "alias"` (single Record), `find all template` (Array), `find all template where lifecycle == state` (filtered Array)
- Extend `InstanceRegistry` with alias index (`by_alias` map), `find_by_alias()`, and `update_lifecycle()` methods
- Full compiler pipeline: grammar rule, AST (`FindExpr`/`FindKind`), parser, checkers (pure fn prohibition, requires clause warning, unknown template warning), and runtime executor

## Test plan
- [x] Grammar tests: `find_by_alias`, `find_by_alias_ident`, `find_all_by_template`, `find_all_with_lifecycle_filter`, `find_keyword_rejected_as_ident`, `find_in_task_binding`, `find_all_in_task_binding`
- [x] Parser tests: `parse_find_by_alias`, `parse_find_by_alias_ident`, `parse_find_all_by_template`, `parse_find_all_with_lifecycle_filter`
- [x] Registry unit tests: `register_with_alias`, `find_by_alias_not_found`, `unregister_cleans_alias`, `update_lifecycle`
- [x] Conformance tests: `valid_find.json`, `pure_no_find.json`
- [x] `cargo test` — all suites pass (0 failures)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — 0 warnings
- [x] Manual: `forge check` confirms `find` in `pure fn` errors and `find all unknown_agent` warns

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)