### PR TITLE
feat: HTTP client with web.fetch, web.post, and search (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden sensei scripts: build-sensei.sh (skip-if-unchanged, smoke test), pretrain-sensei.sh (error capture, jq, idempotency, --force/--dry-run), consult-sensei.sh (jq, content caching, thresholds), assess.sh (per-category scoring, trend tracking, --json)
 
 ### Added
+- **HTTP client capabilities** — `web.fetch(url)` for GET requests and `web.post(url, body)` for POST requests, returning response body as Text; errors produce catchable failures for use with `try ... or` (#51)
+- **Web search implementation** — `search "query"` now dispatches to a configurable search provider (SearXNG) instead of returning an empty list; results include title, url, and snippet fields (#51)
+- **`[web]` config section** — configurable timeout, max redirects, search provider, API key, and search URL with env var expansion (#51)
+- **Boundary enforcement for HTTP** — `web.fetch()`, `web.post()`, and `search` are restricted to `boundary: server` files (#51)
 - **`markdown.render(content)` built-in capability** — converts Markdown to HTML using pulldown-cmark with tables, footnotes, strikethrough, and task lists; `forge` code blocks get `class="language-forge"` for Prism.js syntax highlighting (#49)
 - **Hot-reload development mode** via `forge serve --watch` — watches `.forge` files for changes and hot-swaps the endpoint handler without dropping connections; parse/check errors display in terminal while server keeps running with previous version; config file changes trigger full server restart (#47)
 - **Static file serving** with configurable root directory and URL prefix via `[server.static]` config, powered by tower-http `ServeDir` (#46)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tower-http",
+ "urlencoding",
  "uuid",
 ]
 
@@ -1923,6 +1924,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ redb = "2"
 notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 pulldown-cmark = { version = "0.10", default-features = false, features = ["html"] }
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/checker/boundary_checker.rs
+++ b/src/checker/boundary_checker.rs
@@ -473,7 +473,26 @@ fn check_refs_in_expr(
                 check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
             }
         }
-        Expr::Reason(inner) | Expr::Search(inner) | Expr::Recall(inner) => {
+        Expr::Reason(inner) | Expr::Recall(inner) => {
+            check_refs_in_expr(inner, boundary, registry, file, diagnostics);
+        }
+        Expr::Search(inner) => {
+            if boundary != BoundaryKind::Server {
+                let boundary_name = match boundary {
+                    BoundaryKind::Client => "client",
+                    BoundaryKind::Shared => "shared",
+                    _ => unreachable!(),
+                };
+                diagnostics.push(
+                    Diagnostic::error(
+                        file,
+                        format!("search is not allowed in {} boundary", boundary_name),
+                        expr.span.start..expr.span.end,
+                        "search makes network requests and can only be used in server boundary files",
+                    )
+                    .with_help("move this code to a file with `#! boundary: server`"),
+                );
+            }
             check_refs_in_expr(inner, boundary, registry, file, diagnostics);
         }
         Expr::Classify(c) => {
@@ -495,7 +514,35 @@ fn check_refs_in_expr(
         Expr::UnaryOp(_, a) | Expr::Paren(a) | Expr::FieldAccess(a, _) | Expr::GlobAccess(a) => {
             check_refs_in_expr(a, boundary, registry, file, diagnostics);
         }
-        Expr::MethodCall(inner, _, args) => {
+        Expr::MethodCall(inner, method, args) => {
+            // Boundary enforcement: web.fetch and web.post are server-only
+            if let Expr::Ident(ref ns) = inner.node {
+                if ns == "web"
+                    && (method.node == "fetch" || method.node == "post")
+                    && boundary != BoundaryKind::Server
+                {
+                    let boundary_name = match boundary {
+                        BoundaryKind::Client => "client",
+                        BoundaryKind::Shared => "shared",
+                        _ => unreachable!(),
+                    };
+                    diagnostics.push(
+                        Diagnostic::error(
+                            file,
+                            format!(
+                                "web.{}() is not allowed in {} boundary",
+                                method.node, boundary_name
+                            ),
+                            inner.span.start..method.span.end,
+                            format!(
+                                "web.{}() can only be used in server boundary files",
+                                method.node
+                            ),
+                        )
+                        .with_help("move this code to a file with `#! boundary: server`"),
+                    );
+                }
+            }
             check_refs_in_expr(inner, boundary, registry, file, diagnostics);
             for arg in args {
                 check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct ForgeConfig {
     pub providers: HashMap<String, ProviderConfig>,
     pub server: Option<ServerConfig>,
     pub system: Option<SystemConfig>,
+    pub web: Option<WebConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -40,6 +41,25 @@ impl StaticConfig {
 pub struct SystemConfig {
     pub max_agents: Option<usize>,
     pub max_memory_mb: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct WebConfig {
+    pub timeout_secs: Option<u64>,
+    pub max_redirects: Option<usize>,
+    pub search_provider: Option<String>,
+    pub search_api_key: Option<String>,
+    pub search_url: Option<String>,
+}
+
+impl WebConfig {
+    pub fn timeout_or_default(&self) -> u64 {
+        self.timeout_secs.unwrap_or(30)
+    }
+
+    pub fn max_redirects_or_default(&self) -> usize {
+        self.max_redirects.unwrap_or(10)
+    }
 }
 
 impl ServerConfig {
@@ -288,6 +308,14 @@ impl ForgeConfig {
                 config.base_url = Some(expand_env_var(url));
             }
         }
+        if let Some(ref mut web) = self.web {
+            if let Some(key) = &web.search_api_key {
+                web.search_api_key = Some(expand_env_var(key));
+            }
+            if let Some(url) = &web.search_url {
+                web.search_url = Some(expand_env_var(url));
+            }
+        }
     }
 
     pub fn default_mock_config() -> Self {
@@ -314,6 +342,7 @@ impl ForgeConfig {
             providers,
             server: None,
             system: None,
+            web: None,
         }
     }
 }
@@ -365,6 +394,7 @@ mod tests {
             providers: HashMap::new(),
             server: None,
             system: None,
+            web: None,
         };
         assert!(matches!(
             config.validate(),
@@ -410,6 +440,7 @@ mod tests {
             providers,
             server: None,
             system: None,
+            web: None,
         };
         assert!(matches!(
             config.validate(),

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -110,6 +110,20 @@ impl CapabilityRegistry {
             },
         );
         caps.insert(
+            "web.fetch".into(),
+            CapabilitySignature {
+                inputs: vec![ForgeType::Text],
+                output: ForgeType::Text,
+            },
+        );
+        caps.insert(
+            "web.post".into(),
+            CapabilitySignature {
+                inputs: vec![ForgeType::Text, ForgeType::Text],
+                output: ForgeType::Text,
+            },
+        );
+        caps.insert(
             "data.store".into(),
             CapabilitySignature {
                 inputs: vec![ForgeType::Text, ForgeType::Text],

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -1316,6 +1316,63 @@ impl TaskExecutor {
                         }
                     }
 
+                    // web.fetch() / web.post() — built-in HTTP client capabilities
+                    if let Expr::Ident(ref ns) = obj_expr.node {
+                        if ns == "web" {
+                            let mut arg_vals = Vec::new();
+                            for arg in args {
+                                arg_vals.push(self.eval_expr(&arg.node.value, env).await?);
+                            }
+                            let web_config = self.config.as_ref().and_then(|c| c.web.as_ref());
+                            let client =
+                                crate::runtime::http_client::ForgeHttpClient::new(web_config);
+                            match method.node.as_str() {
+                                "fetch" => {
+                                    let url = arg_vals
+                                        .first()
+                                        .map(|v| format!("{}", v.value))
+                                        .unwrap_or_default();
+                                    match client.fetch(&url).await {
+                                        Ok(body) => {
+                                            return Ok(ConfidentValue::deterministic(Value::Text(
+                                                body,
+                                            )));
+                                        }
+                                        Err(e) => {
+                                            return Err(RuntimeError::FlowError(e));
+                                        }
+                                    }
+                                }
+                                "post" => {
+                                    let url = arg_vals
+                                        .first()
+                                        .map(|v| format!("{}", v.value))
+                                        .unwrap_or_default();
+                                    let body = arg_vals
+                                        .get(1)
+                                        .map(|v| format!("{}", v.value))
+                                        .unwrap_or_default();
+                                    match client.post(&url, &body).await {
+                                        Ok(resp) => {
+                                            return Ok(ConfidentValue::deterministic(Value::Text(
+                                                resp,
+                                            )));
+                                        }
+                                        Err(e) => {
+                                            return Err(RuntimeError::FlowError(e));
+                                        }
+                                    }
+                                }
+                                other => {
+                                    return Err(RuntimeError::Unsupported(format!(
+                                        "web.{}()",
+                                        other
+                                    )));
+                                }
+                            }
+                        }
+                    }
+
                     // Pool .send() interception — pools are declarations, not runtime values
                     if method.node == "send" {
                         if let Expr::Ident(ref name) = obj_expr.node {
@@ -1706,7 +1763,39 @@ impl TaskExecutor {
                     ))
                 }
 
-                Expr::Search(_) => Ok(ConfidentValue::deterministic(Value::List(vec![]))),
+                Expr::Search(query_expr) => {
+                    let query_val = self.eval_expr(query_expr, env).await?;
+                    let query_text = format!("{}", query_val.value);
+                    let web_config = self.config.as_ref().and_then(|c| c.web.as_ref());
+                    let client = crate::runtime::http_client::ForgeHttpClient::new(web_config);
+                    match crate::runtime::http_client::search(&client, &query_text, web_config)
+                        .await
+                    {
+                        Ok(results) => {
+                            let items: Vec<ConfidentValue> = results
+                                .into_iter()
+                                .map(|r| {
+                                    let mut fields = HashMap::new();
+                                    fields.insert(
+                                        "title".into(),
+                                        ConfidentValue::deterministic(Value::Text(r.title)),
+                                    );
+                                    fields.insert(
+                                        "url".into(),
+                                        ConfidentValue::deterministic(Value::Text(r.url)),
+                                    );
+                                    fields.insert(
+                                        "snippet".into(),
+                                        ConfidentValue::deterministic(Value::Text(r.snippet)),
+                                    );
+                                    ConfidentValue::deterministic(Value::Record(fields))
+                                })
+                                .collect();
+                            Ok(ConfidentValue::deterministic(Value::List(items)))
+                        }
+                        Err(e) => Err(RuntimeError::FlowError(e)),
+                    }
+                }
 
                 Expr::Recall(query_expr) => {
                     let query_val = self.eval_expr(query_expr, env).await?;

--- a/src/runtime/http_client.rs
+++ b/src/runtime/http_client.rs
@@ -67,6 +67,7 @@ impl ForgeHttpClient {
 
 // ── Search ───────────────────────────────────────────────────────────────────
 
+#[derive(Debug)]
 pub struct SearchResult {
     pub title: String,
     pub url: String,

--- a/src/runtime/http_client.rs
+++ b/src/runtime/http_client.rs
@@ -1,0 +1,152 @@
+// FORGE HTTP client
+// Outbound HTTP capabilities: web.fetch, web.post, search
+// See issue #51
+
+use reqwest::Client;
+use std::time::Duration;
+
+use crate::config::WebConfig;
+
+pub struct ForgeHttpClient {
+    client: Client,
+}
+
+impl ForgeHttpClient {
+    pub fn new(config: Option<&WebConfig>) -> Self {
+        let timeout = config.map(|c| c.timeout_or_default()).unwrap_or(30);
+        let max_redirects = config.map(|c| c.max_redirects_or_default()).unwrap_or(10);
+        let client = Client::builder()
+            .timeout(Duration::from_secs(timeout))
+            .redirect(reqwest::redirect::Policy::limited(max_redirects))
+            .user_agent("FORGE/1.0")
+            .build()
+            .expect("failed to build HTTP client");
+        Self { client }
+    }
+
+    pub async fn fetch(&self, url: &str) -> Result<String, String> {
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| format_reqwest_error(e, url))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(format!("HTTP {}: {}", status.as_u16(), url));
+        }
+
+        response
+            .text()
+            .await
+            .map_err(|e| format!("failed to read response body from {}: {}", url, e))
+    }
+
+    pub async fn post(&self, url: &str, body: &str) -> Result<String, String> {
+        let response = self
+            .client
+            .post(url)
+            .header("Content-Type", "text/plain")
+            .body(body.to_string())
+            .send()
+            .await
+            .map_err(|e| format_reqwest_error(e, url))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(format!("HTTP {}: {}", status.as_u16(), url));
+        }
+
+        response
+            .text()
+            .await
+            .map_err(|e| format!("failed to read response body from {}: {}", url, e))
+    }
+}
+
+// ── Search ───────────────────────────────────────────────────────────────────
+
+pub struct SearchResult {
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
+}
+
+pub async fn search(
+    client: &ForgeHttpClient,
+    query: &str,
+    config: Option<&WebConfig>,
+) -> Result<Vec<SearchResult>, String> {
+    let provider = config
+        .and_then(|c| c.search_provider.as_deref())
+        .unwrap_or("searxng");
+
+    match provider {
+        "searxng" => search_searxng(client, query, config).await,
+        other => Err(format!(
+            "unsupported search provider: {} (supported: searxng)",
+            other
+        )),
+    }
+}
+
+async fn search_searxng(
+    client: &ForgeHttpClient,
+    query: &str,
+    config: Option<&WebConfig>,
+) -> Result<Vec<SearchResult>, String> {
+    let base_url = config
+        .and_then(|c| c.search_url.as_deref())
+        .unwrap_or("http://localhost:8080");
+
+    let url = format!(
+        "{}/search?q={}&format=json",
+        base_url.trim_end_matches('/'),
+        urlencoding::encode(query)
+    );
+
+    let response = client
+        .client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format_reqwest_error(e, &url))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("search failed: HTTP {}", status.as_u16()));
+    }
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| format!("failed to parse search response: {}", e))?;
+
+    let results = body["results"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|item| SearchResult {
+                    title: item["title"].as_str().unwrap_or("").to_string(),
+                    url: item["url"].as_str().unwrap_or("").to_string(),
+                    snippet: item["content"].as_str().unwrap_or("").to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(results)
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn format_reqwest_error(e: reqwest::Error, url: &str) -> String {
+    if e.is_timeout() {
+        format!("HTTP timeout: {}", url)
+    } else if e.is_connect() {
+        format!("connection failed: {}", url)
+    } else {
+        format!("HTTP error for {}: {}", url, e)
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -6,6 +6,7 @@ pub mod confidence;
 pub mod event_bus;
 pub mod executor;
 pub mod html;
+pub mod http_client;
 pub mod http_server;
 pub mod instance_registry;
 pub mod knowledge_store;

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -162,7 +162,9 @@ async fn accept_hello_run() {
 }
 
 #[tokio::test]
-async fn accept_research_run() {
+async fn accept_research_run_without_search_provider() {
+    // Without a configured search provider, search produces a FlowError
+    // (it tries to connect to localhost:8080 SearXNG by default).
     let program = parse_file("examples/research.forge");
     let mock = MockProvider::new("mock")
         .with_response("search", "Search results about artificial intelligence")
@@ -172,12 +174,9 @@ async fn accept_research_run() {
     let executor = TaskExecutor::new(program, mock_registry(mock), None);
     let result = executor.run().await;
     assert!(
-        result.is_ok(),
-        "research.forge should run without error: {:?}",
-        result.err()
+        result.is_err(),
+        "research.forge should fail without a search provider"
     );
-    let outputs = executor.outputs();
-    assert!(!outputs.is_empty(), "research.forge should produce output");
 }
 
 #[tokio::test]

--- a/tests/boundary_tests.rs
+++ b/tests/boundary_tests.rs
@@ -414,3 +414,92 @@ task noop
     let diags = check_boundary(&[(source, "minimal.forge")]);
     assert!(diags.is_empty());
 }
+
+// ── HTTP client boundary enforcement (issue #51) ────────────
+
+#[test]
+fn web_fetch_in_client_boundary_is_error() {
+    let source = "\
+#! boundary: client
+
+fn main
+  page = web.fetch(\"https://example.com\")
+  give page
+";
+    let diags = check_boundary(&[(source, "client.forge")]);
+    let errs = errors(&diags);
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].message.contains("web.fetch()"));
+    assert!(errs[0].message.contains("client"));
+}
+
+#[test]
+fn web_post_in_client_boundary_is_error() {
+    let source = "\
+#! boundary: client
+
+fn main
+  resp = web.post(\"https://example.com\", \"body\")
+  give resp
+";
+    let diags = check_boundary(&[(source, "client.forge")]);
+    let errs = errors(&diags);
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].message.contains("web.post()"));
+    assert!(errs[0].message.contains("client"));
+}
+
+#[test]
+fn web_fetch_in_server_boundary_is_ok() {
+    let source = "\
+#! boundary: server
+
+fn main
+  page = web.fetch(\"https://example.com\")
+  give page
+";
+    let diags = check_boundary(&[(source, "server.forge")]);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn web_post_in_server_boundary_is_ok() {
+    let source = "\
+#! boundary: server
+
+fn main
+  resp = web.post(\"https://example.com\", \"body\")
+  give resp
+";
+    let diags = check_boundary(&[(source, "server.forge")]);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn search_in_client_boundary_is_error() {
+    let source = "\
+#! boundary: client
+
+fn main
+  results = search \"rust programming\"
+  give results
+";
+    let diags = check_boundary(&[(source, "client.forge")]);
+    let errs = errors(&diags);
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].message.contains("search"));
+    assert!(errs[0].message.contains("client"));
+}
+
+#[test]
+fn search_in_server_boundary_is_ok() {
+    let source = "\
+#! boundary: server
+
+fn main
+  results = search \"rust programming\"
+  give results
+";
+    let diags = check_boundary(&[(source, "server.forge")]);
+    assert!(diags.is_empty());
+}

--- a/tests/http_client_tests.rs
+++ b/tests/http_client_tests.rs
@@ -231,7 +231,7 @@ async fn search_returns_error_for_unsupported_provider() {
 #[tokio::test]
 async fn search_returns_error_when_server_unavailable() {
     let config = WebConfig {
-        timeout_secs: Some(1),
+        timeout_secs: Some(2),
         max_redirects: None,
         search_provider: Some("searxng".to_string()),
         search_api_key: None,
@@ -242,9 +242,10 @@ async fn search_returns_error_when_server_unavailable() {
     let result = search(&client, "test", Some(&config)).await;
     assert!(result.is_err());
     let err = result.unwrap_err();
+    // On Linux/macOS connection is refused immediately; on Windows it may timeout instead
     assert!(
-        err.contains("connection failed"),
-        "expected connection error, got: {}",
+        err.contains("connection failed") || err.contains("timeout"),
+        "expected connection or timeout error, got: {}",
         err
     );
 }

--- a/tests/http_client_tests.rs
+++ b/tests/http_client_tests.rs
@@ -1,0 +1,449 @@
+// Integration tests for FORGE HTTP client (issue #51)
+// Spins up local mock servers to verify web.fetch, web.post, search,
+// error handling, and timeout behavior end-to-end.
+
+use std::collections::HashMap;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::Router;
+use tokio::net::TcpListener;
+
+use forge::config::WebConfig;
+use forge::runtime::http_client::{search, ForgeHttpClient};
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/// Start a mock HTTP server on a random port, return its base URL.
+async fn start_mock_server(app: Router) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{}", addr)
+}
+
+// ── web.fetch tests ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn fetch_returns_body_as_text() {
+    let app = Router::new().route("/hello", get(|| async { "Hello from mock server" }));
+    let base = start_mock_server(app).await;
+    let client = ForgeHttpClient::new(None);
+
+    let result = client.fetch(&format!("{}/hello", base)).await;
+    assert_eq!(result.unwrap(), "Hello from mock server");
+}
+
+#[tokio::test]
+async fn fetch_returns_error_on_404() {
+    let app = Router::new().route("/exists", get(|| async { "ok" }));
+    let base = start_mock_server(app).await;
+    let client = ForgeHttpClient::new(None);
+
+    let url = format!("{}/missing", base);
+    let result = client.fetch(&url).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.contains("HTTP 404"), "expected 404 error, got: {}", err);
+}
+
+#[tokio::test]
+async fn fetch_returns_error_on_500() {
+    let app = Router::new().route(
+        "/error",
+        get(|| async { (StatusCode::INTERNAL_SERVER_ERROR, "server broke") }),
+    );
+    let base = start_mock_server(app).await;
+    let client = ForgeHttpClient::new(None);
+
+    let url = format!("{}/error", base);
+    let result = client.fetch(&url).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.contains("HTTP 500"), "expected 500 error, got: {}", err);
+}
+
+#[tokio::test]
+async fn fetch_returns_connection_error_for_invalid_host() {
+    let client = ForgeHttpClient::new(None);
+    let result = client.fetch("http://127.0.0.1:1").await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("connection failed"),
+        "expected connection error, got: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn fetch_returns_timeout_error() {
+    let app = Router::new().route(
+        "/slow",
+        get(|| async {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            "too late"
+        }),
+    );
+    let base = start_mock_server(app).await;
+
+    // 1-second timeout
+    let config = WebConfig {
+        timeout_secs: Some(1),
+        max_redirects: None,
+        search_provider: None,
+        search_api_key: None,
+        search_url: None,
+    };
+    let client = ForgeHttpClient::new(Some(&config));
+
+    let url = format!("{}/slow", base);
+    let result = client.fetch(&url).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("timeout"),
+        "expected timeout error, got: {}",
+        err
+    );
+}
+
+// ── web.post tests ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn post_sends_body_and_returns_response() {
+    let app = Router::new().route(
+        "/echo",
+        post(|body: String| async move { format!("echoed: {}", body) }),
+    );
+    let base = start_mock_server(app).await;
+    let client = ForgeHttpClient::new(None);
+
+    let result = client.post(&format!("{}/echo", base), "hello world").await;
+    assert_eq!(result.unwrap(), "echoed: hello world");
+}
+
+#[tokio::test]
+async fn post_returns_error_on_4xx() {
+    let app = Router::new().route(
+        "/reject",
+        post(|| async { (StatusCode::BAD_REQUEST, "bad request") }),
+    );
+    let base = start_mock_server(app).await;
+    let client = ForgeHttpClient::new(None);
+
+    let url = format!("{}/reject", base);
+    let result = client.post(&url, "data").await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.contains("HTTP 400"), "expected 400 error, got: {}", err);
+}
+
+// ── search tests ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn search_parses_searxng_json_response() {
+    let app = Router::new().route(
+        "/search",
+        get(|Query(params): Query<HashMap<String, String>>| async move {
+            let query = params.get("q").cloned().unwrap_or_default();
+            let json = serde_json::json!({
+                "results": [
+                    {
+                        "title": format!("Result about {}", query),
+                        "url": "https://example.com/1",
+                        "content": format!("Snippet about {}", query)
+                    },
+                    {
+                        "title": "Second result",
+                        "url": "https://example.com/2",
+                        "content": "Another snippet"
+                    }
+                ]
+            });
+            axum::Json(json)
+        }),
+    );
+    let base = start_mock_server(app).await;
+
+    let config = WebConfig {
+        timeout_secs: None,
+        max_redirects: None,
+        search_provider: Some("searxng".to_string()),
+        search_api_key: None,
+        search_url: Some(base),
+    };
+    let client = ForgeHttpClient::new(Some(&config));
+
+    let results = search(&client, "rust programming", Some(&config))
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].title, "Result about rust programming");
+    assert_eq!(results[0].url, "https://example.com/1");
+    assert_eq!(results[0].snippet, "Snippet about rust programming");
+    assert_eq!(results[1].title, "Second result");
+}
+
+#[tokio::test]
+async fn search_returns_empty_list_for_no_results() {
+    let app = Router::new().route(
+        "/search",
+        get(|| async { axum::Json(serde_json::json!({ "results": [] })) }),
+    );
+    let base = start_mock_server(app).await;
+
+    let config = WebConfig {
+        timeout_secs: None,
+        max_redirects: None,
+        search_provider: Some("searxng".to_string()),
+        search_api_key: None,
+        search_url: Some(base),
+    };
+    let client = ForgeHttpClient::new(Some(&config));
+
+    let results = search(&client, "nothing", Some(&config)).await.unwrap();
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn search_returns_error_for_unsupported_provider() {
+    let config = WebConfig {
+        timeout_secs: None,
+        max_redirects: None,
+        search_provider: Some("nonexistent".to_string()),
+        search_api_key: None,
+        search_url: None,
+    };
+    let client = ForgeHttpClient::new(Some(&config));
+
+    let result = search(&client, "test", Some(&config)).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("unsupported search provider"));
+}
+
+#[tokio::test]
+async fn search_returns_error_when_server_unavailable() {
+    let config = WebConfig {
+        timeout_secs: Some(1),
+        max_redirects: None,
+        search_provider: Some("searxng".to_string()),
+        search_api_key: None,
+        search_url: Some("http://127.0.0.1:1".to_string()),
+    };
+    let client = ForgeHttpClient::new(Some(&config));
+
+    let result = search(&client, "test", Some(&config)).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("connection failed"),
+        "expected connection error, got: {}",
+        err
+    );
+}
+
+// ── Config tests ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn config_defaults_are_applied() {
+    let config = WebConfig {
+        timeout_secs: None,
+        max_redirects: None,
+        search_provider: None,
+        search_api_key: None,
+        search_url: None,
+    };
+    assert_eq!(config.timeout_or_default(), 30);
+    assert_eq!(config.max_redirects_or_default(), 10);
+}
+
+#[tokio::test]
+async fn config_custom_values_are_used() {
+    let config = WebConfig {
+        timeout_secs: Some(60),
+        max_redirects: Some(3),
+        search_provider: Some("searxng".to_string()),
+        search_api_key: Some("key123".to_string()),
+        search_url: Some("https://search.example.com".to_string()),
+    };
+    assert_eq!(config.timeout_or_default(), 60);
+    assert_eq!(config.max_redirects_or_default(), 3);
+}
+
+#[test]
+fn config_toml_with_web_section_parses() {
+    let toml_str = r#"
+[llm]
+default = "mock"
+
+[providers.mock]
+type = "mock"
+
+[web]
+timeout_secs = 15
+max_redirects = 3
+search_provider = "searxng"
+search_url = "http://localhost:9090"
+"#;
+    let config: forge::config::ForgeConfig = toml::from_str(toml_str).unwrap();
+    let web = config.web.unwrap();
+    assert_eq!(web.timeout_or_default(), 15);
+    assert_eq!(web.max_redirects_or_default(), 3);
+    assert_eq!(web.search_provider.unwrap(), "searxng");
+    assert_eq!(web.search_url.unwrap(), "http://localhost:9090");
+}
+
+#[test]
+fn config_toml_without_web_section_parses() {
+    let toml_str = r#"
+[llm]
+default = "mock"
+
+[providers.mock]
+type = "mock"
+"#;
+    let config: forge::config::ForgeConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.web.is_none());
+}
+
+// ── Executor integration (web.fetch via .forge program) ──────────
+
+use forge::llm::providers::mock::MockProvider;
+use forge::llm::registry::ProviderRegistry;
+use forge::runtime::executor::TaskExecutor;
+
+fn mock_registry(mock: MockProvider) -> Arc<ProviderRegistry> {
+    let mut reg = ProviderRegistry::new("mock");
+    reg.register("mock", Arc::new(mock));
+    Arc::new(reg)
+}
+
+#[tokio::test]
+async fn executor_web_fetch_returns_text() {
+    let app = Router::new().route("/data", get(|| async { "server response" }));
+    let base = start_mock_server(app).await;
+
+    let source = format!(
+        r#"
+#! boundary: server
+
+fn main
+  page = web.fetch("{}/data")
+  say page
+"#,
+        base
+    );
+    let program = forge::parser::parse(&source).unwrap();
+    let mock = MockProvider::new("mock").with_default("mock");
+    let config = forge::config::ForgeConfig::default_mock_config();
+    let executor = TaskExecutor::new(program, mock_registry(mock), None).with_config(config);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "executor should succeed: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    assert_eq!(outputs, vec!["server response"]);
+}
+
+#[tokio::test]
+async fn executor_web_post_returns_response() {
+    let app = Router::new().route(
+        "/submit",
+        post(|body: String| async move { format!("got: {}", body) }),
+    );
+    let base = start_mock_server(app).await;
+
+    let source = format!(
+        r#"
+#! boundary: server
+
+fn main
+  resp = web.post("{}/submit", "payload")
+  say resp
+"#,
+        base
+    );
+    let program = forge::parser::parse(&source).unwrap();
+    let mock = MockProvider::new("mock").with_default("mock");
+    let config = forge::config::ForgeConfig::default_mock_config();
+    let executor = TaskExecutor::new(program, mock_registry(mock), None).with_config(config);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "executor should succeed: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    assert_eq!(outputs, vec!["got: payload"]);
+}
+
+#[tokio::test]
+async fn executor_web_fetch_error_caught_by_try_or() {
+    let source = r#"
+#! boundary: server
+
+fn main
+  result = try web.fetch("http://127.0.0.1:1/bad") or "fallback"
+  say result
+"#;
+    let program = forge::parser::parse(source).unwrap();
+    let mock = MockProvider::new("mock").with_default("mock");
+    let config = forge::config::ForgeConfig::default_mock_config();
+    let executor = TaskExecutor::new(program, mock_registry(mock), None).with_config(config);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "try/or should catch error: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    assert_eq!(outputs, vec!["fallback"]);
+}
+
+#[tokio::test]
+async fn executor_search_returns_list_of_records() {
+    let app = Router::new().route(
+        "/search",
+        get(|| async {
+            axum::Json(serde_json::json!({
+                "results": [
+                    {"title": "Found it", "url": "https://found.com", "content": "A snippet"}
+                ]
+            }))
+        }),
+    );
+    let base = start_mock_server(app).await;
+
+    let source = r#"
+#! boundary: server
+
+fn main
+  results = search "test query"
+  first = results[0]
+  say first.title
+"#;
+    let program = forge::parser::parse(source).unwrap();
+    let mock = MockProvider::new("mock").with_default("mock");
+    let mut config = forge::config::ForgeConfig::default_mock_config();
+    config.web = Some(forge::config::WebConfig {
+        timeout_secs: None,
+        max_redirects: None,
+        search_provider: Some("searxng".to_string()),
+        search_api_key: None,
+        search_url: Some(base),
+    });
+    let executor = TaskExecutor::new(program, mock_registry(mock), None).with_config(config);
+    let result = executor.run().await;
+    assert!(result.is_ok(), "search should succeed: {:?}", result.err());
+    let outputs = executor.outputs();
+    assert_eq!(outputs, vec!["Found it"]);
+}


### PR DESCRIPTION
## Summary

- Add `web.fetch(url)` and `web.post(url, body)` built-in capabilities for outbound HTTP requests, returning response body as Text
- Replace `search` expression stub with real dispatch to configurable search provider (SearXNG), returning List of Records with title/url/snippet fields
- Add `[web]` config section with timeout_secs, max_redirects, search_provider, search_api_key, search_url (with env var expansion)
- Enforce boundary restriction: `web.fetch()`, `web.post()`, and `search` are server-only (boundary checker emits diagnostic in client/shared files)
- HTTP errors produce `RuntimeError::FlowError` catchable via `try ... or` pattern

## Key files
- `src/runtime/http_client.rs` — new module: ForgeHttpClient, fetch/post/search + SearXNG provider
- `src/runtime/executor.rs` — web namespace dispatch + Search expression implementation
- `src/checker/boundary_checker.rs` — server-only enforcement for web capabilities
- `src/config.rs` — WebConfig struct
- `src/resolver.rs` — web.fetch/web.post capability registration

## Test plan
- [x] 6 new boundary checker tests (web.fetch/web.post/search in client → error, in server → ok)
- [x] Existing acceptance test updated: search without provider correctly produces FlowError
- [x] 19 integration tests with mock HTTP servers: fetch, post, search, timeout, 4xx/5xx, try/or, config parsing, executor end-to-end
- [x] All 702 tests pass, cargo fmt clean, cargo clippy clean
- [x] CI green on Ubuntu, macOS, and Windows
- [x] Manual test: `web.fetch("https://httpbin.org/get")` returns page content
- [x] Manual test: `try web.fetch("https://invalid") or "fallback"` returns fallback
- [x] Manual test: end-to-end search with running SearXNG instance (59 results)
- [x] Manual test: `web.fetch` + Claude Sonnet reasoning over fetched content
- [x] Manual test: `web.post` + Claude Sonnet reasoning over POST response
- [x] Manual test: `try...or` fallback + Claude Sonnet reasoning over fallback value

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)