### PR TITLE
feat: forge-sensei spawns specialist apprentices (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `deep_dive(topic)` handler on forge-sensei — spawns specialist apprentice agents with filtered knowledge by category, find-before-spawn dedup, `LearnedInsight` subscription for ongoing learning, confidence cap on derived knowledge (#88)
 - `system` declaration runtime semantics — system blocks now serve as the orchestration root, creating shared event bus and instance registry, spawning initial agents from the use-block, wiring event routing from compose expressions (`a >> b`), integrating with wardens for supervised agents, and enforcing resource limits via `[system]` config section (#87)
 - `retire` statement for graceful agent lifecycle termination — `retire` (self), `retire "alias"` (by alias), with optional `with knowledge export: "path.json"` to preserve knowledge as ForgePackage before exit; unregisters from instance registry (Principle VIII — Accountability) (#86)
 - Dynamic warden `adopt()`/`release()` methods for runtime supervision management of spawned agents — `adopt` adds an agent to the manages list, `release` removes and clears retry state (#86)

--- a/workflows/forge-sensei.forge
+++ b/workflows/forge-sensei.forge
@@ -166,6 +166,22 @@ exportable agent forge_sensei
     emit LearnedInsight(category: "interactions", content: lesson, source: "session", confidence: 0.8)
     say "Learned from session."
 
+  # ── Deep Dive: spawn specialist for focused domain learning ──
+
+  on deep_dive(topic: Text)
+    memory.interaction_count = memory.interaction_count + 1
+    existing = find "specialist_{topic}"
+    if existing
+      say "Specialist for [{topic}] already active."
+      give existing
+    child = spawn specialist as "specialist_{topic}"
+      with knowledge where category == topic
+      with confidence_cap: 0.8
+      with memory topic: topic
+    say "Spawned specialist for [{topic}]."
+    emit LearnedInsight(category: topic, content: "Specialist spawned for deep dive", source: "deep_dive", confidence: 0.9)
+    give child
+
   # ── Assess: self-evaluation against conformance knowledge ───
 
   on assess_detailed(test_input: Text, expected: Text)
@@ -196,10 +212,39 @@ exportable agent forge_sensei
     say "forge-sensei is stuck. Escalating for human guidance."
     escalate to human
 
+# ── Specialist Agent (spawned by sensei for deep dives) ──────
+
+agent specialist
+  memory
+    topic: Text
+    query_count: Number
+  knowledge store: ".forge-knowledge/specialist"
+    max_entries: 10000
+    retention: 180d
+  subscribe LearnedInsight where category == memory.topic
+
+  on start
+    say "Specialist initialized for topic: {memory.topic}"
+
+  on LearnedInsight(category: Text, content: Text, source: Text, confidence: Number)
+    learn "{content}" category: category
+    say "Specialist [{memory.topic}] absorbed insight from {source}"
+
+  on query(question: Text)
+    memory.query_count = memory.query_count + 1
+    prior = recall "{memory.topic} {question}"
+    answer = answer_forge_question(question, prior)
+    learn from interaction(question, answer, 0.6) category: "{memory.topic}"
+    give answer
+
+  if stuck for 3 turns
+    say "Specialist stuck. Escalating."
+    escalate to human
+
 # ── Warden ────────────────────────────────────────────────────
 
 warden sensei_warden
-  manages [forge_sensei]
+  manages [forge_sensei, specialist]
   on stuck: nudge, self
     after 3: escalate
   on hallucination: restart, self


### PR DESCRIPTION
## Summary

- Adds `specialist` agent declaration — spawnable template with knowledge store, `LearnedInsight` subscription filtered by topic, and query handler that reuses existing `answer_forge_question` task
- Adds `on deep_dive(topic)` handler to `forge_sensei` — find-before-spawn dedup via `find "specialist_{topic}"`, knowledge transfer filtered by category, confidence cap at 0.8 (Principle I), memory initialization
- Updates `sensei_warden` to manage both `forge_sensei` and `specialist`
- Rebuilds forge-sensei binary with new `deep-dive` CLI command

Closes #88

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 30/30 pass
- [x] `forge check workflows/forge-sensei.forge` — OK
- [x] `scripts/build-sensei.sh` — binary built successfully
- [x] `bin/forge-sensei --help` — shows `deep-dive` command
- [x] `bin/forge-sensei deep-dive --help` — accepts `<TOPIC>` argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)