### PR TITLE
feat: Html type, content-type inference, safe field access (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden sensei scripts: build-sensei.sh (skip-if-unchanged, smoke test), pretrain-sensei.sh (error capture, jq, idempotency, --force/--dry-run), consult-sensei.sh (jq, content caching, thresholds), assess.sh (per-category scoring, trend tracking, --json)
 
 ### Added
+- `Html` builtin type with automatic `text/html` Content-Type inference from endpoint return type annotations (#44)
+- Safe record field access — missing fields return `Unit` instead of crashing, enabling graceful handling of optional request query/header parameters (#44)
 - Exhaustive forge-sensei test suite: parser, checker, and runtime conformance tests + Rust integration tests
 - `scripts/sensei-smoke-test.sh` for end-to-end integration testing
 - `scripts/sensei-cache.sh` for knowledge store and cache management (clean/reset/stats)

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -76,7 +76,7 @@ template_text   = @{ (!("\"" | "{" | "\\") ~ ANY)+ }
 builtin_type = @{
     ( "Text" | "Number" | "Bool" | "Results" | "Report" | "Intent"
     | "Summary" | "Failure" | "Classification" | "Conversation"
-    | "Profile" | "SearchResults" | "Request" | "Response" | "Headers" )
+    | "Profile" | "SearchResults" | "Request" | "Response" | "Headers" | "Html" )
     ~ !(ASCII_ALPHANUMERIC | "_")
 }
 type_name    = { (builtin_type | ident) ~ array_suffix? }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -441,6 +441,7 @@ pub enum TypeName {
     Request,
     Response,
     Headers,
+    Html,
     Custom(String),
     /// Array type: `Text[9]` = Array(Text, Some(9)), `Player[]` = Array(Custom("Player"), None)
     Array(Box<TypeName>, Option<usize>),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -140,6 +140,7 @@ fn build_type_name(pair: Pair) -> anyhow::Result<Spanned<TypeName>> {
             "Request" => TypeName::Request,
             "Response" => TypeName::Response,
             "Headers" => TypeName::Headers,
+            "Html" => TypeName::Html,
             other => TypeName::Custom(other.to_string()),
         },
         Rule::ident => TypeName::Custom(first.as_str().to_string()),
@@ -351,6 +352,7 @@ fn build_atom(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
                 "Request" => TypeName::Request,
                 "Response" => TypeName::Response,
                 "Headers" => TypeName::Headers,
+                "Html" => TypeName::Html,
                 other => TypeName::Custom(other.to_string()),
             };
             Ok(Spanned::new(
@@ -442,6 +444,7 @@ fn build_constructor_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
         "Request" => TypeName::Request,
         "Response" => TypeName::Response,
         "Headers" => TypeName::Headers,
+        "Html" => TypeName::Html,
         other => TypeName::Custom(other.to_string()),
     };
     let args = if let Some(arg_list) = inner.next() {

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -62,6 +62,8 @@ pub struct EndpointResult {
     pub value: ConfidentValue,
     pub status: Option<u16>,
     pub content_type: Option<String>,
+    /// Content-type inferred from the endpoint's return type annotation.
+    pub default_content_type: Option<String>,
 }
 
 // ── Environment (scope stack) ─────────────────────────────────────────────────
@@ -259,6 +261,15 @@ impl TaskExecutor {
                 name: name.to_string(),
             })?;
 
+        // Derive default content-type from return type annotation
+        let default_ct = endpoint.return_type.as_ref().and_then(|ot| {
+            ot.node.types.first().and_then(|tn| match &tn.node {
+                crate::ast::TypeName::Html => Some("text/html".to_string()),
+                crate::ast::TypeName::Text => Some("text/plain".to_string()),
+                _ => None,
+            })
+        });
+
         let mut env = Env::new();
         if let Some(req) = request {
             env.bind("request", req);
@@ -272,11 +283,13 @@ impl TaskExecutor {
                 value: val,
                 status: None,
                 content_type: None,
+                default_content_type: default_ct,
             }),
             Err(RuntimeError::GiveSignal(val, status, content_type)) => Ok(EndpointResult {
                 value: val,
                 status,
                 content_type,
+                default_content_type: default_ct,
             }),
             Err(e) => Err(e),
         }
@@ -1133,9 +1146,7 @@ impl TaskExecutor {
                                     }
                                 }
                             }
-                            Err(RuntimeError::UndefinedVariable {
-                                name: format!(".{}", field.node),
-                            })
+                            Ok(ConfidentValue::deterministic(Value::Unit))
                         }
                         _ => Err(RuntimeError::TypeError {
                             expected: "Record".to_string(),

--- a/src/runtime/http_server.rs
+++ b/src/runtime/http_server.rs
@@ -261,14 +261,19 @@ fn endpoint_result_to_response(result: EndpointResult) -> Response {
         .and_then(|s| StatusCode::from_u16(s).ok())
         .unwrap_or(default_status);
 
-    let (default_content_type, body) = match &result.value.value {
+    let (value_inferred_ct, body) = match &result.value.value {
         Value::Text(s) => ("text/plain", s.clone()),
         Value::Number(n) => ("text/plain", n.to_string()),
         Value::Bool(b) => ("text/plain", b.to_string()),
         Value::Unit => return status_code.into_response(),
         Value::List(_) | Value::Record(_) | Value::Array(_) => {
             let json = value_to_json(&result.value);
-            let ct = result.content_type.as_deref().unwrap_or("application/json");
+            // Priority: explicit > return-type annotation > value-inferred
+            let ct = result
+                .content_type
+                .as_deref()
+                .or(result.default_content_type.as_deref())
+                .unwrap_or("application/json");
             return (
                 status_code,
                 [(axum::http::header::CONTENT_TYPE, ct)],
@@ -278,10 +283,12 @@ fn endpoint_result_to_response(result: EndpointResult) -> Response {
         }
     };
 
+    // Priority: explicit > return-type annotation > value-inferred
     let ct = result
         .content_type
         .as_deref()
-        .unwrap_or(default_content_type);
+        .or(result.default_content_type.as_deref())
+        .unwrap_or(value_inferred_ct);
     (status_code, [(axum::http::header::CONTENT_TYPE, ct)], body).into_response()
 }
 

--- a/src/runtime/memory.rs
+++ b/src/runtime/memory.rs
@@ -120,6 +120,7 @@ fn default_for_type(ty: &TypeName) -> ConfidentValue {
         | TypeName::Request
         | TypeName::Response
         | TypeName::Headers
+        | TypeName::Html
         | TypeName::Custom(_) => Value::Record(HashMap::new()),
         TypeName::Results | TypeName::SearchResults => Value::List(vec![]),
         TypeName::Failure => Value::Text(String::new()),

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,6 +24,7 @@ pub enum ForgeType {
     Request,
     Response,
     Headers,
+    Html,
     Embedding,
     Duration,
     Named(String),
@@ -49,6 +50,7 @@ impl std::fmt::Display for ForgeType {
             ForgeType::Request => write!(f, "Request"),
             ForgeType::Response => write!(f, "Response"),
             ForgeType::Headers => write!(f, "Headers"),
+            ForgeType::Html => write!(f, "Html"),
             ForgeType::Embedding => write!(f, "Embedding"),
             ForgeType::Duration => write!(f, "Duration"),
             ForgeType::Named(s) => write!(f, "{s}"),
@@ -106,6 +108,7 @@ pub fn from_type_name(tn: &TypeName) -> ForgeType {
         TypeName::Request => ForgeType::Request,
         TypeName::Response => ForgeType::Response,
         TypeName::Headers => ForgeType::Headers,
+        TypeName::Html => ForgeType::Html,
         TypeName::Custom(s) => ForgeType::Named(s.clone()),
         TypeName::Array(inner, size) => ForgeType::Array(Box::new(from_type_name(inner)), *size),
     }

--- a/tests/http_server_tests.rs
+++ b/tests/http_server_tests.rs
@@ -311,3 +311,86 @@ async fn default_status_is_200() {
         .expect("request failed");
     assert_eq!(resp.status(), 200);
 }
+
+// ── Issue #44: Html type and content-type inference ───────────
+
+const HTML_ENDPOINT_SERVER: &str = r#"#! boundary: server
+
+endpoint page() -> Html
+  give "<h1>Hello</h1>"
+"#;
+
+#[tokio::test]
+async fn html_return_type_infers_content_type() {
+    let base = spawn_server(HTML_ENDPOINT_SERVER).await;
+    let resp = reqwest::get(format!("{base}/page"))
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(ct, "text/html");
+    assert_eq!(resp.text().await.unwrap(), "<h1>Hello</h1>");
+}
+
+const HTML_OVERRIDE_SERVER: &str = r#"#! boundary: server
+
+endpoint page() -> Html
+  give "<data/>" with content_type: "application/xml"
+"#;
+
+#[tokio::test]
+async fn explicit_content_type_overrides_return_type() {
+    let base = spawn_server(HTML_OVERRIDE_SERVER).await;
+    let resp = reqwest::get(format!("{base}/page"))
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(ct, "application/xml");
+}
+
+// ── Issue #44: Missing record fields return Unit ─────────────
+
+const MISSING_QUERY_SERVER: &str = r#"#! boundary: server
+
+endpoint check() -> Text
+  val = request.query.nonexistent
+  give val
+"#;
+
+#[tokio::test]
+async fn missing_query_field_returns_unit() {
+    let base = spawn_server(MISSING_QUERY_SERVER).await;
+    let resp = reqwest::get(format!("{base}/check"))
+        .await
+        .expect("request failed");
+    // Unit maps to 204 No Content
+    assert_eq!(resp.status(), 204);
+}
+
+const MISSING_HEADER_SERVER: &str = r#"#! boundary: server
+
+endpoint check() -> Text
+  val = request.headers.x_nonexistent
+  give val
+"#;
+
+#[tokio::test]
+async fn missing_header_field_returns_unit() {
+    let base = spawn_server(MISSING_HEADER_SERVER).await;
+    let resp = reqwest::get(format!("{base}/check"))
+        .await
+        .expect("request failed");
+    // Unit maps to 204 No Content
+    assert_eq!(resp.status(), 204);
+}


### PR DESCRIPTION
## Summary

- Add `Html` builtin type (grammar, AST, ForgeType, parser) with automatic `text/html` Content-Type inference from endpoint return type annotations
- Content-Type priority chain: explicit `with content_type` > return type annotation > value-based inference
- Record `.field` access now returns `Unit` for missing keys instead of crashing, enabling graceful handling of optional `request.query`/`request.headers` parameters

Closes #44

## Test plan

- [x] `html_return_type_infers_content_type` — endpoint `-> Html` serves `text/html` automatically
- [x] `explicit_content_type_overrides_return_type` — `with content_type` overrides annotation
- [x] `missing_query_field_returns_unit` — `request.query.nonexistent` returns Unit (204)
- [x] `missing_header_field_returns_unit` — `request.headers.nonexistent` returns Unit (204)
- [x] All 16 pre-existing HTTP server tests still pass
- [x] Full `cargo test` suite passes (600+ tests), `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)