### PR TITLE
refactor: unify tool-use into CompletionRequest/Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`exec` primitive** — first-class CLI execution expression (`exec "command"`) that runs shell commands and returns `uncertain<Text>` with confidence derived from exit code (0 → 0.9, non-zero → 0.3); enforced by pure checker (exec in pure = compile error), uncertain checker (must handle with `when`), and accountability tracer (`exec_call`/`exec_return` events); composes via `>>` with LLM operations (#40)
 - **Host skill bridge** — LLM-mediated execution of SKILL.md ecosystem skills via `skill.namespace.method()` syntax; skills loaded from directories, parsed from YAML frontmatter, executed through an agentic loop where the LLM reads instructions and uses tools (bash, HTTP); results wrapped as `uncertain<T>` with confidence capped at 0.99; pure checker rejects skill calls; full trace events (`skill_call`/`skill_return`); config via `[skills]` TOML section (#40)
-- **LLM tool-use extension** — `LLMProvider` trait extended with `complete_with_tools()` for multi-turn tool-use; `ToolDefinition`, `ToolCallRequest`, `CompletionWithToolsResponse` types; `ProviderRegistry::resolve_and_complete_with_tools()` method; default implementation falls back to regular completion (#40)
+- **LLM tool-use extension** — `ToolDefinition` and `ToolCallRequest` types for LLM tool-use; `MockProvider::with_tool_call_response()` for tool-call simulation in tests (#40)
 - **`ConfidenceSource::ExecResult`** — confidence source for CLI execution results, capped at 0.95 (#40)
 - **`ConfidenceSource::SkillInvocation`** — confidence source for external skill results, capped at 0.99 (#40)
 - **Wiki documentation** — `examples/wiki/README.md` (quick start, configuration, endpoints, deployment guide) and `examples/wiki/ARCHITECTURE.md` (system diagrams, data/event flows, supervision tree, complete 14-primitive feature map); updated top-level README with wiki showcase section (#66)
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Wiki Q&A, search, and auto-reference grounded in actual docs** — `answer_question`, `search_docs`, and `generate_docs` flow now inject real page content into the LLM context via `gather_docs`, eliminating hallucinated FORGE syntax (#122)
 
 ### Changed
+- **Unified tool-use into CompletionRequest/Response** — `tools` field on `CompletionRequest` and `tool_calls` field on `CompletionResponse` replace the separate `complete_with_tools()` trait method, `CompletionWithToolsResponse` type, and `resolve_and_complete_with_tools()` registry method; tool-use requests now get the same fallback chain as standard completions; eliminates duplicate `estimate_confidence()` code (#133)
 - **Wiki UX polish** — doc links show dotted underline with highlight on hover; search results styled as card-like items; confidence badges color-coded (green/yellow/red); theme toggle uses sun/moon icons; activity log gets subtle border (#120)
 - **Wiki search and Q&A link to doc pages** — LLM responses now include markdown links to relevant documentation pages (e.g. `[agent](/docs?slug=agent)`) instead of plain text mentions (#120)
 

--- a/src/llm/cost_tracker.rs
+++ b/src/llm/cost_tracker.rs
@@ -102,6 +102,7 @@ mod tests {
     fn mock_response(cost: f32, tokens_in: u32, tokens_out: u32) -> CompletionResponse {
         CompletionResponse {
             content: "test".to_string(),
+            tool_calls: vec![],
             tokens_in,
             tokens_out,
             latency_ms: 1,

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -72,6 +72,7 @@ pub struct CompletionRequest {
     pub temperature: f32,
     pub stop_sequences: Vec<String>,
     pub json_mode: bool,
+    pub tools: Vec<ToolDefinition>,
 }
 
 impl CompletionRequest {
@@ -83,7 +84,13 @@ impl CompletionRequest {
             temperature: 0.7,
             stop_sequences: vec![],
             json_mode: false,
+            tools: vec![],
         }
+    }
+
+    pub fn with_tools(mut self, tools: Vec<ToolDefinition>) -> Self {
+        self.tools = tools;
+        self
     }
 
     pub fn with_system(mut self, system: impl Into<String>) -> Self {
@@ -105,6 +112,7 @@ impl CompletionRequest {
 #[derive(Debug, Clone)]
 pub struct CompletionResponse {
     pub content: String,
+    pub tool_calls: Vec<ToolCallRequest>,
     pub tokens_in: u32,
     pub tokens_out: u32,
     pub latency_ms: u64,
@@ -189,41 +197,6 @@ pub struct ToolCallRequest {
     pub arguments: serde_json::Value,
 }
 
-/// Response from an LLM call that may include tool use requests.
-#[derive(Debug, Clone)]
-pub struct CompletionWithToolsResponse {
-    pub content: String,
-    pub tool_calls: Vec<ToolCallRequest>,
-    pub tokens_in: u32,
-    pub tokens_out: u32,
-    pub latency_ms: u64,
-    pub cost_usd: f32,
-    pub model_used: String,
-    pub provider_name: String,
-}
-
-impl CompletionWithToolsResponse {
-    /// Heuristic confidence (same as CompletionResponse).
-    pub fn estimate_confidence(&self) -> f32 {
-        let hedging_phrases = [
-            "i'm not sure",
-            "i think",
-            "possibly",
-            "might be",
-            "i cannot",
-            "i don't know",
-            "unclear",
-            "it depends",
-        ];
-        let lower = self.content.to_lowercase();
-        let hedge_count = hedging_phrases
-            .iter()
-            .filter(|p| lower.contains(*p))
-            .count();
-        (0.85 - (hedge_count as f32 * 0.08)).max(0.3)
-    }
-}
-
 // ── The trait every provider implements ────────────────────────────────────────
 
 #[async_trait]
@@ -235,26 +208,6 @@ pub trait LLMProvider: Send + Sync {
         &self,
         request: CompletionRequest,
     ) -> Result<CompletionResponse, ProviderError>;
-
-    /// Complete with tool-use support (for skill execution).
-    /// Default implementation falls back to regular complete() with no tool calls.
-    async fn complete_with_tools(
-        &self,
-        request: CompletionRequest,
-        _tools: &[ToolDefinition],
-    ) -> Result<CompletionWithToolsResponse, ProviderError> {
-        let resp = self.complete(request).await?;
-        Ok(CompletionWithToolsResponse {
-            content: resp.content,
-            tool_calls: vec![],
-            tokens_in: resp.tokens_in,
-            tokens_out: resp.tokens_out,
-            latency_ms: resp.latency_ms,
-            cost_usd: resp.cost_usd,
-            model_used: resp.model_used,
-            provider_name: resp.provider_name,
-        })
-    }
 
     async fn health_check(&self) -> Result<(), ProviderError> {
         self.complete(CompletionRequest::simple("ping").with_max_tokens(1))

--- a/src/llm/providers/anthropic.rs
+++ b/src/llm/providers/anthropic.rs
@@ -234,6 +234,7 @@ impl LLMProvider for AnthropicProvider {
 
         Ok(CompletionResponse {
             content,
+            tool_calls: vec![],
             tokens_in,
             tokens_out,
             latency_ms,

--- a/src/llm/providers/mock.rs
+++ b/src/llm/providers/mock.rs
@@ -1,6 +1,6 @@
 use crate::llm::{
     CompletionRequest, CompletionResponse, LLMProvider, ProviderCapabilities, ProviderError,
-    QualityTier,
+    QualityTier, ToolCallRequest,
 };
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -13,6 +13,7 @@ pub struct MockProvider {
     responses: HashMap<String, String>,
     default_response: String,
     sequence: Option<(Vec<String>, Arc<AtomicUsize>)>,
+    tool_call_response: Option<Vec<ToolCallRequest>>,
 }
 
 impl MockProvider {
@@ -30,6 +31,7 @@ impl MockProvider {
             responses: HashMap::new(),
             default_response: "mock response".to_string(),
             sequence: None,
+            tool_call_response: None,
         }
     }
 
@@ -49,6 +51,12 @@ impl MockProvider {
     /// Takes priority over pattern-based and default responses.
     pub fn with_responses_sequence(mut self, responses: Vec<String>) -> Self {
         self.sequence = Some((responses, Arc::new(AtomicUsize::new(0))));
+        self
+    }
+
+    /// Simulate tool call responses from the LLM.
+    pub fn with_tool_call_response(mut self, tool_calls: Vec<ToolCallRequest>) -> Self {
+        self.tool_call_response = Some(tool_calls);
         self
     }
 }
@@ -74,10 +82,13 @@ impl LLMProvider for MockProvider {
                 .unwrap_or_else(|| self.default_response.clone())
         };
 
+        let tool_calls = self.tool_call_response.clone().unwrap_or_default();
+
         Ok(CompletionResponse {
             tokens_in: (req.prompt.len() / 4) as u32,
             tokens_out: (content.len() / 4) as u32,
             content,
+            tool_calls,
             latency_ms: 1,
             model_used: "mock-model".to_string(),
             provider_name: self.name.clone(),

--- a/src/llm/providers/openai_compat.rs
+++ b/src/llm/providers/openai_compat.rs
@@ -276,6 +276,7 @@ impl LLMProvider for OpenAICompatProvider {
 
         Ok(CompletionResponse {
             content,
+            tool_calls: vec![],
             tokens_in,
             tokens_out,
             latency_ms,

--- a/src/llm/registry.rs
+++ b/src/llm/registry.rs
@@ -1,8 +1,8 @@
 use crate::config::ForgeConfig;
 use crate::llm::providers::build_provider;
 use crate::llm::{
-    BoxedProvider, CapabilityHint, CompletionRequest, CompletionResponse,
-    CompletionWithToolsResponse, LLMProvider, ProviderError, ToolDefinition,
+    BoxedProvider, CapabilityHint, CompletionRequest, CompletionResponse, LLMProvider,
+    ProviderError,
 };
 use std::collections::HashMap;
 
@@ -166,24 +166,6 @@ impl ProviderRegistry {
         }
     }
 
-    /// Resolve provider and complete with tool-use support (for skill execution).
-    pub async fn resolve_and_complete_with_tools(
-        &self,
-        request: CompletionRequest,
-        tools: &[ToolDefinition],
-        hint: Option<&CapabilityHint>,
-    ) -> Result<CompletionWithToolsResponse, ProviderError> {
-        let provider_name = self.choose_provider(hint)?;
-        let provider =
-            self.providers
-                .get(&provider_name)
-                .ok_or_else(|| ProviderError::Unavailable {
-                    provider: provider_name.clone(),
-                    reason: "not found in registry".to_string(),
-                })?;
-        provider.complete_with_tools(request, tools).await
-    }
-
     pub fn get(&self, name: &str) -> Option<&BoxedProvider> {
         self.providers.get(name)
     }
@@ -310,6 +292,7 @@ mod tests {
             ) -> Result<CompletionResponse, ProviderError> {
                 Ok(CompletionResponse {
                     content: "cloud".to_string(),
+                    tool_calls: vec![],
                     tokens_in: 1,
                     tokens_out: 1,
                     latency_ms: 1,

--- a/src/runtime/skill_executor.rs
+++ b/src/runtime/skill_executor.rs
@@ -163,10 +163,12 @@ impl SkillExecutor {
         let mut prompt = initial_prompt.to_string();
 
         for turn in 0..self.max_turns {
-            let request = CompletionRequest::simple(&prompt).with_system(system.to_string());
+            let request = CompletionRequest::simple(&prompt)
+                .with_system(system.to_string())
+                .with_tools(tools.to_vec());
             let response = self
                 .providers
-                .resolve_and_complete_with_tools(request, tools, None)
+                .resolve_and_complete(request, None)
                 .await
                 .map_err(|e| SkillError::ProviderError(e.to_string()))?;
 

--- a/tests/provider_tests.rs
+++ b/tests/provider_tests.rs
@@ -47,6 +47,7 @@ async fn mock_health_check() {
 fn estimate_confidence_no_hedging() {
     let resp = CompletionResponse {
         content: "The answer is 42.".to_string(),
+        tool_calls: vec![],
         tokens_in: 10,
         tokens_out: 5,
         latency_ms: 50,
@@ -61,6 +62,7 @@ fn estimate_confidence_no_hedging() {
 fn estimate_confidence_with_hedging() {
     let resp = CompletionResponse {
         content: "I think it might be 42, but I'm not sure.".to_string(),
+        tool_calls: vec![],
         tokens_in: 10,
         tokens_out: 10,
         latency_ms: 50,
@@ -76,6 +78,7 @@ fn estimate_confidence_with_hedging() {
 fn estimate_confidence_floor() {
     let resp = CompletionResponse {
         content: "I'm not sure, I think it's possibly something, might be unclear, I don't know, it depends, I cannot say".to_string(),
+        tool_calls: vec![],
         tokens_in: 10, tokens_out: 20, latency_ms: 50,
         model_used: "test".to_string(), provider_name: "test".to_string(),
         cost_usd: 0.0,
@@ -119,6 +122,7 @@ fn budget_exceeded() {
     let resp = CompletionResponse {
         cost_usd: 0.002,
         content: "hello".to_string(),
+        tool_calls: vec![],
         tokens_in: 100,
         tokens_out: 50,
         latency_ms: 1,


### PR DESCRIPTION
## Summary

- Moves `tools` and `tool_calls` into the standard `CompletionRequest`/`CompletionResponse` types, eliminating the separate `complete_with_tools()` trait method, `CompletionWithToolsResponse` struct, and `resolve_and_complete_with_tools()` registry method
- Tool-use requests now get the same fallback chain as standard completions (fixes silent regression where tool-use skipped fallbacks)
- Net -43 lines: one type, one path, one confidence model

## Motivation

The split abstraction violated **Principle IV** (Composition Completeness) — tool-use was treated as an optional add-on requiring callers to choose which path to take. Tool-use IS completion; there is no "normal" and "special" oracle query.

## Changes

| File | What |
|---|---|
| `src/llm/mod.rs` | Add `tools`/`tool_calls` to request/response; remove `CompletionWithToolsResponse` and `complete_with_tools()` |
| `src/llm/registry.rs` | Remove `resolve_and_complete_with_tools()` |
| `src/llm/providers/mock.rs` | Add `with_tool_call_response()` for test simulation |
| `src/llm/providers/anthropic.rs` | Add `tool_calls: vec![]` to response |
| `src/llm/providers/openai_compat.rs` | Add `tool_calls: vec![]` to response |
| `src/runtime/skill_executor.rs` | Migrate to unified `complete()` path |
| `tests/provider_tests.rs` | Update response construction sites |
| `src/llm/cost_tracker.rs` | Update test helper |

Supersedes #128 and #129.
Closes #133.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — all 249 tests pass (197 unit + 52 integration)
- [x] `grep` for `complete_with_tools` / `CompletionWithToolsResponse` — zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)