### PR TITLE
feat: wiki doc generation flow with parallel extraction (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Wiki doc generation flow** — `generate_docs` flow with 5-stage DAG (scan, parallel extraction of tasks/agents/flows, reference generation, publish), `data.store` + `emit PageUpdated`, triggered via `/admin_generate_docs` endpoint with HTML result page (#62)
 - **Wiki search agent** — LLM-powered search and Q&A with confidence gating (`when .sure/.unsure/else`), persistent memory tracking index version and query count, event-driven re-indexing via `subscribe`, and confidence badge on answers (#61)
 - **Wiki content agent** — full CRUD operations with lifecycle states, persistent memory, requires guards, event emission, and KV persistence for the wiki content manager (#60)
 - **FORGE Wiki project** — dogfooding showcase web application in `examples/wiki/` demonstrating all 14 language primitives with Tailwind CSS + DaisyUI UI, content seeding, stub agents/flows/pools, warden supervision, and system wiring (#59)

--- a/examples/wiki/server.forge
+++ b/examples/wiki/server.forge
@@ -50,7 +50,7 @@ pure docs_sidebar
   needs active_slug: Text
   gives Html
   do
-    give "<aside class=\"w-64 shrink-0 hidden lg:block\"><ul class=\"menu bg-base-200 rounded-box w-full\"><li class=\"menu-title\">Getting Started</li><li><a href=\"/docs?slug=getting-started\" class=\"{!active_slug}\">Quick Start</a></li><li><a href=\"/docs?slug=principles\">First Principles</a></li><li class=\"menu-title\">Reference</li><li><a href=\"/docs?slug=task\">task</a></li><li><a href=\"/docs?slug=agent\">agent</a></li><li><a href=\"/docs?slug=flow\">flow</a></li><li><a href=\"/docs?slug=pool\">pool</a></li><li><a href=\"/docs?slug=system\">system</a></li><li><a href=\"/docs?slug=event\">event</a></li><li><a href=\"/docs?slug=states\">states</a></li><li><a href=\"/docs?slug=when\">when</a></li><li><a href=\"/docs?slug=pure\">pure</a></li><li><a href=\"/docs?slug=boundary\">boundary</a></li><li><a href=\"/docs?slug=requires\">requires</a></li><li><a href=\"/docs?slug=warden\">warden</a></li><li class=\"menu-title\">About</li><li><a href=\"/docs?slug=roadmap\">Roadmap</a></li></ul></aside>"
+    give "<aside class=\"w-64 shrink-0 hidden lg:block\"><ul class=\"menu bg-base-200 rounded-box w-full\"><li class=\"menu-title\">Getting Started</li><li><a href=\"/docs?slug=getting-started\" class=\"{!active_slug}\">Quick Start</a></li><li><a href=\"/docs?slug=principles\">First Principles</a></li><li class=\"menu-title\">Reference</li><li><a href=\"/docs?slug=task\">task</a></li><li><a href=\"/docs?slug=agent\">agent</a></li><li><a href=\"/docs?slug=flow\">flow</a></li><li><a href=\"/docs?slug=pool\">pool</a></li><li><a href=\"/docs?slug=system\">system</a></li><li><a href=\"/docs?slug=event\">event</a></li><li><a href=\"/docs?slug=states\">states</a></li><li><a href=\"/docs?slug=when\">when</a></li><li><a href=\"/docs?slug=pure\">pure</a></li><li><a href=\"/docs?slug=boundary\">boundary</a></li><li><a href=\"/docs?slug=requires\">requires</a></li><li><a href=\"/docs?slug=warden\">warden</a></li><li class=\"menu-title\">Generated</li><li><a href=\"/docs?slug=auto-reference\">Auto Reference</a></li><li class=\"menu-title\">About</li><li><a href=\"/docs?slug=roadmap\">Roadmap</a></li></ul></aside>"
 
 pure hero_section
   gives Html
@@ -273,24 +273,59 @@ agent search_agent
   on stats
     give "Index v{memory.index_version}, {memory.query_count} queries processed"
 
-# ── Stub Flow ────────────────────────────────────────────────────
+# ── Doc Generation Flow ─────────────────────────────────────────
 #
-# Demonstrates: flow with stages. Full implementation in issue #62.
+# Auto-generates reference docs from FORGE source files (issue #62).
+# DAG: scan_files -> [extract_tasks | extract_agents | extract_flows] -> generate_reference -> publish
+#
+# Parallelism:
+#   Wave 0: scan_files
+#   Wave 1: extract_tasks, extract_agents, extract_flows  (parallel)
+#   Wave 2: generate_reference
+#   Wave 3: publish
 
-flow doc_gen_flow
-  needs source: Text
+flow generate_docs
+  needs sources: Text[]
   gives Text
 
-  stage scan
-    summary = reason "Summarize the key concepts in this FORGE source code:\n{source}"
+  stage scan_files
+    file_contents = sources
+    say "Scanning {sources.length} source files..."
+    give file_contents
 
-  stage generate
-    needs scan.summary
-    doc = reason "Generate reference documentation from this summary: {scan.summary}"
+  stage extract_tasks
+    needs scan_files.*
+    signatures = reason "Extract all task declarations from this FORGE source code.\nFor each task, provide: name, parameters, return type, and a one-line description.\nSource: {scan_files}"
+    when signatures.sure -> give signatures
+    when signatures.unsure -> give signatures
+    else -> give "No task declarations found."
 
-  stage format
-    needs generate.doc
-    give generate.doc
+  stage extract_agents
+    needs scan_files.*
+    signatures = reason "Extract all agent declarations from this FORGE source code.\nFor each agent: name, states, memory fields, handlers, and a one-line description.\nSource: {scan_files}"
+    when signatures.sure -> give signatures
+    when signatures.unsure -> give signatures
+    else -> give "No agent declarations found."
+
+  stage extract_flows
+    needs scan_files.*
+    signatures = reason "Extract all flow declarations from this FORGE source code.\nFor each flow: name, stages, dependencies, and a one-line description.\nSource: {scan_files}"
+    when signatures.sure -> give signatures
+    when signatures.unsure -> give signatures
+    else -> give "No flow declarations found."
+
+  stage generate_reference
+    needs extract_tasks.*, extract_agents.*, extract_flows.*
+    reference = reason "Generate a comprehensive reference document in Markdown format.\nOrganize by category: Tasks, Agents, Flows.\nInclude code examples for each item.\n\nTasks: {extract_tasks}\nAgents: {extract_agents}\nFlows: {extract_flows}"
+    when reference.sure -> give reference
+    when reference.unsure -> give reference
+    else -> give "Could not generate reference documentation."
+
+  stage publish
+    needs generate_reference.*
+    data.store("page:auto-reference", generate_reference)
+    emit PageUpdated(slug: "auto-reference")
+    give "Reference documentation generated and published"
 
 # ── Stub Pool ────────────────────────────────────────────────────
 #
@@ -373,6 +408,13 @@ endpoint ask(question: Text) -> Html
 endpoint api_search(q: Text) -> Text
   results = search_docs(q)
   give results
+
+endpoint admin_generate_docs() -> Html
+  nav = nav_bar("")
+  sources = data.list("page:")
+  result = generate_docs(sources)
+  body = "<div class=\"container mx-auto px-4 py-8\"><h1 class=\"text-3xl font-bold mb-6\">Doc Generation</h1><div class=\"alert alert-success\"><span>{result}</span></div><a href=\"/docs?slug=auto-reference\" class=\"btn btn-primary mt-4\">View Generated Reference</a></div>"
+  give page_layout("Admin — Generate Docs", nav, body)
 
 # -- Entry Point --
 

--- a/examples/wiki/server.forge
+++ b/examples/wiki/server.forge
@@ -290,7 +290,7 @@ flow generate_docs
 
   stage scan_files
     file_contents = sources
-    say "Scanning {sources.length} source files..."
+    say "Scanning {sources.len()} source files..."
     give file_contents
 
   stage extract_tasks

--- a/tests/e2e/pages/admin.page.ts
+++ b/tests/e2e/pages/admin.page.ts
@@ -1,0 +1,28 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class AdminPage extends BasePage {
+  readonly heading: Locator;
+  readonly successAlert: Locator;
+  readonly viewReferenceLink: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.heading = page.locator('h1');
+    this.successAlert = page.locator('.alert-success');
+    this.viewReferenceLink = page.getByRole('link', { name: 'View Generated Reference' });
+  }
+
+  async goto() {
+    await this.page.goto('/admin_generate_docs');
+  }
+
+  async expectLoaded() {
+    await expect(this.heading).toContainText('Doc Generation');
+  }
+
+  async expectSuccess() {
+    await expect(this.successAlert).toBeVisible();
+    await expect(this.successAlert).toContainText('generated');
+  }
+}

--- a/tests/e2e/specs/admin.spec.ts
+++ b/tests/e2e/specs/admin.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { AdminPage } from '../pages/admin.page';
+import { DocsPage } from '../pages/docs.page';
+
+test.describe('Doc Generation (issue #62)', () => {
+  test('admin endpoint triggers flow and shows success', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+    await admin.expectLoaded();
+    await admin.expectSuccess();
+  });
+
+  test('generated reference is viewable via docs endpoint', async ({ page }) => {
+    // Trigger generation first
+    const admin = new AdminPage(page);
+    await admin.goto();
+    await admin.expectSuccess();
+
+    // Follow link to view generated docs
+    await admin.viewReferenceLink.click();
+    await expect(page).toHaveURL(/slug=auto-reference/);
+
+    const docs = new DocsPage(page);
+    await docs.expectLoaded();
+    const text = await docs.article.textContent();
+    expect(text!.length).toBeGreaterThan(10);
+  });
+
+  test('view reference link navigates correctly', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+    await admin.viewReferenceLink.click();
+    await expect(page).toHaveURL(/slug=auto-reference/);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace stub `doc_gen_flow` with full `generate_docs` flow featuring 5-stage DAG with automatic parallel execution
- Three extraction stages (tasks, agents, flows) run in parallel after scan, then feed into reference generation and publish
- Add `/admin_generate_docs` endpoint with HTML result page and link to generated reference
- Add "Auto Reference" link in docs sidebar under new "Generated" section
- E2E tests: admin page object + 3 specs covering flow trigger, result viewing, and navigation

## Parallelism DAG
```
scan_files
    |
    ├── extract_tasks ──────┐
    ├── extract_agents ─────┤  (Wave 1 — parallel)
    └── extract_flows ──────┘
                            |
                    generate_reference  (Wave 2)
                            |
                        publish         (Wave 3)
```

## Primitives Showcased
| Primitive | Usage |
|---|---|
| `flow` | Multi-stage pipeline |
| `stage` | Named computation stages |
| `needs` | Dependency declarations enabling auto-parallelism |
| `reason` | LLM-powered extraction and generation |
| `when` | Confidence gating on all oracle results |
| `data.store` | Publish generated docs to KV store |
| `emit` | Trigger search re-indexing via PageUpdated |

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 722 tests pass
- [x] `cargo fmt` + `cargo clippy` clean
- [x] `forge check` — only pre-existing PageLifecycle error (cross-file resolution, from #60)
- [x] `forge trace` — parallel timing verified (3 extraction stages start at same timestamp)
- [x] Playwright E2E — 3/3 specs pass (admin trigger, reference viewing, link navigation)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)