### PR TITLE
feat: webhook support, multi-file serve, and forge-sensei web UI (#52)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,10 @@ on:
   push:
     paths: [Cargo.lock]
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   audit:
     name: Audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Webhook support** — `POST /webhook/{endpoint}` routes dispatch inbound HTTP requests to endpoint handlers with JSON body parsing, Content-Type validation (must be `application/json`), and optional HMAC-SHA256 signature verification via `X-Hub-Signature-256` header (#52)
+- **`emit` in endpoint handlers** — `emit` statements now work outside agent context when an event bus is attached, enabling webhook endpoints to publish events that agents subscribe to (#52)
+- **`[server.webhook_secrets]` config** — per-endpoint HMAC secrets for webhook signature verification with constant-time comparison (#52)
+
 ### Changed
 - Rewrite forge-sensei as flagship FORGE application — fix 7 correctness bugs (recall dispatch, state transitions, degenerate confidence, dead events, timer no-op, fallback lie, specialist lifecycle), add 8 FORGE constructs (type records, flows, contract, match, requires, pipe, try/or, for loops), objective assessment via predict_outcome + check_prediction
 - Harden sensei scripts: build-sensei.sh (skip-if-unchanged, smoke test), pretrain-sensei.sh (error capture, jq, idempotency, --force/--dry-run), consult-sensei.sh (jq, content caching, thresholds), assess.sh (per-category scoring, trend tracking, --json)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -399,6 +400,8 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "hex",
+ "hmac",
  "notify",
  "pest",
  "pest_derive",
@@ -408,6 +411,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "tempfile",
  "thiserror",
  "tokio",
@@ -536,6 +540,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,17 +367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,11 +803,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -830,15 +819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -919,10 +899,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1000,12 +977,11 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "7.0.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.11.0",
- "filetime",
  "inotify",
  "kqueue",
  "libc",
@@ -1013,16 +989,16 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "notify-types"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "instant",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1070,7 +1046,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1129,12 +1105,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1310,15 +1280,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ dirs = "6"
 axum = "0.7"
 tower-http = { version = "0.6", features = ["cors", "fs"] }
 redb = "2"
-notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
+notify = { version = "8", default-features = false, features = ["macos_kqueue"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 pulldown-cmark = { version = "0.10", default-features = false, features = ["html"] }
 urlencoding = "2.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 sha2 = "0.10"
+hmac = "0.12"
+hex = "0.4"
+subtle = "2"
 toml = "0.8"
 dirs = "6"
 axum = "0.7"

--- a/roadmap.md
+++ b/roadmap.md
@@ -56,7 +56,7 @@ Everything in this document exists to reach that moment.
 | M3 — Core Runtime | Async executor, flows, pools, agents, events, timers, providers | Done | 2026-04-02 |
 | M4 — Build System | `forge build` standalone binaries, multi-file composition, agent REPL | Done | 2026-04-03 |
 | M5 — Ecosystem Core | Persistent memory, knowledge categories, instance registry, spawn/find/retire, system runtime, forge-sensei specialist spawning | Done | 2026-04-04 |
-| M6 — Web Runtime | HTML templates, static serving, hot-reload, HTTP client, webhooks | Open | — |
+| M6 — Web Runtime | HTML templates, static serving, hot-reload, HTTP client, markdown, webhooks | In Progress | — |
 | M7 — WASM Compilation | Cranelift backend for pure functions, browser WASM target | Open | — |
 | M8 — Wiki Showcase | First real FORGE application: wiki with search agent, fact-checking pool, warden supervision | Open | — |
 | M9 — Layer 1 Complete | All tracks done, conformance suite finalized, documentation complete | Open | — |
@@ -84,19 +84,19 @@ The substrate for agent birth, learning, specialization, discovery, communicatio
 | #87 | `system` declaration runtime — orchestration, event routing, warden integration | Done |
 | #88 | Specialist spawning — forge-sensei creates domain expert apprentices | Done |
 
-### Track B — Web & Capabilities: 4/13
+### Track B — Web & Capabilities: 6/9
 
 Web runtime, HTTP client, data persistence, and external integrations.
 
 | Issue | Feature | Status |
 |-------|---------|--------|
-| #44 | HTTP request/response types | Open |
-| #45 | HTML template rendering | Open |
-| #46 | Static file serving with Tailwind CSS | Open |
-| #47 | Hot-reload development mode | Open |
-| #51 | HTTP client: `web.fetch`, `web.post` | Open |
+| #44 | HTTP request/response types | Done |
+| #45 | HTML template rendering | Done |
+| #46 | Static file serving with Tailwind CSS | Done |
+| #47 | Hot-reload development mode | Done |
+| #49 | Markdown rendering | Done |
+| #51 | HTTP client: `web.fetch`, `web.post` | Done |
 | #52 | Webhook and callback support | Open |
-| #49 | Markdown rendering | Open |
 | #50 | Vector embeddings and semantic search | Open |
 | #40 | Host skill bridge and Slack adapter | Open |
 
@@ -129,11 +129,11 @@ Cranelift backend for compiling FORGE to WebAssembly.
 
 ```
 Track A ████████████████████ 9/9  (100%)  — Ecosystem Core
-Track B ████░░░░░░░░░░░░░░░░ 4/13 ( 31%)  — Web & Capabilities
+Track B █████████████░░░░░░░ 6/9  ( 67%)  — Web & Capabilities
 Track C ░░░░░░░░░░░░░░░░░░░░ 0/7  (  0%)  — Wiki Showcase
 Track D ░░░░░░░░░░░░░░░░░░░░ 0/4  (  0%)  — WASM Compilation
 ─────────────────────────────────────────
-Overall ████████████████░░░░ 56/72 ( 78%)
+Overall ████████████████████ 15/29 ( 52%)
 ```
 
 ---

--- a/src/build.rs
+++ b/src/build.rs
@@ -805,7 +805,14 @@ async fn main() -> anyhow::Result<()> {{
     let executor = forge::runtime::executor::TaskExecutor::new(
         program, Arc::new(registry), None,
     );
-    let server = forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref());
+    let event_bus = forge::runtime::event_bus::EventBus::new_shared(None);
+    let mut server = forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref())
+        .with_event_bus(event_bus);
+    if let Some(ref srv_config) = config.server {{
+        if let Some(ref secrets) = srv_config.webhook_secrets {{
+            server = server.with_webhook_secrets(secrets.clone());
+        }}
+    }}
     server.run().await
 }}
 "#,

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,9 @@ pub struct ServerConfig {
     pub cors_origins: Option<Vec<String>>,
     #[serde(rename = "static")]
     pub static_files: Option<StaticConfig>,
+    /// HMAC secrets for webhook signature verification, keyed by endpoint name.
+    /// Example: `webhook_secrets = { github_push = "my-secret" }`
+    pub webhook_secrets: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -217,6 +220,7 @@ impl ForgeConfig {
                 port: None,
                 cors_origins: None,
                 static_files: None,
+                webhook_secrets: None,
             });
             server.host = Some(host);
         }
@@ -227,6 +231,7 @@ impl ForgeConfig {
                     port: None,
                     cors_origins: None,
                     static_files: None,
+                    webhook_secrets: None,
                 });
                 server.port = Some(val);
             }
@@ -239,6 +244,7 @@ impl ForgeConfig {
                 port: None,
                 cors_origins: None,
                 static_files: None,
+                webhook_secrets: None,
             });
             let static_cfg = server.static_files.get_or_insert(StaticConfig {
                 root: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -765,8 +765,19 @@ async fn serve_program(
             Err(_) => std::process::exit(1),
         };
 
+        // Create event bus for webhook → agent event delivery
+        let event_bus = forge::runtime::event_bus::EventBus::new_shared(None);
+
         let mut server =
-            forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref());
+            forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref())
+                .with_event_bus(event_bus);
+
+        // Wire webhook secrets from config
+        if let Some(ref srv_config) = config.server {
+            if let Some(ref secrets) = srv_config.webhook_secrets {
+                server = server.with_webhook_secrets(secrets.clone());
+            }
+        }
 
         if let Some(host) = cli_host {
             server = server.with_host(host);
@@ -792,9 +803,20 @@ async fn serve_with_watch(
             Err(_) => std::process::exit(1),
         };
 
+        // Create event bus for webhook → agent event delivery
+        let event_bus = forge::runtime::event_bus::EventBus::new_shared(None);
+
         let mut server =
             forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref())
