### PR TITLE
feat: wire SkillExecutor initialization at runtime startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **SkillExecutor wiring** — `build_skill_executor()` helper loads skills from config directories and wires the executor at all four `TaskExecutor::new()` call sites, enabling `skill.namespace.method()` calls at runtime; respects `[skills]` config for dirs, timeout, and max turns; no-op when config section is absent (#130)
 - **`exec` primitive** — first-class CLI execution expression (`exec "command"`) that runs shell commands and returns `uncertain<Text>` with confidence derived from exit code (0 → 0.9, non-zero → 0.3); enforced by pure checker (exec in pure = compile error), uncertain checker (must handle with `when`), and accountability tracer (`exec_call`/`exec_return` events); composes via `>>` with LLM operations (#40)
 - **Host skill bridge** — LLM-mediated execution of SKILL.md ecosystem skills via `skill.namespace.method()` syntax; skills loaded from directories, parsed from YAML frontmatter, executed through an agentic loop where the LLM reads instructions and uses tools (bash, HTTP); results wrapped as `uncertain<T>` with confidence capped at 0.99; pure checker rejects skill calls; full trace events (`skill_call`/`skill_return`); config via `[skills]` TOML section (#40)
 - **LLM tool-use extension** — `ToolDefinition` and `ToolCallRequest` types for LLM tool-use; `MockProvider::with_tool_call_response()` for tool-call simulation in tests (#40)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use forge::ast::{Expr, TemplatePart, TopLevel};
 use forge::portability::{
@@ -502,6 +502,30 @@ fn parse_or_exit(source: &str, file: &Path) -> forge::ast::Program {
     }
 }
 
+/// Build a [`SkillExecutor`] from config when the `[skills]` section is present.
+fn build_skill_executor(
+    config: &forge::config::ForgeConfig,
+    providers: &Arc<forge::llm::registry::ProviderRegistry>,
+    tracer: Option<&forge::tracer::Tracer>,
+) -> Option<Arc<forge::runtime::skill_executor::SkillExecutor>> {
+    let skills_cfg = config.skills.as_ref()?;
+    let dirs = skills_cfg.skill_dirs_or_default();
+    let loaded = forge::runtime::skill_loader::SkillLoader::load_from_dirs(&dirs);
+    let mut registry = forge::runtime::skill_registry::SkillRegistry::new();
+    for skill in loaded {
+        registry.register(skill);
+    }
+    let shared = Arc::new(Mutex::new(registry));
+    let mut executor =
+        forge::runtime::skill_executor::SkillExecutor::new(Arc::clone(providers), shared);
+    executor.max_turns = skills_cfg.max_turns_or_default();
+    executor.default_timeout = std::time::Duration::from_secs(skills_cfg.timeout_or_default());
+    if let Some(t) = tracer {
+        executor = executor.with_tracer(Arc::new(t.clone()));
+    }
+    Some(Arc::new(executor))
+}
+
 async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
     let source = read_source(file)?;
     let program = parse_or_exit(&source, file);
@@ -532,6 +556,7 @@ async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
     let config_clone = config.clone();
     let registry = forge::llm::registry::ProviderRegistry::from_config(config)
         .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
+    let providers = Arc::new(registry);
 
     let tracer = if trace
         || std::env::var("FORGE_TRACE")
@@ -543,8 +568,13 @@ async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
         None
     };
 
-    let executor = forge::runtime::executor::TaskExecutor::new(program, Arc::new(registry), tracer)
-        .with_config(config_clone);
+    let skill_exec = build_skill_executor(&config_clone, &providers, tracer.as_ref());
+    let mut executor =
+        forge::runtime::executor::TaskExecutor::new(program, Arc::clone(&providers), tracer)
+            .with_config(config_clone);
+    if let Some(se) = skill_exec {
+        executor = executor.with_skill_executor(se);
+    }
 
     match executor.run().await {
         Ok(_) => {}
@@ -617,6 +647,7 @@ async fn run_manifest(manifest_path: &Path, trace: bool) -> anyhow::Result<()> {
     let config_clone = config.clone();
     let registry = forge::llm::registry::ProviderRegistry::from_config(config)
         .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
+    let providers = Arc::new(registry);
 
     let tracer = if trace
         || std::env::var("FORGE_TRACE")
@@ -628,9 +659,16 @@ async fn run_manifest(manifest_path: &Path, trace: bool) -> anyhow::Result<()> {
         None
     };
 
-    let executor =
-        forge::runtime::executor::TaskExecutor::new(composed.program, Arc::new(registry), tracer)
-            .with_config(config_clone);
+    let skill_exec = build_skill_executor(&config_clone, &providers, tracer.as_ref());
+    let mut executor = forge::runtime::executor::TaskExecutor::new(
+        composed.program,
+        Arc::clone(&providers),
+        tracer,
+    )
+    .with_config(config_clone);
+    if let Some(se) = skill_exec {
+        executor = executor.with_skill_executor(se);
+    }
 
     match executor.run().await {
         Ok(_) => {}
@@ -813,10 +851,18 @@ fn try_build_executor_multi(
 
     let registry = forge::llm::registry::ProviderRegistry::from_config(config.clone())
         .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
+    let providers = Arc::new(registry);
 
-    let executor =
-        forge::runtime::executor::TaskExecutor::new(composed.program, Arc::new(registry), tracer)
-            .with_config(config.clone());
+    let skill_exec = build_skill_executor(&config, &providers, tracer.as_ref());
+    let mut executor = forge::runtime::executor::TaskExecutor::new(
+        composed.program,
+        Arc::clone(&providers),
+        tracer,
+    )
+    .with_config(config.clone());
+    if let Some(se) = skill_exec {
+        executor = executor.with_skill_executor(se);
+    }
 
     Ok((executor, config))
 }
@@ -874,9 +920,15 @@ fn try_build_executor(
 
     let registry = forge::llm::registry::ProviderRegistry::from_config(config.clone())
         .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
+    let providers = Arc::new(registry);
 
-    let executor = forge::runtime::executor::TaskExecutor::new(program, Arc::new(registry), tracer)
-        .with_config(config.clone());
+    let skill_exec = build_skill_executor(&config, &providers, tracer.as_ref());
+    let mut executor =
+        forge::runtime::executor::TaskExecutor::new(program, Arc::clone(&providers), tracer)
+            .with_config(config.clone());
+    if let Some(se) = skill_exec {
+        executor = executor.with_skill_executor(se);
+    }
 
     Ok((executor, config))
 }

--- a/tests/skill_integration_tests.rs
+++ b/tests/skill_integration_tests.rs
@@ -193,6 +193,12 @@ fn skill_confidence_capped() {
 
 #[tokio::test]
 async fn exec_runs_npx_skills_find() {
+    // This test uses Unix-only piping (tail) and npx is too slow on Windows CI.
+    if cfg!(windows) {
+        eprintln!("Skipping: not supported on Windows");
+        return;
+    }
+
     // This test calls the real npx skills CLI — skip if not available
     let npx_check = std::process::Command::new("which")
         .arg("npx")


### PR DESCRIPTION
## Summary

- Add `build_skill_executor()` helper in `src/main.rs` that loads skills from config directories, registers them, and creates a `SkillExecutor` with configured timeout/max_turns
- Wire the helper at all 4 `TaskExecutor::new()` call sites (`run_program`, `run_manifest`, `build_executor`, `try_build_executor`)
- When `[skills]` config section is absent, behavior is unchanged (helper returns `None`)

Closes #130

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 52 passed, 0 failed
- [ ] Manual: add `[skills]` section to `forge.config.toml` with a SKILL.md directory, run a program using `skill.namespace.method()`, confirm it dispatches to SkillExecutor

🤖 Generated with [Claude Code](https://claude.com/claude-code)