### PR TITLE
feat: wiki fact-checking pool with majority vote (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Wiki fact-checking pool** — `verify_document` task extracts claims via LLM and verifies each through `fact_check_panel` (3 workers, majority strategy, 30s timeout, fallback on timeout); claims classified as PASS/NEEDS_REVIEW/FAIL based on consensus confidence; integrated as `fact_check` stage in `generate_docs` flow with dedicated admin endpoint (#63)
+- **`.split(delimiter)` string method** — splits Text into Array of Text values for per-element iteration with `for` loops (#63)
+- **`.join(delimiter)` array method** — joins Array/List elements into Text with delimiter (#63)
 - **Wiki doc generation flow** — `generate_docs` flow with 5-stage DAG (scan, parallel extraction of tasks/agents/flows, reference generation, publish), `data.store` + `emit PageUpdated`, triggered via `/admin_generate_docs` endpoint with HTML result page (#62)
 - **Wiki search agent** — LLM-powered search and Q&A with confidence gating (`when .sure/.unsure/else`), persistent memory tracking index version and query count, event-driven re-indexing via `subscribe`, and confidence badge on answers (#61)
 - **Wiki content agent** — full CRUD operations with lifecycle states, persistent memory, requires guards, event emission, and KV persistence for the wiki content manager (#60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Wiki fact-checking pool** — `verify_document` task extracts claims via LLM and verifies each through `fact_check_panel` (3 workers, majority strategy, 30s timeout, fallback on timeout); claims classified as PASS/NEEDS_REVIEW/FAIL based on consensus confidence; integrated as `fact_check` stage in `generate_docs` flow with dedicated admin endpoint (#63)
+- **Wiki fact-checking pool** — `verify_document` task extracts claims via LLM and verifies each through `fact_check_panel` (3 workers, majority strategy, 30s timeout, fallback on timeout); individual verdicts via `fact_check_detail` (all strategy); claims classified as PASS/NEEDS_REVIEW/FAIL based on consensus confidence; integrated as `fact_check` stage in `generate_docs` flow with dedicated `admin_fact_check` endpoint (#63)
 - **`.split(delimiter)` string method** — splits Text into Array of Text values for per-element iteration with `for` loops (#63)
 - **`.join(delimiter)` array method** — joins Array/List elements into Text with delimiter (#63)
+- **`.length` field access on Text** — `text.length` now works as a property (previously only available as `.len`) (#63)
+- **Variable reassignment in nested scopes** — `bind` now updates outer-scope variables when reassigning inside `for`/`if`/`match` blocks (#63)
+- **Mixed Text/Html concatenation** — `Text + Html` and `Html + Text` now work via the `+` operator, producing Text (#63)
 - **Wiki doc generation flow** — `generate_docs` flow with 5-stage DAG (scan, parallel extraction of tasks/agents/flows, reference generation, publish), `data.store` + `emit PageUpdated`, triggered via `/admin_generate_docs` endpoint with HTML result page (#62)
 - **Wiki search agent** — LLM-powered search and Q&A with confidence gating (`when .sure/.unsure/else`), persistent memory tracking index version and query count, event-driven re-indexing via `subscribe`, and confidence badge on answers (#61)
 - **Wiki content agent** — full CRUD operations with lifecycle states, persistent memory, requires guards, event emission, and KV persistence for the wiki content manager (#60)

--- a/examples/wiki/server.forge
+++ b/examples/wiki/server.forge
@@ -50,7 +50,7 @@ pure docs_sidebar
   needs active_slug: Text
   gives Html
   do
-    give "<aside class=\"w-64 shrink-0 hidden lg:block\"><ul class=\"menu bg-base-200 rounded-box w-full\"><li class=\"menu-title\">Getting Started</li><li><a href=\"/docs?slug=getting-started\" class=\"{!active_slug}\">Quick Start</a></li><li><a href=\"/docs?slug=principles\">First Principles</a></li><li class=\"menu-title\">Reference</li><li><a href=\"/docs?slug=task\">task</a></li><li><a href=\"/docs?slug=agent\">agent</a></li><li><a href=\"/docs?slug=flow\">flow</a></li><li><a href=\"/docs?slug=pool\">pool</a></li><li><a href=\"/docs?slug=system\">system</a></li><li><a href=\"/docs?slug=event\">event</a></li><li><a href=\"/docs?slug=states\">states</a></li><li><a href=\"/docs?slug=when\">when</a></li><li><a href=\"/docs?slug=pure\">pure</a></li><li><a href=\"/docs?slug=boundary\">boundary</a></li><li><a href=\"/docs?slug=requires\">requires</a></li><li><a href=\"/docs?slug=warden\">warden</a></li><li class=\"menu-title\">Generated</li><li><a href=\"/docs?slug=auto-reference\">Auto Reference</a></li><li class=\"menu-title\">About</li><li><a href=\"/docs?slug=roadmap\">Roadmap</a></li></ul></aside>"
+    give "<aside class=\"w-64 shrink-0 hidden lg:block\"><ul class=\"menu bg-base-200 rounded-box w-full\"><li class=\"menu-title\">Getting Started</li><li><a href=\"/docs?slug=getting-started\" class=\"{!active_slug}\">Quick Start</a></li><li><a href=\"/docs?slug=principles\">First Principles</a></li><li class=\"menu-title\">Reference</li><li><a href=\"/docs?slug=task\">task</a></li><li><a href=\"/docs?slug=agent\">agent</a></li><li><a href=\"/docs?slug=flow\">flow</a></li><li><a href=\"/docs?slug=pool\">pool</a></li><li><a href=\"/docs?slug=system\">system</a></li><li><a href=\"/docs?slug=event\">event</a></li><li><a href=\"/docs?slug=states\">states</a></li><li><a href=\"/docs?slug=when\">when</a></li><li><a href=\"/docs?slug=pure\">pure</a></li><li><a href=\"/docs?slug=boundary\">boundary</a></li><li><a href=\"/docs?slug=requires\">requires</a></li><li><a href=\"/docs?slug=warden\">warden</a></li><li class=\"menu-title\">Generated</li><li><a href=\"/docs?slug=auto-reference\">Auto Reference</a></li><li><a href=\"/docs?slug=fact-check-report\">Fact-Check Report</a></li><li class=\"menu-title\">About</li><li><a href=\"/docs?slug=roadmap\">Roadmap</a></li></ul></aside>"
 
 pure hero_section
   gives Html
@@ -276,13 +276,14 @@ agent search_agent
 # ── Doc Generation Flow ─────────────────────────────────────────
 #
 # Auto-generates reference docs from FORGE source files (issue #62).
-# DAG: scan_files -> [extract_tasks | extract_agents | extract_flows] -> generate_reference -> publish
+# DAG: scan_files -> [extract_* (parallel)] -> generate_reference -> fact_check -> publish
 #
 # Parallelism:
 #   Wave 0: scan_files
 #   Wave 1: extract_tasks, extract_agents, extract_flows  (parallel)
 #   Wave 2: generate_reference
-#   Wave 3: publish
+#   Wave 3: fact_check
+#   Wave 4: publish
 
 flow generate_docs
   needs sources: Text[]
@@ -321,29 +322,82 @@ flow generate_docs
     when reference.unsure -> give reference
     else -> give "Could not generate reference documentation."
 
-  stage publish
+  stage fact_check
     needs generate_reference.*
-    data.store("page:auto-reference", generate_reference)
-    emit PageUpdated(slug: "auto-reference")
-    give "Reference documentation generated and published"
+    report = verify_document(generate_reference)
+    when report.sure -> give report
+    when report.unsure -> give report
+    else -> give "Fact-checking could not complete."
 
-# ── Stub Pool ────────────────────────────────────────────────────
+  stage publish
+    needs generate_reference.*, fact_check.*
+    data.store("page:auto-reference", generate_reference)
+    data.store("page:fact-check-report", fact_check)
+    emit PageUpdated(slug: "auto-reference")
+    give "Reference docs generated, verified, and published"
+
+# ── Fact-Checking Pool ───────────────────────────────────────────
 #
-# Demonstrates: pool with workers. Full implementation in issue #63.
+# Demonstrates: pool with majority vote, per-claim verification (#63).
+# Three independent checkers evaluate each claim; 2/3 must agree.
+# Conservative: uncertain claims (split decision) marked NEEDS_REVIEW.
+
+task extract_claims
+  needs document: Text
+  gives Text
+  do
+    claims = reason "Extract individual factual claims from this FORGE documentation. Return one claim per line, nothing else. Only extract verifiable factual statements.\n\nDocument:\n{document}"
+    when claims.sure -> give claims
+    when claims.unsure -> give claims
+    else -> give ""
 
 task fact_checker
   needs claim: Text
   gives Text
   do
-    result = reason "Is this claim about FORGE accurate? Answer YES or NO with a brief explanation: {claim}"
+    result = reason "Is this claim about FORGE accurate? FORGE has 14 primitives: task, pure, flow, agent, pool, system, warden, event, states, when, boundary, requires, spawn, find. Answer with exactly YES or NO followed by a brief explanation.\n\nClaim: {claim}"
     when result.sure -> give result
-    when result.unsure -> give "uncertain"
-    else -> give "could not verify"
+    when result.unsure -> give "UNCERTAIN: {result}"
+    else -> give "UNCERTAIN: could not verify"
+
+task fact_check_fallback
+  needs claim: Text
+  gives Text
+  do
+    give "TIMEOUT: verification timed out"
 
 pool fact_check_panel
   workers: fact_checker * 3
   strategy: majority
   timeout: 30s
+  fallback: fact_check_fallback
+
+task classify_verdict
+  needs verdict: Text
+  gives Text
+  do
+    when verdict.sure -> give "PASS"
+    when verdict.unsure -> give "NEEDS_REVIEW"
+    else -> give "FAIL"
+
+task verify_document
+  needs document: Text
+  gives Text
+  do
+    raw_claims = extract_claims(document)
+    if raw_claims == ""
+      give "No verifiable claims found."
+    claims = raw_claims.split("\n")
+    report = ""
+    for claim in claims
+      trimmed = claim.trim()
+      if trimmed.length > 0
+        verdict = fact_check_panel("check", trimmed)
+        label = classify_verdict(verdict)
+        report = report + "- " + label + ": " + trimmed + "\n"
+    if report == ""
+      give "No verifiable claims found."
+    give report.trim()
 
 # ── Warden ───────────────────────────────────────────────────────
 #
@@ -413,8 +467,16 @@ endpoint admin_generate_docs() -> Html
   nav = nav_bar("")
   sources = data.list("page:")
   result = generate_docs(sources)
-  body = "<div class=\"container mx-auto px-4 py-8\"><h1 class=\"text-3xl font-bold mb-6\">Doc Generation</h1><div class=\"alert alert-success\"><span>{result}</span></div><a href=\"/docs?slug=auto-reference\" class=\"btn btn-primary mt-4\">View Generated Reference</a></div>"
+  body = "<div class=\"container mx-auto px-4 py-8\"><h1 class=\"text-3xl font-bold mb-6\">Doc Generation</h1><div class=\"alert alert-success\"><span>{result}</span></div><a href=\"/docs?slug=auto-reference\" class=\"btn btn-primary mt-4\">View Generated Reference</a><a href=\"/docs?slug=fact-check-report\" class=\"btn btn-outline mt-4 ml-2\">View Fact-Check Report</a></div>"
   give page_layout("Admin — Generate Docs", nav, body)
+
+endpoint admin_fact_check(slug: Text) -> Html
+  nav = nav_bar("")
+  content = data.get("page:{slug}")
+  report = verify_document(content)
+  rendered = markdown.render(report)
+  body = "<div class=\"container mx-auto px-4 py-8\"><h1 class=\"text-3xl font-bold mb-6\">Fact-Check Report</h1><p class=\"mb-4\">Verifying page: <code>{slug}</code></p><div class=\"prose max-w-none\">{!rendered}</div><a href=\"/docs?slug={slug}\" class=\"btn btn-ghost mt-4\">Back to page</a></div>"
+  give page_layout("Fact Check — FORGE", nav, body)
 
 # -- Entry Point --
 

--- a/examples/wiki/server.forge
+++ b/examples/wiki/server.forge
@@ -372,6 +372,11 @@ pool fact_check_panel
   timeout: 30s
   fallback: fact_check_fallback
 
+pool fact_check_detail
+  workers: fact_checker * 3
+  strategy: all
+  timeout: 30s
+
 task classify_verdict
   needs verdict: Text
   gives Text
@@ -394,7 +399,9 @@ task verify_document
       if trimmed.length > 0
         verdict = fact_check_panel("check", trimmed)
         label = classify_verdict(verdict)
-        report = report + "- " + label + ": " + trimmed + "\n"
+        individual = fact_check_detail("check", trimmed)
+        verdicts_text = individual.join(" | ")
+        report = report + "- " + label + ": " + trimmed + "\n  Verdicts: [" + verdicts_text + "]\n"
     if report == ""
       give "No verifiable claims found."
     give report.trim()

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -89,6 +89,14 @@ impl Env {
     }
 
     pub(crate) fn bind(&mut self, name: &str, value: ConfidentValue) {
+        // If the variable already exists in an outer scope, update it there
+        // (reassignment semantics). Otherwise, create in the current scope.
+        for scope in self.scopes.iter_mut().rev() {
+            if scope.contains_key(name) {
+                scope.insert(name.to_string(), value);
+                return;
+            }
+        }
         if let Some(scope) = self.scopes.last_mut() {
             scope.insert(name.to_string(), value);
         }
@@ -1248,6 +1256,9 @@ impl TaskExecutor {
                         (Value::Array(v) | Value::List(v), "len" | "length" | "count") => {
                             Ok(ConfidentValue::deterministic(Value::Number(v.len() as f64)))
                         }
+                        (Value::Text(s) | Value::Html(s), "len" | "length") => {
+                            Ok(ConfidentValue::deterministic(Value::Number(s.len() as f64)))
+                        }
                         // Record field access — transparently unwrap _type/_value wrapper
                         (Value::Record(fields), _) => {
                             // Direct field access
@@ -1677,11 +1688,11 @@ impl TaskExecutor {
                             }
                             let delim_val = self.eval_expr(&args[0].node.value, env).await?;
                             let delimiter = match &delim_val.value {
-                                Value::Text(s) => s.clone(),
+                                Value::Text(s) | Value::Html(s) => s.clone(),
                                 _ => {
                                     return Err(RuntimeError::TypeError {
                                         expected: "Text delimiter".to_string(),
-                                        got: format!("{}", delim_val.value),
+                                        got: format!("{:?}", delim_val.value),
                                     })
                                 }
                             };
@@ -1711,11 +1722,11 @@ impl TaskExecutor {
                             }
                             let delim_val = self.eval_expr(&args[0].node.value, env).await?;
                             let delimiter = match &delim_val.value {
-                                Value::Text(s) => s.clone(),
+                                Value::Text(s) | Value::Html(s) => s.clone(),
                                 _ => {
                                     return Err(RuntimeError::TypeError {
                                         expected: "Text delimiter".to_string(),
-                                        got: format!("{}", delim_val.value),
+                                        got: format!("{:?}", delim_val.value),
                                     })
                                 }
                             };
@@ -2427,10 +2438,11 @@ fn eval_binop(left: &Value, op: &BinOp, right: &Value) -> Result<Value, RuntimeE
             }
             Ok(Value::Number(a / b))
         }
-        // String concatenation
+        // String concatenation (Text + Text → Text, Html + Html → Html, mixed → Text)
         (Value::Text(a), BinOp::Add, Value::Text(b)) => Ok(Value::Text(format!("{}{}", a, b))),
-        // Html concatenation
         (Value::Html(a), BinOp::Add, Value::Html(b)) => Ok(Value::Html(format!("{}{}", a, b))),
+        (Value::Text(a), BinOp::Add, Value::Html(b)) => Ok(Value::Text(format!("{}{}", a, b))),
+        (Value::Html(a), BinOp::Add, Value::Text(b)) => Ok(Value::Text(format!("{}{}", a, b))),
         // Numeric comparison
         (Value::Number(a), BinOp::Lt, Value::Number(b)) => Ok(Value::Bool(a < b)),
         (Value::Number(a), BinOp::Gt, Value::Number(b)) => Ok(Value::Bool(a > b)),

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -1245,7 +1245,7 @@ impl TaskExecutor {
                             };
                             Ok(ConfidentValue::deterministic(Value::Bool(same)))
                         }
-                        (Value::Array(v) | Value::List(v), "len" | "count") => {
+                        (Value::Array(v) | Value::List(v), "len" | "length" | "count") => {
                             Ok(ConfidentValue::deterministic(Value::Number(v.len() as f64)))
                         }
                         // Record field access — transparently unwrap _type/_value wrapper
@@ -1667,6 +1667,73 @@ impl TaskExecutor {
                                 Value::Text(text)
                             };
                             Ok(ConfidentValue::derived(val, obj.confidence))
+                        }
+                        "split" => {
+                            if args.len() != 1 {
+                                return Err(RuntimeError::TypeError {
+                                    expected: "1 argument".to_string(),
+                                    got: format!("{} arguments", args.len()),
+                                });
+                            }
+                            let delim_val = self.eval_expr(&args[0].node.value, env).await?;
+                            let delimiter = match &delim_val.value {
+                                Value::Text(s) => s.clone(),
+                                _ => {
+                                    return Err(RuntimeError::TypeError {
+                                        expected: "Text delimiter".to_string(),
+                                        got: format!("{}", delim_val.value),
+                                    })
+                                }
+                            };
+                            let text = match &obj.value {
+                                Value::Text(s) | Value::Html(s) => s.as_str(),
+                                _ => {
+                                    return Err(RuntimeError::TypeError {
+                                        expected: "Text".to_string(),
+                                        got: format!("{}", obj.value),
+                                    })
+                                }
+                            };
+                            let parts: Vec<ConfidentValue> = text
+                                .split(&delimiter)
+                                .map(|part| {
+                                    ConfidentValue::deterministic(Value::Text(part.to_string()))
+                                })
+                                .collect();
+                            Ok(ConfidentValue::deterministic(Value::Array(parts)))
+                        }
+                        "join" => {
+                            if args.len() != 1 {
+                                return Err(RuntimeError::TypeError {
+                                    expected: "1 argument".to_string(),
+                                    got: format!("{} arguments", args.len()),
+                                });
+                            }
+                            let delim_val = self.eval_expr(&args[0].node.value, env).await?;
+                            let delimiter = match &delim_val.value {
+                                Value::Text(s) => s.clone(),
+                                _ => {
+                                    return Err(RuntimeError::TypeError {
+                                        expected: "Text delimiter".to_string(),
+                                        got: format!("{}", delim_val.value),
+                                    })
+                                }
+                            };
+                            let items = match &obj.value {
+                                Value::Array(v) | Value::List(v) => v,
+                                _ => {
+                                    return Err(RuntimeError::TypeError {
+                                        expected: "Array or List".to_string(),
+                                        got: format!("{}", obj.value),
+                                    })
+                                }
+                            };
+                            let joined: String = items
+                                .iter()
+                                .map(|item| format!("{}", item.value))
+                                .collect::<Vec<_>>()
+                                .join(&delimiter);
+                            Ok(ConfidentValue::deterministic(Value::Text(joined)))
                         }
                         other => Err(RuntimeError::Unsupported(format!("method .{}()", other))),
                     }
@@ -2877,5 +2944,88 @@ fn main
         )
         .await;
         assert!(matches!(result, Err(RuntimeError::FlowError(ref msg)) if msg.contains("cycle")));
+    }
+
+    // ── split / join tests ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_split_basic() {
+        let (result, outputs) = run_forge(
+            r#"
+fn main
+  text = "a,b,c"
+  parts = text.split(",")
+  say parts.length
+  for p in parts
+      say p
+"#,
+        )
+        .await;
+        assert!(result.is_ok(), "split failed: {:?}", result.err());
+        assert_eq!(outputs, vec!["3", "a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn test_split_newline() {
+        let (result, outputs) = run_forge(
+            r#"
+fn main
+  text = "line one
+line two
+line three"
+  parts = text.split("\n")
+  say parts.length
+"#,
+        )
+        .await;
+        assert!(result.is_ok(), "split newline failed: {:?}", result.err());
+        assert_eq!(outputs, vec!["3"]);
+    }
+
+    #[tokio::test]
+    async fn test_split_no_match() {
+        let (result, outputs) = run_forge(
+            r#"
+fn main
+  text = "no delimiter here"
+  parts = text.split(",")
+  say parts.length
+"#,
+        )
+        .await;
+        assert!(result.is_ok(), "split no match failed: {:?}", result.err());
+        assert_eq!(outputs, vec!["1"]);
+    }
+
+    #[tokio::test]
+    async fn test_join_basic() {
+        let (result, outputs) = run_forge(
+            r#"
+fn main
+  text = "a,b,c"
+  parts = text.split(",")
+  joined = parts.join(" | ")
+  say joined
+"#,
+        )
+        .await;
+        assert!(result.is_ok(), "join failed: {:?}", result.err());
+        assert_eq!(outputs, vec!["a | b | c"]);
+    }
+
+    #[tokio::test]
+    async fn test_split_join_roundtrip() {
+        let (result, outputs) = run_forge(
+            r#"
+fn main
+  original = "hello world foo"
+  parts = original.split(" ")
+  back = parts.join(" ")
+  say back
+"#,
+        )
+        .await;
+        assert!(result.is_ok(), "roundtrip failed: {:?}", result.err());
+        assert_eq!(outputs, vec!["hello world foo"]);
     }
 }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -366,6 +366,41 @@ async fn accept_tictactoe_game() {
     println!("=== Tic-tac-toe full game complete — X wins! ===");
 }
 
+// ── Fact-check pool acceptance test (issue #63) ─────────────────
+
+#[test]
+fn accept_fact_check_pool_parse() {
+    let diags = check_file("examples/fact_check_pool.forge");
+    let errs = errors(&diags);
+    assert!(
+        errs.is_empty(),
+        "fact_check_pool.forge should have no checker errors, got: {:?}",
+        errs.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn accept_fact_check_pool_run() {
+    let program = parse_file("examples/fact_check_pool.forge");
+    // Mock provider returns 3 identical responses for the 3 pool workers
+    let mock = MockProvider::new("mock").with_default("YES this claim is factually accurate");
+    let executor = TaskExecutor::new(program, mock_registry(mock), None);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "fact_check_pool.forge should run without error: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    assert!(
+        outputs
+            .iter()
+            .any(|o| o.contains("YES") || o.contains("Verdict")),
+        "should output a verdict, got: {:?}",
+        outputs
+    );
+}
+
 // ── CLI smoke tests ──────────────────────────────────────────────
 
 #[test]

--- a/tests/e2e/pages/admin.page.ts
+++ b/tests/e2e/pages/admin.page.ts
@@ -5,20 +5,30 @@ export class AdminPage extends BasePage {
   readonly heading: Locator;
   readonly successAlert: Locator;
   readonly viewReferenceLink: Locator;
+  readonly viewFactCheckLink: Locator;
 
   constructor(page: Page) {
     super(page);
     this.heading = page.locator('h1');
     this.successAlert = page.locator('.alert-success');
     this.viewReferenceLink = page.getByRole('link', { name: 'View Generated Reference' });
+    this.viewFactCheckLink = page.getByRole('link', { name: 'View Fact-Check Report' });
   }
 
   async goto() {
     await this.page.goto('/admin_generate_docs');
   }
 
+  async gotoFactCheck(slug: string) {
+    await this.page.goto(`/admin_fact_check?slug=${slug}`);
+  }
+
   async expectLoaded() {
     await expect(this.heading).toContainText('Doc Generation');
+  }
+
+  async expectFactCheckLoaded() {
+    await expect(this.heading).toContainText('Fact-Check Report');
   }
 
   async expectSuccess() {

--- a/tests/e2e/specs/admin.spec.ts
+++ b/tests/e2e/specs/admin.spec.ts
@@ -33,3 +33,67 @@ test.describe('Doc Generation (issue #62)', () => {
     await expect(page).toHaveURL(/slug=auto-reference/);
   });
 });
+
+test.describe('Fact-Checking Pool (issue #63)', () => {
+  test('admin_generate_docs shows fact-check report link', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+    await admin.expectLoaded();
+    await admin.expectSuccess();
+    await expect(admin.viewFactCheckLink).toBeVisible();
+  });
+
+  test('fact-check report link navigates to report page', async ({ page }) => {
+    const admin = new AdminPage(page);
+    await admin.goto();
+    await admin.expectSuccess();
+
+    await admin.viewFactCheckLink.click();
+    await expect(page).toHaveURL(/slug=fact-check-report/);
+  });
+
+  test('admin_fact_check endpoint renders verification report', async ({ page }) => {
+    // Seed a page first via generate_docs
+    const admin = new AdminPage(page);
+    await admin.goto();
+    await admin.expectSuccess();
+
+    // Navigate to fact-check for auto-reference
+    await admin.gotoFactCheck('auto-reference');
+    await admin.expectFactCheckLoaded();
+
+    // Report should have content
+    const prose = page.locator('.prose');
+    await expect(prose).toBeVisible();
+    const text = await prose.textContent();
+    expect(text!.length).toBeGreaterThan(0);
+  });
+
+  test('sidebar includes fact-check report link', async ({ page }) => {
+    const docs = new DocsPage(page);
+    await docs.goto('getting-started');
+    await docs.expectSidebarVisible();
+
+    const factCheckLink = page.getByRole('link', { name: 'Fact-Check Report' });
+    await expect(factCheckLink).toBeVisible();
+  });
+
+  test('fact-check report contains per-claim breakdown', async ({ page }) => {
+    // Seed docs first
+    const admin = new AdminPage(page);
+    await admin.goto();
+    await admin.expectSuccess();
+
+    // View fact-check report via docs
+    const docs = new DocsPage(page);
+    await docs.goto('fact-check-report');
+    await docs.expectLoaded();
+
+    const text = await docs.article.textContent();
+    // Report should contain verdict labels (PASS, NEEDS_REVIEW, or FAIL)
+    // and individual verdicts
+    expect(text!.length).toBeGreaterThan(10);
+    // With mock provider, claims should have verdicts
+    expect(text).toMatch(/PASS|NEEDS_REVIEW|FAIL|Verdicts/);
+  });
+});

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -458,3 +458,122 @@ async fn pool_via_send_method_call() {
     let result = executor.run().await.unwrap();
     assert!(matches!(result.value, Value::Unit | Value::Text(_)));
 }
+
+// ── Fact-check specific tests (issue #63) ───────────────────────────────────
+
+#[tokio::test]
+async fn fact_check_majority_pass() {
+    // 2/3 agree on identical "YES" answer — consensus with 0.67 agreement.
+    // Use identical responses for the 2 agreeing workers so concurrent
+    // dispatch order does not affect the majority result.
+    let registry = mock_registry_with_sequence(vec![
+        "YES this claim is accurate".to_string(),
+        "YES this claim is accurate".to_string(),
+        "NO this claim is inaccurate".to_string(),
+    ]);
+
+    let task = reason_task("fact_checker");
+    let program = program_with(vec![task]);
+    let decl = pool_decl_node(
+        "fact_check_panel",
+        "fact_checker",
+        3.0,
+        PoolStrategy::Majority,
+        Some(Duration {
+            value: 30,
+            unit: DurationUnit::Seconds,
+        }),
+        None,
+    );
+
+    let pool = PoolExecutor::new(decl, &program, registry, None).unwrap();
+    let result = pool
+        .send("check", vec![text_arg("FORGE has 14 primitives")])
+        .await
+        .unwrap();
+
+    // Should return consensus (YES) — 2 identical answers cluster together
+    assert!(
+        matches!(&result.value, Value::Text(s) if s.contains("YES")),
+        "expected YES consensus, got: {:?}",
+        result.value
+    );
+    // Source should be ConsensusAgreement with ~0.67 agreement
+    assert!(
+        matches!(result.source, ConfidenceSource::ConsensusAgreement(a) if a > 0.6 && a < 0.8),
+        "expected agreement ~0.67, got: {:?}",
+        result.source
+    );
+}
+
+#[tokio::test]
+async fn fact_check_majority_fail() {
+    // 2/3 agree on identical "NO" answer
+    let registry = mock_registry_with_sequence(vec![
+        "NO this claim is false".to_string(),
+        "NO this claim is false".to_string(),
+        "YES this is correct".to_string(),
+    ]);
+
+    let task = reason_task("fact_checker");
+    let program = program_with(vec![task]);
+    let decl = pool_decl_node(
+        "fact_check_panel",
+        "fact_checker",
+        3.0,
+        PoolStrategy::Majority,
+        Some(Duration {
+            value: 30,
+            unit: DurationUnit::Seconds,
+        }),
+        None,
+    );
+
+    let pool = PoolExecutor::new(decl, &program, registry, None).unwrap();
+    let result = pool
+        .send("check", vec![text_arg("FORGE has 100 primitives")])
+        .await
+        .unwrap();
+
+    // Should return consensus (NO)
+    assert!(
+        matches!(&result.value, Value::Text(s) if s.contains("NO")),
+        "expected NO consensus, got: {:?}",
+        result.value
+    );
+}
+
+#[tokio::test]
+async fn fact_check_unanimous() {
+    // 3/3 agree — unanimous, agreement = 1.0
+    let registry = mock_registry_with_sequence(vec![
+        "YES this is accurate".to_string(),
+        "YES this is accurate".to_string(),
+        "YES this is accurate".to_string(),
+    ]);
+
+    let task = reason_task("fact_checker");
+    let program = program_with(vec![task]);
+    let decl = pool_decl_node(
+        "fact_check_panel",
+        "fact_checker",
+        3.0,
+        PoolStrategy::Majority,
+        None,
+        None,
+    );
+
+    let pool = PoolExecutor::new(decl, &program, registry, None).unwrap();
+    let result = pool
+        .send("check", vec![text_arg("test claim")])
+        .await
+        .unwrap();
+
+    // Should be .sure() with agreement 1.0
+    assert!(result.sure(), "expected .sure() for unanimous agreement");
+    assert!(
+        matches!(result.source, ConfidenceSource::ConsensusAgreement(a) if a > 0.99),
+        "expected agreement ~1.0, got: {:?}",
+        result.source
+    );
+}


### PR DESCRIPTION
## Summary

- **Fact-checking pipeline**: `verify_document` task extracts claims via LLM, iterates each claim through `fact_check_panel` pool (3 workers, majority strategy, 30s timeout), classifies verdicts as PASS/NEEDS_REVIEW/FAIL based on consensus confidence. Individual verdicts captured via `fact_check_detail` pool (all strategy)
- **`.split()` / `.join()` runtime methods**: New string/array methods enabling per-element iteration over LLM-extracted text — `text.split("\n")` returns Array, `array.join(", ")` returns Text
- **Flow integration**: New `fact_check` stage in `generate_docs` flow between `generate_reference` and `publish`; fact-check report stored alongside auto-reference docs
- **Admin endpoint**: `admin_fact_check(slug)` verifies any wiki page on demand with rendered markdown report
- **Runtime fixes**: Variable reassignment in nested scopes (for/if/match), `.length` on Text field access, mixed Text/Html concatenation, Html-typed delimiters in split/join

## Primitives Showcased

| Primitive | Usage |
|---|---|
| `pool` | `fact_check_panel` — 3 parallel workers with majority, `fact_check_detail` — 3 workers with all |
| `strategy: majority` | Majority vote resolution (2/3 must agree) |
| `strategy: all` | Collect all individual verdicts |
| `timeout` | 30-second deadline per check |
| `fallback` | `fact_check_fallback` runs on timeout |
| `task` | `extract_claims`, `fact_checker`, `classify_verdict`, `verify_document` |
| `when` | Confidence gating on consensus verdicts |
| `flow` | `generate_docs` with `fact_check` stage |
| `for` | Per-claim iteration over extracted claims |
| `endpoint` | `admin_fact_check` for on-demand verification |

## Test plan

- [x] 5 unit tests for `.split()` / `.join()` (basic, newline, no-match, join, roundtrip)
- [x] 3 pool integration tests (`fact_check_majority_pass`, `fact_check_majority_fail`, `fact_check_unanimous`)
- [x] 2 acceptance tests (parse + run `fact_check_pool.forge` with mock provider)
- [x] 5 Playwright E2E tests (admin endpoint, fact-check report link, verification report, sidebar link, per-claim breakdown)
- [x] Full Playwright suite passes (41 tests)
- [x] `cargo fmt --check && cargo clippy -- -D warnings` clean
- [x] Full test suite passes (610+ tests)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)