-                .with_watch_mode(true);
+                .with_watch_mode(true)
+                .with_event_bus(event_bus);
+
+        // Wire webhook secrets from config
+        if let Some(ref srv_config) = config.server {
+            if let Some(ref secrets) = srv_config.webhook_secrets {
+                server = server.with_webhook_secrets(secrets.clone());
+            }
+        }
 
         if let Some(ref host) = cli_host {
             server = server.with_host(host.clone());

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -275,6 +275,11 @@ impl TaskExecutor {
         &self.endpoint_map
     }
 
+    /// Get the event bus reference (for webhook wiring).
+    pub fn event_bus(&self) -> Option<&crate::runtime::event_bus::SharedEventBus> {
+        self.event_bus.as_ref()
+    }
+
     /// Check if an OutputType includes Html.
     fn returns_html_output(gives: &Option<Spanned<OutputType>>) -> bool {
         gives.as_ref().is_some_and(|ot| {
@@ -549,16 +554,18 @@ impl TaskExecutor {
 
                 // ── Agent features (issue #11) ─────────────────────────────
                 Stmt::Emit(name, args) => {
-                    if let Some(ref ctx_arc) = self.agent_context {
-                        let mut arg_vals = Vec::new();
-                        let mut fields = std::collections::HashMap::new();
-                        for arg in args {
-                            let val = self.eval_expr(&arg.node.value, env).await?;
-                            if let Some(ref label) = arg.node.label {
-                                fields.insert(label.node.clone(), val.clone());
-                            }
-                            arg_vals.push(val);
+                    let mut arg_vals = Vec::new();
+                    let mut fields = std::collections::HashMap::new();
+                    for arg in args {
+                        let val = self.eval_expr(&arg.node.value, env).await?;
+                        if let Some(ref label) = arg.node.label {
+                            fields.insert(label.node.clone(), val.clone());
                         }
+                        arg_vals.push(val);
+                    }
+
+                    if let Some(ref ctx_arc) = self.agent_context {
+                        // Inside agent: collect in sink for batch publish
                         ctx_arc
                             .lock()
                             .unwrap()
@@ -569,6 +576,22 @@ impl TaskExecutor {
                                 args: arg_vals,
                                 fields,
                             });
+                    } else if let Some(ref bus) = self.event_bus {
+                        // Outside agent (e.g. endpoint/webhook): publish directly
+                        let source = self
+                            .agent_name
+                            .clone()
+                            .unwrap_or_else(|| "endpoint".to_string());
+                        let payload = crate::runtime::event_bus::EventPayload {
+                            event_name: name.node.clone(),
+                            args: arg_vals,
+                            source_agent: source.clone(),
+                            fields,
+                        };
+                        let delivered = bus.read().await.publish(&payload);
+                        if let Some(ref t) = self.tracer {
+                            t.event_emit(&source, &name.node, delivered);
+                        }
                     } else {
                         return Err(RuntimeError::Unsupported("emit outside agent".into()));
                     }

--- a/src/runtime/http_server.rs
+++ b/src/runtime/http_server.rs
@@ -22,6 +22,7 @@ use tower_http::services::ServeDir;
 
 use crate::config::ServerConfig;
 use crate::runtime::confidence::{ConfidentValue, Value};
+use crate::runtime::event_bus::SharedEventBus;
 use crate::runtime::executor::{EndpointResult, TaskExecutor};
 
 // ── Swappable executor for hot-reload ───────────────────────────────────────
@@ -36,6 +37,10 @@ pub struct AppState {
     pub executor: SwappableExecutor,
     /// Broadcast channel for SSE reload notifications (only in watch mode).
     pub reload_tx: Option<broadcast::Sender<()>>,
+    /// Shared event bus for webhook → agent event delivery.
+    pub event_bus: Option<SharedEventBus>,
+    /// HMAC secrets keyed by webhook endpoint name.
+    pub webhook_secrets: HashMap<String, String>,
 }
 
 impl AppState {
@@ -54,6 +59,7 @@ pub struct ForgeServer {
     static_root: Option<String>,
     static_prefix: Option<String>,
     watch_mode: bool,
+    webhook_secrets: HashMap<String, String>,
 }
 
 impl ForgeServer {
@@ -77,6 +83,8 @@ impl ForgeServer {
             state: AppState {
                 executor: Arc::new(RwLock::new(executor)),
                 reload_tx: None,
+                event_bus: None,
+                webhook_secrets: HashMap::new(),
             },
             host,
             port,
@@ -84,6 +92,7 @@ impl ForgeServer {
             static_root,
             static_prefix,
             watch_mode: false,
+            webhook_secrets: HashMap::new(),
         }
     }
 
@@ -109,6 +118,27 @@ impl ForgeServer {
         self
     }
 
+    /// Attach an event bus for webhook → agent event delivery.
+    pub fn with_event_bus(mut self, bus: SharedEventBus) -> Self {
+        // Wire the event bus into the executor so `emit` works in endpoint handlers.
+        // We clone the executor, attach the bus, and replace it.
+        {
+            let mut guard = self.state.executor.write().unwrap();
+            let executor = guard.clone().with_event_bus(bus.clone());
+            *guard = executor;
+        }
+        self.state.event_bus = Some(bus);
+        self
+    }
+
+    /// Set HMAC secrets for webhook signature verification.
+    /// Keys are endpoint names, values are secret strings.
+    pub fn with_webhook_secrets(mut self, secrets: HashMap<String, String>) -> Self {
+        self.state.webhook_secrets = secrets.clone();
+        self.webhook_secrets = secrets;
+        self
+    }
+
     /// Get a handle to the swappable executor for the file watcher.
     pub fn swappable_executor(&self) -> SwappableExecutor {
         self.state.executor.clone()
@@ -123,7 +153,10 @@ impl ForgeServer {
     fn build_router(&self) -> Router<()> {
         // Dynamic catch-all routing: endpoint lookup happens at request time,
         // so new/removed endpoints are visible immediately after hot-reload.
-        let mut router = Router::new().route("/:endpoint", get(handle_get).post(handle_post));
+        // Webhook route: POST /webhook/:name with Content-Type validation and optional HMAC
+        let mut router = Router::new()
+            .route("/webhook/:endpoint", axum::routing::post(handle_webhook))
+            .route("/:endpoint", get(handle_get).post(handle_post));
 
         // SSE reload endpoint (watch mode only)
         if self.watch_mode {
@@ -222,6 +255,7 @@ pub fn print_endpoint_list(endpoints: &HashMap<String, crate::ast::EndpointDecl>
             .unwrap_or_default();
         println!("  GET  /{name}?{}{ret}", params.join("&"));
         println!("  POST /{name}{ret}");
+        println!("  POST /webhook/{name}{ret}");
     }
 }
 
@@ -305,6 +339,124 @@ async fn handle_sse_reload(
     });
 
     Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+/// Webhook handler: POST /webhook/:name
+/// Validates Content-Type is application/json, optionally verifies HMAC signature,
+/// then dispatches to the endpoint handler with full request context.
+async fn handle_webhook(
+    State(state): State<AppState>,
+    Path(endpoint_name): Path<String>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    // Content-Type must be application/json
+    let content_type = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !content_type.starts_with("application/json") {
+        return (
+            StatusCode::BAD_REQUEST,
+            "Content-Type must be application/json",
+        )
+            .into_response();
+    }
+
+    // Optional HMAC signature verification
+    if let Some(secret) = state.webhook_secrets.get(&endpoint_name) {
+        let signature = headers
+            .get("x-hub-signature-256")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if !verify_hmac_signature(secret, &body, signature) {
+            return (StatusCode::UNAUTHORIZED, "invalid signature").into_response();
+        }
+    }
+
+    // Parse JSON body
+    let body_str = match String::from_utf8(body.to_vec()) {
+        Ok(s) => s,
+        Err(_) => {
+            return (StatusCode::BAD_REQUEST, "invalid UTF-8 body").into_response();
+        }
+    };
+    let json_value: serde_json::Value = match serde_json::from_str(&body_str) {
+        Ok(v) => v,
+        Err(_) => {
+            return (StatusCode::BAD_REQUEST, "invalid JSON body").into_response();
+        }
+    };
+
+    // Clone executor with event bus attached
+    let executor = {
+        let ex = state.executor.read().unwrap().clone();
+        if let Some(ref bus) = state.event_bus {
+            if ex.event_bus().is_none() {
+                ex.with_event_bus(bus.clone())
+            } else {
+                ex
+            }
+        } else {
+            ex
+        }
+    };
+
+    if !executor.endpoints().contains_key(&endpoint_name) {
+        return (StatusCode::NOT_FOUND, "webhook endpoint not found").into_response();
+    }
+
+    let params: HashMap<String, String> = match json_value.as_object() {
+        Some(map) => map
+            .iter()
+            .map(|(k, v)| {
+                let s = match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                (k.clone(), s)
+            })
+            .collect(),
+        None => HashMap::new(),
+    };
+
+    let request = build_request_record("POST", &endpoint_name, &params, &headers, &body_str);
+    let args = params_to_args(params);
+    dispatch_endpoint(
+        executor,
+        &endpoint_name,
+        args,
+        request,
+        state.is_watch_mode(),
+    )
+    .await
+}
+
+/// Verify GitHub-style HMAC-SHA256 signature.
+/// Signature format: "sha256=<hex_digest>"
+fn verify_hmac_signature(secret: &str, body: &[u8], signature: &str) -> bool {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let expected_hex = match signature.strip_prefix("sha256=") {
+        Some(hex) => hex,
+        None => return false,
+    };
+
+    let mut mac = match Hmac::<Sha256>::new_from_slice(secret.as_bytes()) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    mac.update(body);
+    let result = mac.finalize().into_bytes();
+    let computed_hex = hex::encode(result);
+
+    // Constant-time comparison to prevent timing attacks
+    use subtle::ConstantTimeEq;
+    computed_hex
+        .as_bytes()
+        .ct_eq(expected_hex.as_bytes())
+        .into()
 }
 
 fn params_to_args(params: HashMap<String, String>) -> HashMap<String, ConfidentValue> {

--- a/tests/http_server_tests.rs
+++ b/tests/http_server_tests.rs
@@ -173,6 +173,7 @@ async fn server_config_defaults() {
         port: None,
         cors_origins: None,
         static_files: None,
+        webhook_secrets: None,
     };
     assert_eq!(config.host_or_default(), "127.0.0.1");
     assert_eq!(config.port_or_default(), 3000);
@@ -185,6 +186,7 @@ async fn server_config_custom() {
         port: Some(8080),
         cors_origins: Some(vec!["http://localhost:3000".to_string()]),
         static_files: None,
+        webhook_secrets: None,
     };
     assert_eq!(config.host_or_default(), "0.0.0.0");
     assert_eq!(config.port_or_default(), 8080);
@@ -562,6 +564,7 @@ async fn static_file_served_with_correct_mime() {
         host: None,
         port: None,
         cors_origins: None,
+        webhook_secrets: None,
         static_files: Some(StaticConfig {
             root: Some(tmp.path().to_str().unwrap().to_string()),
             prefix: Some("/static".to_string()),
@@ -596,6 +599,7 @@ async fn static_file_404_for_missing() {
         host: None,
         port: None,
         cors_origins: None,
+        webhook_secrets: None,
         static_files: Some(StaticConfig {
             root: Some(tmp.path().to_str().unwrap().to_string()),
             prefix: Some("/static".to_string()),
@@ -623,6 +627,7 @@ async fn static_does_not_shadow_dynamic_routes() {
         host: None,
         port: None,
         cors_origins: None,
+        webhook_secrets: None,
         static_files: Some(StaticConfig {
             root: Some(tmp.path().to_str().unwrap().to_string()),
             prefix: Some("/static".to_string()),
@@ -655,6 +660,7 @@ endpoint link() -> Html
         host: None,
         port: None,
         cors_origins: None,
+        webhook_secrets: None,
         static_files: Some(StaticConfig {
             root: Some("static".to_string()),
             prefix: Some("/static".to_string()),
@@ -685,6 +691,7 @@ endpoint img_url()
         host: None,
         port: None,
         cors_origins: None,
+        webhook_secrets: None,
         static_files: Some(StaticConfig {
             root: Some("public".to_string()),
             prefix: Some("/assets".to_string()),
@@ -698,4 +705,271 @@ endpoint img_url()
     assert_eq!(resp.status(), 200);
     let body = resp.text().await.unwrap();
     assert_eq!(body, "/assets/img/logo.png");
+}
+
+// ── Issue #52: Webhook support ────────────────────────────────────
+
+const WEBHOOK_SERVER: &str = r#"#! boundary: server
+
+endpoint hook(payload: Text) -> Text
+  give "received: {payload}"
+"#;
+
+/// Spawn a server with event bus attached for webhook tests.
+async fn spawn_webhook_server(source: &str) -> String {
+    let program = forge::parser::parse(source).expect("parse failed");
+    let executor = TaskExecutor::new(program, mock_registry(), None);
+    let event_bus = forge::runtime::event_bus::EventBus::new_shared(None);
+    let server = ForgeServer::new(executor, None).with_event_bus(event_bus);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind failed");
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(async move {
+        server
+            .run_on_listener(listener)
+            .await
+            .expect("server failed");
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    format!("http://127.0.0.1:{port}")
+}
+
+/// Spawn a server with HMAC secrets for signature verification tests.
+async fn spawn_webhook_server_with_secrets(
+    source: &str,
+    secrets: std::collections::HashMap<String, String>,
+) -> String {
+    let program = forge::parser::parse(source).expect("parse failed");
+    let executor = TaskExecutor::new(program, mock_registry(), None);
+    let event_bus = forge::runtime::event_bus::EventBus::new_shared(None);
+    let server = ForgeServer::new(executor, None)
+        .with_event_bus(event_bus)
+        .with_webhook_secrets(secrets);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind failed");
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(async move {
+        server
+            .run_on_listener(listener)
+            .await
+            .expect("server failed");
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::test]
+async fn webhook_post_dispatches_to_endpoint() {
+    let base = spawn_webhook_server(WEBHOOK_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/hook"))
+        .header("content-type", "application/json")
+        .body(r#"{"payload": "hello"}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "received: hello");
+}
+
+#[tokio::test]
+async fn webhook_json_body_parsed_as_text_param() {
+    let base = spawn_webhook_server(WEBHOOK_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/hook"))
+        .header("content-type", "application/json")
+        .body(r#"{"payload": "test data"}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("test data"));
+}
+
+#[tokio::test]
+async fn webhook_invalid_json_returns_400() {
+    let base = spawn_webhook_server(WEBHOOK_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/hook"))
+        .header("content-type", "application/json")
+        .body("not json at all {{{")
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn webhook_wrong_content_type_returns_400() {
+    let base = spawn_webhook_server(WEBHOOK_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/hook"))
+        .header("content-type", "text/plain")
+        .body(r#"{"payload": "hello"}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 400);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("application/json"));
+}
+
+#[tokio::test]
+async fn webhook_nonexistent_endpoint_returns_404() {
+    let base = spawn_webhook_server(WEBHOOK_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/nonexistent"))
+        .header("content-type", "application/json")
+        .body(r#"{}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn webhook_hmac_valid_signature_accepted() {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let secret = "test-secret-123";
+    let mut secrets = std::collections::HashMap::new();
+    secrets.insert("hook".to_string(), secret.to_string());
+
+    let base = spawn_webhook_server_with_secrets(WEBHOOK_SERVER, secrets).await;
+
+    let body = r#"{"payload": "signed"}"#;
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(body.as_bytes());
+    let signature = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/hook"))
+        .header("content-type", "application/json")
+        .header("x-hub-signature-256", &signature)
+        .body(body)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("signed"));
+}
+
+#[tokio::test]
+async fn webhook_hmac_invalid_signature_rejected() {
+    let mut secrets = std::collections::HashMap::new();
+    secrets.insert("hook".to_string(), "real-secret".to_string());
+
+    let base = spawn_webhook_server_with_secrets(WEBHOOK_SERVER, secrets).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/hook"))
+        .header("content-type", "application/json")
+        .header("x-hub-signature-256", "sha256=deadbeef")
+        .body(r#"{"payload": "hacked"}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn webhook_hmac_missing_signature_rejected() {
+    let mut secrets = std::collections::HashMap::new();
+    secrets.insert("hook".to_string(), "my-secret".to_string());
+
+    let base = spawn_webhook_server_with_secrets(WEBHOOK_SERVER, secrets).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/hook"))
+        .header("content-type", "application/json")
+        .body(r#"{"payload": "unsigned"}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 401);
+}
+
+const WEBHOOK_EMIT_SERVER: &str = r#"#! boundary: server
+
+event WebhookReceived
+  data: Text
+
+endpoint github_push(payload: Text) -> Text
+  emit WebhookReceived(data: payload)
+  give "ok"
+"#;
+
+#[tokio::test]
+async fn webhook_endpoint_can_emit_events() {
+    let base = spawn_webhook_server(WEBHOOK_EMIT_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/github_push"))
+        .header("content-type", "application/json")
+        .body(r#"{"payload": "push event data"}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "ok");
+}
+
+const WEBHOOK_REQUEST_CONTEXT_SERVER: &str = r#"#! boundary: server
+
+endpoint inspect() -> Text
+  method = request.method
+  body = request.body
+  give "{method}: {body}"
+"#;
+
+#[tokio::test]
+async fn webhook_request_context_available() {
+    let base = spawn_webhook_server(WEBHOOK_REQUEST_CONTEXT_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/inspect"))
+        .header("content-type", "application/json")
+        .body(r#"{"key": "value"}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.starts_with("POST:"));
+    assert!(body.contains("key"));
+}
+
+#[tokio::test]
+async fn webhook_no_secret_configured_skips_verification() {
+    // When no secret is configured for this endpoint, requests without signatures should work
+    let base = spawn_webhook_server(WEBHOOK_SERVER).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/webhook/hook"))
+        .header("content-type", "application/json")
+        .body(r#"{"payload": "no secret needed"}"#)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
 }


### PR DESCRIPTION
## Summary
- **Webhook support (#52)** — `POST /webhook/{endpoint}` routes with JSON Content-Type validation, optional HMAC-SHA256 signature verification (`X-Hub-Signature-256`), and event bus integration so endpoints can `emit` events to agents
- **`recall` outside agent context** — `recall` now works in endpoint handlers (returns empty with zero confidence when no knowledge store is attached, graceful degradation)
- **Multi-file `forge serve`** — `forge serve entry.forge -s dep.forge` merges source files before serving, enabling multi-file projects with cross-file function calls
- **forge-sensei web UI** — multi-file project (`workflows/forge-sensei/`) with 7 endpoints: status dashboard, ask form, ask (LLM), review form, review (LLM), webhook ingest, webhook learn
- **CI fixes** — upgrade `notify` 7→8 (removes unmaintained `instant` advisory), add `checks: write` permission to audit workflow
- **Roadmap sync** — Track B updated from 4/13 to 6/9

## Commits
1. `feat: webhook support with inbound HTTP triggers for agents (#52)`
2. `fix: upgrade notify 7→8 to resolve unmaintained instant advisory, fix audit CI permissions`
3. `feat: forge-sensei multi-file project with web endpoints`
4. `feat: multi-file serve support and forge-sensei static assets`
5. `test: integration tests for multi-file serve and forge-sensei web UI`
6. `feat: standalone knowledge store for endpoints, recall outside agent`

## Test Coverage

**Automated (cargo test): 730+ tests, 0 failures**
- 12 webhook tests (dispatch, JSON parsing, Content-Type, 404, HMAC valid/invalid/missing, emit, request context)
- 7 multi-file serve tests (cross-file pure fn calls, events, HTML rendering, webhooks)
- 10 forge-sensei web tests (status page, nav links, forms, ask/review dispatch, webhook ingest/learn, endpoint registration, 404)

**E2E with real Anthropic API: 10/10 pass**
- GET /status, /ask_form, /review_form → 200 with correct HTML
- POST /ask, /review → 200 with LLM-generated answers
- POST /webhook/webhook_ingest, /webhook/webhook_learn → 200
- Error cases: 404 (unknown), 400 (bad Content-Type)

## Acceptance Criteria (#52)
- [x] `POST /webhook/endpoint_name` dispatches to the endpoint handler
- [x] JSON body is parsed and available as Text parameter
- [x] Agent state (memory, lifecycle) maintained across webhook calls
- [x] Webhook endpoint can emit events that agents subscribe to
- [x] Invalid JSON body returns 400 with clear error
- [x] Non-existent webhook endpoint returns 404

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)