### PR TITLE
feat: markdown.render capability (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden sensei scripts: build-sensei.sh (skip-if-unchanged, smoke test), pretrain-sensei.sh (error capture, jq, idempotency, --force/--dry-run), consult-sensei.sh (jq, content caching, thresholds), assess.sh (per-category scoring, trend tracking, --json)
 
 ### Added
+- **`markdown.render(content)` built-in capability** — converts Markdown to HTML using pulldown-cmark with tables, footnotes, strikethrough, and task lists; `forge` code blocks get `class="language-forge"` for Prism.js syntax highlighting (#49)
 - **Hot-reload development mode** via `forge serve --watch` — watches `.forge` files for changes and hot-swaps the endpoint handler without dropping connections; parse/check errors display in terminal while server keeps running with previous version; config file changes trigger full server restart (#47)
 - **Static file serving** with configurable root directory and URL prefix via `[server.static]` config, powered by tower-http `ServeDir` (#46)
 - **`asset()` built-in function** returns prefixed URL path for static assets, e.g. `asset("css/style.css")` → `/static/css/style.css` (#46)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "notify",
  "pest",
  "pest_derive",
+ "pulldown-cmark",
  "redb",
  "reqwest",
  "serde",
@@ -1151,6 +1152,24 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
 name = "quinn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 redb = "2"
 notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
+pulldown-cmark = { version = "0.10", default-features = false, features = ["html"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,7 +443,7 @@ fn open_forge_storage() -> anyhow::Result<forge::runtime::storage::SharedStorage
     Ok(Arc::new(storage))
 }
 
-fn read_source(file: &PathBuf) -> anyhow::Result<String> {
+fn read_source(file: &Path) -> anyhow::Result<String> {
     std::fs::read_to_string(file)
         .map_err(|e| anyhow::anyhow!("could not read {}: {}", file.display(), e))
 }
@@ -458,7 +458,7 @@ fn parse_or_exit(source: &str, file: &Path) -> forge::ast::Program {
     }
 }
 
-async fn run_program(file: &PathBuf, trace: bool) -> anyhow::Result<()> {
+async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
     let source = read_source(file)?;
     let program = parse_or_exit(&source, file);
     let fname = file.display().to_string();
@@ -701,7 +701,7 @@ fn try_build_executor(
     ),
     anyhow::Error,
 > {
-    let source = read_source(&file.to_path_buf())?;
+    let source = read_source(file)?;
     let fname = file.display().to_string();
 
     let program = match forge::parser::parse(&source) {
@@ -751,7 +751,7 @@ fn try_build_executor(
 }
 
 async fn serve_program(
-    file: &PathBuf,
+    file: &Path,
     cli_host: Option<String>,
     cli_port: Option<u16>,
     watch: bool,
@@ -836,7 +836,7 @@ async fn serve_with_watch(
     }
 }
 
-async fn run_agent(file: &PathBuf) -> anyhow::Result<()> {
+async fn run_agent(file: &Path) -> anyhow::Result<()> {
     let source = read_source(file)?;
     let program = parse_or_exit(&source, file);
 
@@ -993,7 +993,7 @@ fn parse_args(input: &str) -> Vec<String> {
 }
 
 /// Send a single event to an agent non-interactively, print the result, and exit.
-async fn send_to_agent(file: &PathBuf, event: &str, args: Vec<String>) -> anyhow::Result<()> {
+async fn send_to_agent(file: &Path, event: &str, args: Vec<String>) -> anyhow::Result<()> {
     let source = read_source(file)?;
     let program = parse_or_exit(&source, file);
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -139,6 +139,13 @@ impl CapabilityRegistry {
             },
         );
         caps.insert(
+            "markdown.render".into(),
+            CapabilitySignature {
+                inputs: vec![ForgeType::Text],
+                output: ForgeType::Html,
+            },
+        );
+        caps.insert(
             "asset".into(),
             CapabilitySignature {
                 inputs: vec![ForgeType::Text],

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -1290,6 +1290,32 @@ impl TaskExecutor {
                         }
                     }
 
+                    // markdown.render() — built-in Markdown capability
+                    if let Expr::Ident(ref ns) = obj_expr.node {
+                        if ns == "markdown" {
+                            let mut arg_vals = Vec::new();
+                            for arg in args {
+                                arg_vals.push(self.eval_expr(&arg.node.value, env).await?);
+                            }
+                            match method.node.as_str() {
+                                "render" => {
+                                    let content = arg_vals
+                                        .first()
+                                        .map(|v| format!("{}", v.value))
+                                        .unwrap_or_default();
+                                    let html = crate::runtime::markdown::render_markdown(&content);
+                                    return Ok(ConfidentValue::deterministic(Value::Html(html)));
+                                }
+                                other => {
+                                    return Err(RuntimeError::Unsupported(format!(
+                                        "markdown.{}()",
+                                        other
+                                    )));
+                                }
+                            }
+                        }
+                    }
+
                     // Pool .send() interception — pools are declarations, not runtime values
                     if method.node == "send" {
                         if let Expr::Ident(ref name) = obj_expr.node {

--- a/src/runtime/markdown.rs
+++ b/src/runtime/markdown.rs
@@ -1,0 +1,92 @@
+//! Markdown rendering for FORGE — converts Markdown to HTML via pulldown-cmark.
+
+use pulldown_cmark::{html, Options, Parser};
+
+/// Render Markdown text to HTML.
+///
+/// Enables tables, footnotes, strikethrough, and task lists.
+/// Fenced code blocks tagged `forge` get `class="language-forge"` for Prism.js.
+pub fn render_markdown(input: &str) -> String {
+    if input.is_empty() {
+        return String::new();
+    }
+
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_FOOTNOTES);
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TASKLISTS);
+
+    let parser = Parser::new_ext(input, options);
+    let mut html_output = String::new();
+    html::push_html(&mut html_output, parser);
+    html_output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert_eq!(render_markdown(""), "");
+    }
+
+    #[test]
+    fn renders_heading() {
+        let result = render_markdown("# Hello");
+        assert!(result.contains("<h1>Hello</h1>"));
+    }
+
+    #[test]
+    fn renders_paragraph() {
+        let result = render_markdown("Hello world");
+        assert!(result.contains("<p>Hello world</p>"));
+    }
+
+    #[test]
+    fn forge_code_block_gets_language_class() {
+        let input = "```forge\ntask greet(name: Text) -> Text\n```";
+        let result = render_markdown(input);
+        assert!(
+            result.contains("language-forge"),
+            "expected language-forge class, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn renders_table() {
+        let input = "| A | B |\n|---|---|\n| 1 | 2 |";
+        let result = render_markdown(input);
+        assert!(result.contains("<table>"));
+        assert!(result.contains("<td>1</td>"));
+    }
+
+    #[test]
+    fn renders_strikethrough() {
+        let result = render_markdown("~~deleted~~");
+        assert!(result.contains("<del>deleted</del>"));
+    }
+
+    #[test]
+    fn renders_task_list() {
+        let input = "- [x] done\n- [ ] todo";
+        let result = render_markdown(input);
+        assert!(result.contains("checked"));
+        assert!(result.contains("type=\"checkbox\""));
+    }
+
+    #[test]
+    fn renders_links() {
+        let result = render_markdown("[click](https://example.com)");
+        assert!(result.contains("<a href=\"https://example.com\">click</a>"));
+    }
+
+    #[test]
+    fn invalid_markdown_passes_through() {
+        let input = "some ][ broken [[ markup";
+        let result = render_markdown(input);
+        assert!(result.contains("some ][ broken [[ markup"));
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9,6 +9,7 @@ pub mod html;
 pub mod http_server;
 pub mod instance_registry;
 pub mod knowledge_store;
+pub mod markdown;
 pub mod memory;
 pub mod pool;
 pub mod state_machine;


### PR DESCRIPTION
## Summary
- Add `markdown.render(content: Text) -> Html` built-in capability using pulldown-cmark
- Supports tables, footnotes, strikethrough, and task lists
- `forge` code blocks get `class="language-forge"` for Prism.js syntax highlighting
- Pure deterministic operation composable with `html.layout` from #45

Closes #49

## Test plan
- [x] 9 unit tests covering all acceptance criteria (empty input, headings, paragraphs, forge code blocks, tables, strikethrough, task lists, links, invalid markdown)
- [x] Full test suite passes (676 tests, 0 failures)
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)