### PR TITLE
feat: wiki content agent with full CRUD and lifecycle states (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Wiki content agent** — full CRUD operations with lifecycle states, persistent memory, requires guards, event emission, and KV persistence for the wiki content manager (#60)
 - **FORGE Wiki project** — dogfooding showcase web application in `examples/wiki/` demonstrating all 14 language primitives with Tailwind CSS + DaisyUI UI, content seeding, stub agents/flows/pools, warden supervision, and system wiring (#59)
 - **`data.get(key)` capability** — retrieve values from persistent KV storage, returns `Unit` for missing keys (#59)
 - **`data.list(prefix)` capability** — list all keys matching a prefix from persistent KV storage, returns `Array` (#59)

--- a/examples/wiki/server.forge
+++ b/examples/wiki/server.forge
@@ -153,32 +153,80 @@ task answer_question
     when answer.unsure -> give answer
     else -> give "I could not generate a confident answer for this question."
 
-# ── Stub Agents ──────────────────────────────────────────────────
+# ── Content Agent ────────────────────────────────────────────────
 #
-# Minimal agent declarations to demonstrate the primitive.
-# Full implementations in issues #60 and #61.
+# Full CRUD content manager with lifecycle states (issue #60).
+# Manages page lifecycle through typed state machine transitions,
+# with persistent memory, requires guards, and event emission.
 
 agent content_manager
   lifecycle: PageLifecycle
-  memory
-    page_count: Number
-    last_updated: Text
-  subscribe PageCreated
-  subscribe PageUpdated
+  memory persistent
+    pages: Text[]
+    edit_history: Text[]
+    total_edits: Number
 
   on start
     say "ContentAgent ready."
-    memory.page_count = 0
 
-  on page_update(slug: Text)
-    requires slug != "" on fail: give "slug required"
-    memory.page_count = memory.page_count + 1
-    memory.last_updated = slug
+  on create_page(slug: Text, title: Text, content: Text)
+    requires slug.length > 0 on fail: give "slug required"
+    requires title.length > 0 on fail: give "title required"
+    page_data = "{title}\n---\n{content}"
+    data.store("page:{slug}", page_data)
+    memory.pages = memory.pages + [slug]
+    memory.total_edits = memory.total_edits + 1
+    emit PageCreated(slug: slug, title: title)
+    give "Created: {slug}"
+
+  on update_page(slug: Text, content: Text)
+    requires slug.length > 0 on fail: give "slug required"
+    existing = data.get("page:{slug}")
+    if existing == ""
+      give "page not found: {slug}"
+    data.store("page:{slug}", content)
+    memory.edit_history = memory.edit_history + [slug]
+    memory.total_edits = memory.total_edits + 1
     emit PageUpdated(slug: slug)
-    say "Updated: {slug}"
+    give "Updated: {slug}"
 
-  on PageCreated
-    memory.page_count = memory.page_count + 1
+  on submit_for_review(slug: Text)
+    requires lifecycle == draft on fail: give "page must be in draft to submit for review"
+    existing = data.get("page:{slug}")
+    if existing == ""
+      give "page not found: {slug}"
+    transition to review
+    give "Submitted for review: {slug}"
+
+  on publish_page(slug: Text)
+    requires lifecycle == review on fail: give "page must be in review to publish"
+    existing = data.get("page:{slug}")
+    if existing == ""
+      give "page not found: {slug}"
+    transition to published
+    emit PagePublished(slug: slug)
+    give "Published: {slug}"
+
+  on reject_page(slug: Text)
+    requires lifecycle == review on fail: give "page must be in review to reject"
+    transition to draft
+    give "Rejected, back to draft: {slug}"
+
+  on archive_page(slug: Text)
+    requires lifecycle == published on fail: give "page must be published to archive"
+    transition to archived
+    give "Archived: {slug}"
+
+  on restore_page(slug: Text)
+    requires lifecycle == archived on fail: give "page must be archived to restore"
+    transition to draft
+    give "Restored to draft: {slug}"
+
+  on list_pages
+    give memory.pages
+
+  on stats
+    give "Total pages: {memory.pages.length}, Total edits: {memory.total_edits}"
 
 agent search_agent
   memory

--- a/examples/wiki/shared.forge
+++ b/examples/wiki/shared.forge
@@ -29,8 +29,8 @@ event PagePublished
 # ── Lifecycle ────────────────────────────────────────────────────
 
 states PageLifecycle
-  draft -> review
-  review -> published
-  review -> draft
-  published -> archived
-  archived -> draft
+  draft -> review when content_complete
+  review -> published when approved
+  review -> draft when needs_revision
+  published -> archived when archive_requested
+  archived -> draft when restore_requested


### PR DESCRIPTION
## Summary

- Replace stub `content_manager` agent with full CRUD implementation featuring 9 handlers: `create_page`, `update_page`, `submit_for_review`, `publish_page`, `reject_page`, `archive_page`, `restore_page`, `list_pages`, `stats`
- Add `memory persistent` with `pages`, `edit_history`, and `total_edits` fields that survive restart
- Add lifecycle state guards (`requires lifecycle == X`) on all transition handlers, validated at compile time by the states checker
- Add `when` guard labels to PageLifecycle transitions in `shared.forge` for documentation clarity

## Primitives Showcased

| Primitive | Usage |
|---|---|
| `states` | PageLifecycle with `when` guard labels |
| `agent` | content_manager — long-running stateful process |
| `memory persistent` | Pages list, edit history survive restart |
| `requires` | Guards against empty slugs, wrong lifecycle state |
| `emit` | PageCreated, PageUpdated, PagePublished events |
| `transition` | Explicit lifecycle state changes with compile-time validation |
| `data.store` / `data.get` | KV persistence for page content |

## Parser Learnings

- `requires` clauses must appear at handler top (before statements) — grammar constraint
- Handler return types use `:` syntax, not `->` (which is for task/pure/endpoint)
- `data.get` returns `Unit` for missing keys (deterministic), not uncertain — use `if existing == ""` for presence checks

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] `cargo test` — all 30 tests pass
- [x] `cargo run -- check --merge examples/wiki/shared.forge examples/wiki/server.forge` — OK

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)