### PR TITLE
fix: wiki Q&A and search grounded in actual doc content (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Wiki Q&A and search grounded in actual docs** — `answer_question` and `search_docs` now inject real page content into the LLM context via `gather_docs`, eliminating hallucinated FORGE syntax (#122)
+
 ### Changed
 - **Wiki UX polish** — doc links show dotted underline with highlight on hover; search results styled as card-like items; confidence badges color-coded (green/yellow/red); theme toggle uses sun/moon icons; activity log gets subtle border (#120)
 - **Wiki search and Q&A link to doc pages** — LLM responses now include markdown links to relevant documentation pages (e.g. `[agent](/docs?slug=agent)`) instead of plain text mentions (#120)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Wiki Q&A and search grounded in actual docs** — `answer_question` and `search_docs` now inject real page content into the LLM context via `gather_docs`, eliminating hallucinated FORGE syntax (#122)
+- **Wiki Q&A, search, and auto-reference grounded in actual docs** — `answer_question`, `search_docs`, and `generate_docs` flow now inject real page content into the LLM context via `gather_docs`, eliminating hallucinated FORGE syntax (#122)
 
 ### Changed
 - **Wiki UX polish** — doc links show dotted underline with highlight on hover; search results styled as card-like items; confidence badges color-coded (green/yellow/red); theme toggle uses sun/moon icons; activity log gets subtle border (#120)

--- a/examples/wiki/server.forge
+++ b/examples/wiki/server.forge
@@ -144,10 +144,20 @@ task load_page
     content = data.get("page:{slug}")
     give content
 
+task gather_docs
+  gives Text
+  do
+    pages = data.list("page:")
+    docs = []
+    for key in pages
+      content = data.get(key)
+      docs = docs + ["--- {key} ---\n{content}"]
+    give docs.join("\n\n")
+
 # ── Search Task ──────────────────────────────────────────────────
 #
 # LLM-powered search with confidence gating (issue #61).
-# Demonstrates: task, when, classify, reason, data.list
+# Demonstrates: task, when, classify, reason, data.list, gather_docs
 
 task search_docs
   needs query: Text
@@ -155,9 +165,9 @@ task search_docs
   do
     if query == ""
       give ""
-    pages = data.list("page:")
+    docs = gather_docs()
     intent = classify query into ["reference", "tutorial", "troubleshooting", "general"]
-    results = reason "You are a FORGE documentation search engine. Available pages: {pages}\n\nSearch query: '{query}' (intent: {intent})\n\nIMPORTANT: Every page reference MUST be a markdown link. Use the format [slug](/docs?slug=slug) for every page you mention. Example: - [agent](/docs?slug=agent) — Core FORGE entity\n\nList the most relevant pages with one-line excerpt. Format as a markdown list."
+    results = reason "You are a FORGE documentation search engine. Use the documentation below to provide accurate excerpts.\n\n{docs}\n\nSearch query: '{query}' (intent: {intent})\n\nIMPORTANT: Every page reference MUST be a markdown link. Use the format [slug](/docs?slug=slug) for every page you mention. Example: - [agent](/docs?slug=agent) — Core FORGE entity\n\nList the most relevant pages with one-line excerpt from their actual content. Format as a markdown list."
     when results.sure -> give results
     when results.unsure -> give "Partial matches found (confidence is moderate):\n{results}"
     else -> give "No confident results for: {query}"
@@ -165,7 +175,7 @@ task search_docs
 # ── Q&A Task ─────────────────────────────────────────────────────
 #
 # LLM-powered Q&A with confidence gating (issue #61).
-# Demonstrates: task, when, reason, data.list
+# Demonstrates: task, when, reason, gather_docs
 
 task answer_question
   needs question: Text
@@ -173,8 +183,8 @@ task answer_question
   do
     if question == ""
       give ""
-    pages = data.list("page:")
-    answer = reason "You are a FORGE language expert. Using the available documentation pages ({pages}), answer this question accurately and concisely.\n\nIMPORTANT: Every time you mention a FORGE concept that has a doc page, you MUST link it using markdown. Use the format [name](/docs?slug=slug). Available doc slugs: getting-started, principles, roadmap, home, task, agent, flow, pool, system, event, states, when, pure, boundary, requires, warden. For example, write [pool](/docs?slug=pool) not just 'pool'. Never mention a concept as plain text if it has a doc slug.\n\nQuestion: {question}"
+    docs = gather_docs()
+    answer = reason "You are a FORGE language expert. Use ONLY the documentation below to answer. Do not invent syntax.\n\n{docs}\n\nIMPORTANT: Every time you mention a FORGE concept that has a doc page, you MUST link it using markdown. Use the format [name](/docs?slug=slug). Available doc slugs: getting-started, principles, roadmap, home, task, agent, flow, pool, system, event, states, when, pure, boundary, requires, warden. For example, write [pool](/docs?slug=pool) not just 'pool'. Never mention a concept as plain text if it has a doc slug.\n\nQuestion: {question}"
     when answer.sure -> give answer
     when answer.unsure -> give "I'm not fully confident, but here's what I found:\n{answer}"
     else -> give "I don't have enough information to answer that reliably."

--- a/examples/wiki/server.forge
+++ b/examples/wiki/server.forge
@@ -314,38 +314,37 @@ agent search_agent
 #   Wave 4: publish
 
 flow generate_docs
-  needs sources: Text[]
+  needs sources: Text
   gives Text
 
   stage scan_files
-    file_contents = sources
-    say "Scanning {sources.len()} source files..."
-    give file_contents
+    say "Loaded documentation content"
+    give sources
 
   stage extract_tasks
     needs scan_files.*
-    signatures = reason "Extract all task declarations from this FORGE source code.\nFor each task, provide: name, parameters, return type, and a one-line description.\nSource: {scan_files}"
+    signatures = reason "Extract all task declarations from the FORGE documentation below.\nFor each task, provide: name, parameters, return type, and a one-line description.\nUse ONLY what appears in the documentation. Do not invent syntax.\n\nDocumentation:\n{scan_files}"
     when signatures.sure -> give signatures
     when signatures.unsure -> give signatures
     else -> give "No task declarations found."
 
   stage extract_agents
     needs scan_files.*
-    signatures = reason "Extract all agent declarations from this FORGE source code.\nFor each agent: name, states, memory fields, handlers, and a one-line description.\nSource: {scan_files}"
+    signatures = reason "Extract all agent declarations from the FORGE documentation below.\nFor each agent: name, states, memory fields, handlers, and a one-line description.\nUse ONLY what appears in the documentation. Do not invent syntax.\n\nDocumentation:\n{scan_files}"
     when signatures.sure -> give signatures
     when signatures.unsure -> give signatures
     else -> give "No agent declarations found."
 
   stage extract_flows
     needs scan_files.*
-    signatures = reason "Extract all flow declarations from this FORGE source code.\nFor each flow: name, stages, dependencies, and a one-line description.\nSource: {scan_files}"
+    signatures = reason "Extract all flow declarations from the FORGE documentation below.\nFor each flow: name, stages, dependencies, and a one-line description.\nUse ONLY what appears in the documentation. Do not invent syntax.\n\nDocumentation:\n{scan_files}"
     when signatures.sure -> give signatures
     when signatures.unsure -> give signatures
     else -> give "No flow declarations found."
 
   stage generate_reference
     needs extract_tasks.*, extract_agents.*, extract_flows.*
-    reference = reason "Generate a comprehensive reference document in Markdown format.\nOrganize by category: Tasks, Agents, Flows.\nInclude code examples for each item.\n\nTasks: {extract_tasks}\nAgents: {extract_agents}\nFlows: {extract_flows}"
+    reference = reason "Generate a comprehensive reference document in Markdown format.\nOrganize by category: Tasks, Agents, Flows.\nInclude code examples for each item.\nUse ONLY the extracted information below. Do not invent syntax or examples.\n\nTasks: {extract_tasks}\nAgents: {extract_agents}\nFlows: {extract_flows}"
     when reference.sure -> give reference
     when reference.unsure -> give reference
     else -> give "Could not generate reference documentation."
@@ -532,8 +531,8 @@ endpoint api_search(q: Text) -> Text
 
 endpoint admin_generate_docs() -> Html
   nav = nav_bar("")
-  sources = data.list("page:")
-  result = generate_docs(sources)
+  docs = gather_docs()
+  result = generate_docs(docs)
   body = "<div class=\"container mx-auto px-4 py-8\"><h1 class=\"text-3xl font-bold mb-6\">Doc Generation</h1><div class=\"alert alert-success\"><span>{result}</span></div><a href=\"/docs?slug=auto-reference\" class=\"btn btn-primary mt-4\">View Generated Reference</a><a href=\"/docs?slug=fact-check-report\" class=\"btn btn-outline mt-4 ml-2\">View Fact-Check Report</a></div>"
   give page_layout("Admin — Generate Docs", nav, body)
 

--- a/tests/e2e/pages/admin.page.ts
+++ b/tests/e2e/pages/admin.page.ts
@@ -16,11 +16,11 @@ export class AdminPage extends BasePage {
   }
 
   async goto() {
-    await this.page.goto('/admin_generate_docs');
+    await this.page.goto('/admin_generate_docs', { timeout: 120_000 });
   }
 
   async gotoFactCheck(slug: string) {
-    await this.page.goto(`/admin_fact_check?slug=${slug}`);
+    await this.page.goto(`/admin_fact_check?slug=${slug}`, { timeout: 120_000 });
   }
 
   async expectLoaded() {

--- a/tests/e2e/pages/search.page.ts
+++ b/tests/e2e/pages/search.page.ts
@@ -15,9 +15,9 @@ export class SearchPage extends BasePage {
 
   async goto(query?: string) {
     if (query) {
-      await this.page.goto(`/search?q=${encodeURIComponent(query)}`);
+      await this.page.goto(`/search_page?q=${encodeURIComponent(query)}`);
     } else {
-      await this.page.goto('/search?q=');
+      await this.page.goto('/search_page?q=');
     }
   }
 

--- a/tests/e2e/specs/admin.spec.ts
+++ b/tests/e2e/specs/admin.spec.ts
@@ -3,6 +3,9 @@ import { AdminPage } from '../pages/admin.page';
 import { DocsPage } from '../pages/docs.page';
 
 test.describe('Doc Generation (issue #62)', () => {
+  // generate_docs flow makes multiple LLM calls with full doc context
+  test.beforeEach(async () => { test.setTimeout(120_000); });
+
   test('admin endpoint triggers flow and shows success', async ({ page }) => {
     const admin = new AdminPage(page);
     await admin.goto();
@@ -35,6 +38,9 @@ test.describe('Doc Generation (issue #62)', () => {
 });
 
 test.describe('Fact-Checking Pool (issue #63)', () => {
+  // fact-checking requires doc generation + per-claim verification
+  test.beforeEach(async () => { test.setTimeout(180_000); });
+
   test('admin_generate_docs shows fact-check report link', async ({ page }) => {
     const admin = new AdminPage(page);
     await admin.goto();
@@ -53,6 +59,7 @@ test.describe('Fact-Checking Pool (issue #63)', () => {
   });
 
   test('admin_fact_check endpoint renders verification report', async ({ page }) => {
+    test.setTimeout(300_000); // doc gen + fact-check with full doc context
     // Seed a page first via generate_docs
     const admin = new AdminPage(page);
     await admin.goto();

--- a/tests/e2e/specs/ask.spec.ts
+++ b/tests/e2e/specs/ask.spec.ts
@@ -13,7 +13,7 @@ test.describe('Q&A', () => {
   test('submitting a question returns an answer', async ({ page }) => {
     // Use GET with query param since the form's native POST sends form-encoded data
     // but the endpoint expects application/json
-    await page.goto('/ask?question=What+is+a+task');
+    await page.goto('/ask_page?question=What+is+a+task');
     const answerCard = page.locator('.card .card-body');
     await expect(answerCard).toBeVisible();
     const text = await answerCard.textContent();
@@ -22,7 +22,7 @@ test.describe('Q&A', () => {
 
   test('answer page shows confidence badge', async ({ page }) => {
     const ask = new AskPage(page);
-    await page.goto('/ask?question=What+is+a+pool');
+    await page.goto('/ask_page?question=What+is+a+pool');
     await expect(ask.confidenceBadge).toBeVisible();
     const badge = await ask.confidenceBadge.textContent();
     expect(badge).toMatch(/confidence/);

--- a/tests/e2e/specs/search.spec.ts
+++ b/tests/e2e/specs/search.spec.ts
@@ -15,8 +15,8 @@ test.describe('Search', () => {
     await search.goto();
     await search.search('task');
 
-    await expect(page).toHaveURL(/q=task/);
-    await search.expectResultsVisible();
+    // Form uses AJAX fetch, so URL doesn't change — wait for results to appear
+    await expect(search.results).toHaveText(/.+/, { timeout: 15_000 });
   });
 
   test('URL query param pre-fills input', async ({ page }) => {
@@ -38,6 +38,6 @@ test.describe('Search', () => {
   test('Cmd+K shortcut navigates to search', async ({ page }) => {
     await page.goto('/home');
     await page.keyboard.press('Meta+k');
-    await expect(page).toHaveURL(/\/search/);
+    await expect(page).toHaveURL(/\/search_page/);
   });
 });

--- a/tests/e2e/specs/warden-real.spec.ts
+++ b/tests/e2e/specs/warden-real.spec.ts
@@ -29,7 +29,7 @@ test.describe('Warden Supervision — Real API (issue #64)', () => {
   test('Q&A gives real answers', async ({ page }) => {
     test.setTimeout(60_000);
     // Use GET with query param (form POST sends wrong Content-Type)
-    await page.goto('/ask?question=What+is+a+warden+in+FORGE');
+    await page.goto('/ask_page?question=What+is+a+warden+in+FORGE');
     const answerCard = page.locator('.card .card-body');
     await expect(answerCard).toBeVisible({ timeout: 45_000 });
     const answer = await answerCard.textContent();
@@ -79,7 +79,7 @@ test.describe('Warden Supervision — Real API (issue #64)', () => {
   test('confidence tiers reflect real LLM confidence', async ({ page }) => {
     test.setTimeout(60_000);
     // Use GET with query param
-    await page.goto('/ask?question=What+are+the+14+primitives+in+FORGE');
+    await page.goto('/ask_page?question=What+are+the+14+primitives+in+FORGE');
     const answerCard = page.locator('.card .card-body');
     await expect(answerCard).toBeVisible({ timeout: 45_000 });
     // Confidence badge should be visible
@@ -102,7 +102,7 @@ test.describe('Warden Supervision — Real API (issue #64)', () => {
     await search.expectResultsVisible();
 
     // Use GET for Q&A — wait for server-side LLM call
-    await page.goto('/ask?question=Explain+FORGE+supervision', { timeout: 60_000 });
+    await page.goto('/ask_page?question=Explain+FORGE+supervision', { timeout: 60_000 });
     const answerCard = page.locator('.card .card-body');
     await expect(answerCard).toBeVisible({ timeout: 10_000 });
   });

--- a/tests/e2e/specs/warden.spec.ts
+++ b/tests/e2e/specs/warden.spec.ts
@@ -21,7 +21,7 @@ test.describe('Warden Supervision (issue #64)', () => {
 
   test('Q&A works under supervision', async ({ page }) => {
     // Use GET with query param (same as existing ask.spec.ts pattern)
-    await page.goto('/ask?question=What+is+a+warden');
+    await page.goto('/ask_page?question=What+is+a+warden');
     const answerCard = page.locator('.card .card-body');
     await expect(answerCard).toBeVisible();
     const answer = await answerCard.textContent();
@@ -45,7 +45,7 @@ test.describe('Warden Supervision (issue #64)', () => {
   });
 
   test('admin fact-check works under supervision', async ({ page }) => {
-    test.setTimeout(120_000); // requires doc generation + fact-checking
+    test.setTimeout(300_000); // requires doc generation + fact-checking with full doc context
     // Seed docs first
     const admin = new AdminPage(page);
     await admin.goto();

--- a/tests/wiki_acceptance_tests.rs
+++ b/tests/wiki_acceptance_tests.rs
@@ -98,7 +98,7 @@ fn wiki_mock_registry() -> Arc<ProviderRegistry> {
             "- **task**: Core execution primitive for deterministic work\n- **agent**: Stateful lifecycle actor with memory and handlers",
         )
         .with_response(
-            "answer this question",
+            "Do not invent syntax",
             "FORGE has 14 primitives including task, pure, flow, agent, pool, warden, and system. Each primitive serves a specific role in AI agent orchestration.",
         )
         .with_response(
@@ -125,7 +125,7 @@ fn wiki_mock_registry() -> Arc<ProviderRegistry> {
             "Generate a comprehensive reference",
             "# FORGE Reference\n\n## Tasks\n- seed_page: Store content\n- load_page: Retrieve content\n\n## Agents\n- content_manager: Full CRUD lifecycle\n- search_agent: Index and search\n- qa_agent: Answer questions",
         )
-        .with_response("classify", "reference")
+        .with_response("Classify the following", "reference")
         .with_default("mock wiki response");
 
     mock_registry_from(mock)
@@ -1460,10 +1460,10 @@ async fn wiki_confidence_tier_low() {
     // when we configure it that way.
     let mock = MockProvider::new("mock")
         .with_response(
-            "answer this question",
+            "Do not invent syntax",
             "I don't have enough information to answer that.",
         )
-        .with_response("classify", "general")
+        .with_response("Classify the following", "general")
         .with_default("mock");
 
     let program = load_wiki_program();
@@ -1510,10 +1510,10 @@ async fn wiki_confidence_tier_low() {
 async fn wiki_confidence_tier_medium() {
     let mock = MockProvider::new("mock")
         .with_response(
-            "answer this question",
+            "Do not invent syntax",
             "I'm not fully confident, but FORGE has 14 primitives.",
         )
-        .with_response("classify", "general")
+        .with_response("Classify the following", "general")
         .with_default("mock");
 
     let program = load_wiki_program();
@@ -1568,7 +1568,7 @@ async fn wiki_search_unsure_branch() {
             "Search query:",
             "I think the task primitive is the core execution unit. Possibly related to agents.",
         )
-        .with_response("classify", "reference")
+        .with_response("Classify the following", "reference")
         .with_default("mock");
 
     let program = load_wiki_program();
@@ -1607,7 +1607,7 @@ async fn wiki_search_else_branch() {
             "Search query:",
             "I'm not sure, I think it might be unclear, possibly it depends on context, I don't know exactly",
         )
-        .with_response("classify", "general")
+        .with_response("Classify the following", "general")
         .with_default("mock");
 
     let program = load_wiki_program();
@@ -1643,10 +1643,10 @@ async fn wiki_qa_unsure_branch() {
     // Q&A with 1 hedging phrase → .unsure → "I'm not fully confident" prefix
     let mock = MockProvider::new("mock")
         .with_response(
-            "answer this question",
+            "Do not invent syntax",
             "I think FORGE has multiple primitives for agent orchestration.",
         )
-        .with_response("classify", "general")
+        .with_response("Classify the following", "general")
         .with_default("mock");
 
     let program = load_wiki_program();
@@ -1684,10 +1684,10 @@ async fn wiki_qa_else_branch() {
     // Q&A with many hedging phrases → else → "I don't have enough information"
     let mock = MockProvider::new("mock")
         .with_response(
-            "answer this question",
+            "Do not invent syntax",
             "I'm not sure about this. I think it might be something, but it's unclear. Possibly it depends, I don't know",
         )
-        .with_response("classify", "general")
+        .with_response("Classify the following", "general")
         .with_default("mock");
 
     let program = load_wiki_program();


### PR DESCRIPTION
## Summary
- Added `gather_docs` task that loads all wiki page content from KV storage via `for` loop + `data.get`, returning a single formatted text block
- Updated `answer_question` to inject real doc content with "Use ONLY the documentation below. Do not invent syntax." grounding instructions
- Updated `search_docs` similarly so excerpts come from actual page content
- Fixed mock test patterns (`"classify"` → `"Classify the following"`, `"answer this question"` → `"Do not invent syntax"`) to avoid false matches when doc content is injected into prompts

Closes #122

## Test plan
- [x] All 51 Rust tests pass (including Q&A confidence tier and search branch tests)
- [x] `cargo fmt` and `cargo clippy` clean
- [ ] Manual: ask "What is a task in FORGE?" at `/ask` — answer uses real indentation-based syntax
- [ ] Manual: search "boundary" at `/search` — excerpts from actual docs
- [ ] E2E Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)