### PR TITLE
docs: wiki README, architecture guide, and top-level showcase (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Wiki documentation** — `examples/wiki/README.md` (quick start, configuration, endpoints, deployment guide) and `examples/wiki/ARCHITECTURE.md` (system diagrams, data/event flows, supervision tree, complete 14-primitive feature map); updated top-level README with wiki showcase section (#66)
+
 ### Fixed
 - **Wiki Auto Reference & Fact-Check Report UX** — fixed Record serialization leak (`{reference:` / `{report:` prefix) by changing `Value::Record` Display to output values instead of `{key: value}` debug format; moved `data.store` into generating stages; improved extraction prompts to produce structured markdown; restructured fact-check output with summary table and collapsible per-claim verdicts; added intro context to both pages (#124)
 - **Wiki Q&A, search, and auto-reference grounded in actual docs** — `answer_question`, `search_docs`, and `generate_docs` flow now inject real page content into the LLM context via `gather_docs`, eliminating hallucinated FORGE syntax (#122)

--- a/README.md
+++ b/README.md
@@ -377,6 +377,31 @@ This is not a toy example — it is the actual `forge-sensei` program that teach
 
 ---
 
+## See it in action — the FORGE Wiki
+
+The [`examples/wiki/`](examples/wiki/) directory contains a complete documentation wiki built in FORGE — ~580 lines that exercise all 14 language primitives in a real, working application. Browse docs, search with LLM-powered confidence gating, ask questions, and auto-generate verified reference documentation.
+
+What the wiki demonstrates:
+
+- **Agents** with persistent memory and typed state machines (`content_manager`, `search_agent`, `qa_agent`)
+- **Flows** with parallel DAG execution (3 LLM extractions in parallel, then generation, then fact-checking)
+- **Pools** with majority-vote verification (3 independent checkers per claim)
+- **Warden** supervision with 5 failure policies and escalation chains
+- **Events** for reactive cross-agent communication (content changes trigger search re-indexing)
+- **Confidence gating** from LLM output through to color-coded UI badges
+- **Pure** rendering functions enforcing the determinism boundary
+- **System** composition wiring agents with `>>`
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+forge serve examples/wiki/server.forge -s examples/wiki/shared.forge --watch
+# Open http://127.0.0.1:3000/home
+```
+
+See the [Wiki README](examples/wiki/README.md) for the full guide and [Architecture](examples/wiki/ARCHITECTURE.md) for system diagrams and the complete feature map.
+
+---
+
 ## The nine principles
 
 Every feature in FORGE traces to one of nine principles. Every design decision is a refusal or an affirmation of these beliefs.
@@ -585,6 +610,7 @@ task analyze_contract
 ✅ system orchestration          — multi-agent wiring with shared event bus
 ✅ forge build                   — standalone native binaries with CLI + REPL
 ✅ forge-sensei                  — self-referential learning agent (FORGE teaching FORGE)
+✅ Wiki showcase                 — documentation wiki using all 14 primitives
 ```
 
 ### Coming next
@@ -593,7 +619,6 @@ task analyze_contract
 ⬜ Web runtime                   — HTML templates, static serving, hot-reload
 ⬜ HTTP client                   — web.fetch, webhooks, external integrations
 ⬜ WASM compilation              — Cranelift backend, browser target
-⬜ Wiki showcase                 — first real FORGE application
 ```
 
 ### Future layers

--- a/examples/wiki/ARCHITECTURE.md
+++ b/examples/wiki/ARCHITECTURE.md
@@ -1,0 +1,243 @@
+# FORGE Wiki Architecture
+
+The wiki is a documentation site built entirely in FORGE. It exists to prove that FORGE's primitives compose into a real, working application — not a toy. Every language feature appears at least once, and every component serves a real purpose.
+
+---
+
+## System diagram
+
+```
+                          ┌──────────────────────────────────────┐
+                          │         warden wiki_supervisor       │
+                          │   crash · stuck · hallucination ·    │
+                          │   timeout · budget → escalate        │
+                          └────────────┬─────────────────────────┘
+                                       │ manages
+              ┌────────────────────────┼────────────────────────┐
+              │                        │                        │
+     ┌────────▼────────┐     ┌────────▼────────┐     ┌────────▼────────┐
+     │ content_manager  │     │  search_agent   │     │    qa_agent     │
+     │  PageLifecycle   │────▶│  subscribe ×3   │────▶│  answer_question│
+     │  CRUD + states   │emit │  search + ask   │     │  + tracking     │
+     └────────┬─────────┘     └────────┬────────┘     └────────┬────────┘
+              │                        │                        │
+              │ data.store/get         │ search_docs            │ answer_question
+              ▼                        ▼                        ▼
+     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+     │   ReDB (pages)  │     │   LLM (reason)  │     │   LLM (reason)  │
+     └─────────────────┘     └─────────────────┘     └─────────────────┘
+
+     ──────────── event bus: PageCreated · PageUpdated · PagePublished ────────────
+
+                                  ┌──────────┐
+     8 endpoints ────────────────▶│ pure HTML │──▶ browser
+     (home, docs, search, ask,    │ helpers   │
+      api_search, ask_form,       └──────────┘
+      admin_generate_docs,
+      admin_fact_check)
+```
+
+---
+
+## Component inventory
+
+| Component | Primitive | Purpose |
+|-----------|-----------|---------|
+| `wiki_head`, `nav_bar`, `docs_sidebar`, `hero_section`, `feature_cards`, `page_layout`, `docs_layout`, `not_found_page`, `search_results_html`, `qa_page`, `ask_form_page`, `confidence_tier` | `pure` | Deterministic HTML rendering — no LLM calls allowed |
+| `seed_page`, `load_page`, `gather_docs` | `task` | Data operations: store, retrieve, list pages |
+| `search_docs` | `task` | LLM search with `classify` + `reason` + `when` confidence gating |
+| `answer_question` | `task` | LLM Q&A with `reason` + `when` confidence gating |
+| `content_manager` | `agent` | Stateful page CRUD with lifecycle, persistent memory, event emission |
+| `search_agent` | `agent` | Reactive search index — subscribes to content events |
+| `qa_agent` | `agent` | Q&A wrapper with question tracking |
+| `generate_docs` | `flow` | 5-stage DAG: scan → extract (parallel ×3) → generate → fact-check → publish |
+| `fact_check_panel` | `pool` | 3 workers, majority strategy, 30s timeout, fallback |
+| `fact_check_detail` | `pool` | 3 workers, all strategy (collects every verdict) |
+| `wiki_supervisor` | `warden` | Supervises all 3 agents with 5 failure policies |
+| `forge_wiki` | `system` | Wires agents: `content >> search >> qa` |
+| `PageLifecycle` | `states` | State machine: draft → review → published → archived |
+| `PageCreated`, `PageUpdated`, `PagePublished` | `event` | Typed cross-agent notifications |
+| `home`, `docs`, `search_page`, `ask_form`, `ask_page`, `api_search`, `admin_generate_docs`, `admin_fact_check` | `endpoint` | HTTP routes returning Html or Text |
+| `requires lifecycle == ...` | `requires` | Guard clauses on state transitions |
+| `when results.sure / .unsure` | `when` | Confidence-aware branching |
+| `#! boundary: server` / `shared` | `boundary` | Server/shared compilation boundary |
+| `fn main` | `fn` | Entry point |
+
+---
+
+## Data flow
+
+A typical request follows this path:
+
+```
+Browser                  FORGE Runtime                    LLM / Data Store
+  │                          │                                │
+  │  GET /docs?slug=agent    │                                │
+  │─────────────────────────▶│                                │
+  │                          │  data.get("page:agent")        │
+  │                          │───────────────────────────────▶│
+  │                          │◀───────────────────────────────│
+  │                          │  markdown.render(content)      │
+  │                          │  docs_sidebar(slug)            │
+  │                          │  docs_layout(slug, sidebar,    │
+  │                          │              rendered)          │
+  │◀─────────────────────────│                                │
+  │         Html             │                                │
+```
+
+LLM-powered requests add a reasoning step:
+
+```
+  GET /ask_page?question=... → answer_question(question)
+                              → gather_docs() → data.list("page:")
+                              → reason "..." with docs context
+                              → when answer.sure → answer
+                                when answer.unsure → qualified answer
+                                else → "I don't have enough information"
+                              → confidence_tier(answer)
+                              → qa_page(question, rendered, confidence)
+```
+
+---
+
+## Event flow
+
+Content changes propagate through typed events to reactive subscribers:
+
+```
+content_manager                    event bus                  search_agent
+  │                                   │                           │
+  │  emit PageCreated(slug, title)    │                           │
+  │──────────────────────────────────▶│                           │
+  │                                   │  on PageCreated           │
+  │                                   │──────────────────────────▶│
+  │                                   │     index_version += 1    │
+  │                                   │                           │
+  │  emit PageUpdated(slug)           │                           │
+  │──────────────────────────────────▶│                           │
+  │                                   │  on PageUpdated           │
+  │                                   │──────────────────────────▶│
+  │                                   │     index_version += 1    │
+```
+
+Events are defined in `shared.forge` (the `shared` boundary) so both server and future client code can reference them.
+
+---
+
+## Supervision tree
+
+The `wiki_supervisor` warden manages all three agents with escalating recovery policies:
+
+| Failure | First response | Escalation |
+|---------|---------------|------------|
+| `hallucination` | `restart, self` | After 3: `escalate` |
+| `stuck` | `nudge, self` | After 5: `restart` |
+| `crash` | `restart, self` | After 3: `escalate` |
+| `timeout` | `restart, self` | — |
+| `budget` | `downgrade, self` | After 2: `escalate` |
+
+Global rate limit: `max_retries 10 per 1h then escalate`.
+
+The `self` directive means the agent attempts self-recovery before the warden intervenes. On escalation, the agent is removed from the supervision tree — the wiki continues serving with degraded functionality.
+
+---
+
+## Confidence pipeline
+
+Confidence flows from LLM output through to the UI:
+
+```
+LLM (reason)                    FORGE runtime              Pure rendering
+  │                                 │                          │
+  │  uncertain<Text>                │                          │
+  │────────────────────────────────▶│                          │
+  │                                 │  when .sure → answer     │
+  │                                 │  when .unsure → "I'm     │
+  │                                 │    not fully confident…"  │
+  │                                 │  else → "I don't have    │
+  │                                 │    enough information…"   │
+  │                                 │                          │
+  │                                 │  confidence_tier(answer)  │
+  │                                 │─────────────────────────▶│
+  │                                 │  "high" / "medium" /     │
+  │                                 │  "low confidence"        │
+  │                                 │                          │
+  │                                 │  qa_page(q, answer,      │
+  │                                 │          confidence)      │
+  │                                 │─────────────────────────▶│
+  │                                 │    badge-success (green)  │
+  │                                 │    badge-warning (yellow) │
+  │                                 │    badge-error (red)      │
+```
+
+The text markers ("don't have enough information", "not fully confident") act as confidence signals that `confidence_tier` maps to UI badges. This is a pure function — no LLM call, no ambiguity.
+
+---
+
+## Doc generation flow
+
+The `generate_docs` flow is a 5-stage DAG with parallel extraction:
+
+```
+Wave 0:  scan_files
+              │
+    ┌─────────┼──────────┐
+    ▼         ▼          ▼
+Wave 1:  extract_    extract_    extract_
+         tasks       agents      flows        ← parallel
+    │         │          │
+    └─────────┼──────────┘
+              ▼
+Wave 2:  generate_reference
+              │
+              ▼
+Wave 3:  fact_check  ← uses pool (majority vote)
+              │
+              ▼
+Wave 4:  publish  ← emits PageUpdated
+```
+
+Each extraction stage uses `reason` with anti-hallucination guardrails ("Use ONLY what appears in the documentation. Do not invent syntax."). The `generate_reference` stage combines all extractions into a single markdown document. The `fact_check` stage runs the document through the verification pool before publishing.
+
+---
+
+## Fact-check pools
+
+Two pools with different strategies verify generated documentation:
+
+**`fact_check_panel`** — majority vote (2 of 3 must agree):
+- 3 `fact_checker` workers run in parallel
+- Each gets the same claim and returns YES/NO with explanation
+- `strategy: majority` — the consensus answer wins
+- 30s timeout with `fact_check_fallback` on expiry
+
+**`fact_check_detail`** — all verdicts collected:
+- Same 3 workers, but `strategy: all` preserves every verdict
+- Used to show individual worker reasoning in collapsible UI details
+
+The `verify_document` task orchestrates both pools per claim, classifies verdicts (PASS / NEEDS_REVIEW / FAIL), and builds a summary table with per-claim details.
+
+---
+
+## Feature map
+
+Every one of FORGE's 14 primitives is used in this wiki:
+
+| # | Primitive | Where in `server.forge` | Why |
+|---|-----------|------------------------|-----|
+| 1 | `task` | Lines 133–191, 376–463 | Data ops, LLM search/QA, fact-checking |
+| 2 | `pure` | Lines 25–128 | All HTML rendering — determinism boundary enforced |
+| 3 | `flow` | Lines 316–368 | Multi-stage doc generation with parallel extraction |
+| 4 | `agent` | Lines 198–303, 470–487 | Stateful content, search, and QA agents |
+| 5 | `pool` | Lines 400–409 | Parallel fact-checking with majority vote |
+| 6 | `system` | Lines 517–523 | Wires agents with `>>` composition |
+| 7 | `warden` | Lines 494–511 | Supervises all agents with failure policies |
+| 8 | `event` | `shared.forge` lines 19–27 | PageCreated, PageUpdated, PagePublished |
+| 9 | `states` | `shared.forge` lines 31–36 | PageLifecycle state machine |
+| 10 | `when` | Lines 171–173, 188–190, 327–329, 381–383, 390–392, 415–417 | Confidence-aware branching throughout |
+| 11 | `boundary` | Line 1 (`server`), `shared.forge` line 1 (`shared`) | Server/shared compilation boundary |
+| 12 | `requires` | Lines 209, 210, 230, 238, 247, 252, 257 | Guard clauses on lifecycle transitions |
+| 13 | `endpoint` | Lines 529–574 | 8 HTTP routes serving the web UI |
+| 14 | `fn` | Lines 578–581 | Entry point (`fn main`) |
+
+Additional builtins used: `use` (imports), `say` (logging), `emit` (events), `subscribe` (reactive handlers), `transition to` (state changes), `memory persistent` (ACID storage), `classify` (LLM classification), `reason` (LLM reasoning), `data.store`/`data.get`/`data.list` (persistence), `markdown.render` (markdown to HTML).

--- a/examples/wiki/README.md
+++ b/examples/wiki/README.md
@@ -1,0 +1,199 @@
+# FORGE Wiki
+
+A documentation wiki built entirely in FORGE, showcasing all 14 language primitives in a single, working application. Browse docs, search with LLM-powered confidence gating, ask questions, and auto-generate verified reference documentation — all defined in ~580 lines of FORGE.
+
+## Prerequisites
+
+- **FORGE** built from source: `cargo build` in the repo root
+- **Anthropic API key** with access to Claude Sonnet
+
+## Quick start
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+forge serve examples/wiki/server.forge -s examples/wiki/shared.forge --watch
+```
+
+Open [http://127.0.0.1:3000/home](http://127.0.0.1:3000/home).
+
+The `--watch` flag enables hot-reload on file changes. Content from `content/` is seeded automatically on startup.
+
+## Configuration
+
+All configuration lives in [`forge.config.toml`](forge.config.toml):
+
+```toml
+[llm]
+default = "wiki-provider"
+
+[providers.wiki-provider]
+type = "anthropic"
+model = "claude-sonnet-4-20250514"
+api_key = "${ANTHROPIC_API_KEY}"
+timeout_secs = 60
+
+[server]
+host = "127.0.0.1"
+port = 3000
+
+[server.static]
+root = "examples/wiki/static"
+prefix = "/static"
+```
+
+| Key | Purpose |
+|-----|---------|
+| `providers.*.type` | LLM provider (`anthropic`, `openai`, etc.) |
+| `providers.*.model` | Model ID for LLM calls |
+| `providers.*.api_key` | API key — use `${ENV_VAR}` syntax to read from environment |
+| `providers.*.timeout_secs` | Per-call timeout for LLM requests |
+| `server.host` / `server.port` | Bind address and port |
+| `server.static.root` | Directory for static files (CSS, JS, images) |
+| `server.static.prefix` | URL prefix for static file routes |
+
+## Content management
+
+Wiki pages are markdown files in `content/`:
+
+```
+content/
+  home.md                   Landing page
+  getting-started.md        Installation and first program
+  principles.md             The 9 first principles
+  roadmap.md                Development roadmap
+  reference/
+    task.md                 task primitive reference
+    agent.md                agent primitive reference
+    flow.md                 flow primitive reference
+    pool.md                 pool primitive reference
+    system.md               system primitive reference
+    event.md                event primitive reference
+    states.md               states primitive reference
+    when.md                 when primitive reference
+    pure.md                 pure primitive reference
+    boundary.md             boundary primitive reference
+    requires.md             requires primitive reference
+    warden.md               warden primitive reference
+```
+
+Pages are stored in ReDB via `data.store("page:{slug}", content)` and retrieved with `data.get("page:{slug}")`. The slug maps directly to the filename (without `.md`). To add a page, create a markdown file in `content/` and add its slug to the sidebar in the `docs_sidebar` pure function in `server.forge`.
+
+## Endpoints
+
+| Route | Method | Returns | Description |
+|-------|--------|---------|-------------|
+| `/home` | GET | Html | Landing page with hero section and feature cards |
+| `/docs?slug=<slug>` | GET | Html | Render a documentation page by slug |
+| `/search_page?q=<query>` | GET | Html | LLM-powered search with confidence gating |
+| `/ask_form` | GET | Html | Question form for the Q&A agent |
+| `/ask_page?question=<q>` | GET | Html | LLM answer with confidence badge |
+| `/api_search?q=<query>` | GET | Text | JSON API for programmatic search |
+| `/admin_generate_docs` | GET | Html | Trigger auto-reference doc generation flow |
+| `/admin_fact_check?slug=<slug>` | GET | Html | Run fact-check pool on a specific page |
+
+## Admin features
+
+### Auto-reference generation
+
+Visit `/admin_generate_docs` to trigger the `generate_docs` flow. This runs a 5-stage pipeline:
+
+1. **scan_files** — loads all page content
+2. **extract_tasks / extract_agents / extract_flows** — three LLM extractions run in parallel
+3. **generate_reference** — combines extractions into a markdown reference doc
+4. **fact_check** — verifies claims through a 3-worker majority-vote pool
+5. **publish** — stores results and emits update events
+
+The generated reference appears at `/docs?slug=auto-reference` and the fact-check report at `/docs?slug=fact-check-report`.
+
+### Per-page fact checking
+
+Visit `/admin_fact_check?slug=<slug>` to verify any page. Each claim is extracted, sent to 3 independent checkers, and classified as PASS / NEEDS_REVIEW / FAIL based on consensus.
+
+## Project structure
+
+```
+examples/wiki/
+  server.forge              Main application (~580 lines)
+  shared.forge              Types, events, and state machine (shared boundary)
+  client.forge              Client-side stub (future WASM target)
+  forge.config.toml         Provider, server, and static file config
+  ARCHITECTURE.md           System diagrams and feature map
+  README.md                 This file
+  content/                  Markdown documentation pages
+    home.md
+    getting-started.md
+    principles.md
+    roadmap.md
+    reference/              Per-primitive reference docs (12 files)
+  static/
+    css/style.css           Custom styles (DaisyUI theme, code blocks, animations)
+    js/app.js               Client interactivity (theme toggle, form interceptors)
+    js/forge-highlight.js   Prism.js language definition for FORGE syntax
+  .forge-data/
+    server.redb             ReDB database (page content, agent memory, events)
+```
+
+## Deployment
+
+### Production considerations
+
+**Tailwind CSS** — The wiki uses Tailwind via CDN for development convenience. For production, replace with a built CSS file:
+
+```bash
+# Install standalone Tailwind CLI
+curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-arm64
+chmod +x tailwindcss-macos-arm64
+
+# Build production CSS
+./tailwindcss-macos-arm64 -i static/css/style.css -o static/css/tailwind.out.css --minify
+```
+
+Then update `wiki_head` in `server.forge` to reference the local CSS instead of the CDN script tag.
+
+**Environment variables:**
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # Required: LLM provider key
+```
+
+### Running with `forge serve`
+
+```bash
+forge serve examples/wiki/server.forge \
+  -s examples/wiki/shared.forge \
+  --watch                                # optional: hot-reload on changes
+```
+
+### Reverse proxy (nginx)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name wiki.example.com;
+
+    ssl_certificate     /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Reverse proxy (Caddy)
+
+```
+wiki.example.com {
+    reverse_proxy 127.0.0.1:3000
+}
+```
+
+Caddy handles SSL automatically via Let's Encrypt.
+
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagrams, data flow, supervision tree, and a complete map of every FORGE primitive used in this wiki.


### PR DESCRIPTION
## Summary

- Add `examples/wiki/README.md` — quick start, configuration guide, endpoint table, content management, project structure, and deployment guide (nginx/caddy snippets, production Tailwind build)
- Add `examples/wiki/ARCHITECTURE.md` — system diagram, component inventory, data flow, event flow, supervision tree, confidence pipeline, doc generation flow, fact-check pools, and complete 14-primitive feature map with line references
- Update top-level `README.md` with "See it in action — the FORGE Wiki" showcase section after "The agent ecosystem"; move Wiki from "Coming next" to "Working today" checklist

Closes #66

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 52 passed, 0 failed
- [x] Verify README quick start works: `forge serve examples/wiki/server.forge -s examples/wiki/shared.forge --watch` — starts, seeds 16 pages, lists all routes
- [x] Verify all 8 endpoint routes listed match actual `server.forge` endpoints
- [x] Verify ARCHITECTURE.md feature map line numbers match current `server.forge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)