### PR TITLE
feat: command background mode — process manager (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured argv form for `command`: `command ["git", "commit", "-m", msg]` — safe, no injection (#160)
 - `env` modifier for `command`: `command "build" env { RUST_LOG: "debug" }` (#160)
 - `command` runtime execution — synchronous process spawning with structured record return (`stdout`, `stderr`, `exit_code`, `success`) (#161)
+- `command` background mode — UUID handle-based lifecycle with `command.status()`, `command.output()`, `command.cancel()` (#162)
+- `CommandManager` process manager with incremental output buffering, timeout auto-cancel, and graceful shutdown (#162)
 
 ## [0.1.0] - 2026-04-09
 

--- a/conformance/runtime/command_background.json
+++ b/conformance/runtime/command_background.json
@@ -1,0 +1,11 @@
+{
+  "name": "command_background_spawn",
+  "category": "runtime",
+  "description": "Background command returns handle immediately and emits bg_spawn trace",
+  "input": "task run\n  gives Text\n  do\n    h = command \"echo bg_test\" background true timeout 10s\n    give h\n\nfn main\n  say run()\n",
+  "mock_responses": [],
+  "expected": {
+    "outcome": "run_ok",
+    "trace_shape": ["command_call", "command_bg_spawn"]
+  }
+}

--- a/examples/command_background.forge
+++ b/examples/command_background.forge
@@ -1,0 +1,15 @@
+# command acceptance test: background mode — spawn, poll status, get output
+task run_bg
+  gives Text
+  do
+    handle = command "echo bg_hello" background true timeout 10s
+    wait = command "sleep 0.2"
+    status = command.status(handle)
+    output = command.output(handle)
+    when status.sure -> say status.status
+    else -> say "uncertain"
+    when output.sure -> give output.stdout
+    else -> give "no_output"
+
+fn main
+  say run_bg()

--- a/examples/command_background_cancel.forge
+++ b/examples/command_background_cancel.forge
@@ -1,0 +1,13 @@
+# command acceptance test: background mode — cancel a running process
+task run_cancel
+  gives Text
+  do
+    handle = command "sleep 60" background true timeout 30s
+    command.cancel(handle)
+    wait = command "sleep 0.2"
+    status = command.status(handle)
+    when status.sure -> give status.status
+    else -> give "unknown"
+
+fn main
+  say run_cancel()

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -559,7 +559,8 @@ postfix_op   = {
 }
 
 pipe_term = {
-    command_expr
+    command_method_expr
+  | command_expr
   | exec_expr
   | find_expr
   | reason_expr
@@ -589,6 +590,8 @@ command_modifier = {
   | "env" ~ _s ~ env_map
 }
 command_expr = { "command" ~ _s ~ command_arg ~ (_s ~ command_modifier)* }
+command_method_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+command_method_expr = { "command" ~ "." ~ command_method_name ~ "(" ~ _s_opt ~ arg_list? ~ _s_opt ~ ")" }
 env_map      = { "{" ~ _s_opt ~ env_entry ~ (_s_opt ~ "," ~ _s_opt ~ env_entry)* ~ _s_opt ~ "}" }
 env_entry    = { ident ~ _s_opt ~ ":" ~ _s_opt ~ expr }
 reason_expr   = { "reason" ~ _s ~ string_arg }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -487,6 +487,8 @@ pub enum Expr {
     Exec(Box<Spanned<Expr>>),
     /// `command "cmd" [in "dir"] [timeout 60s] [background true]`
     Command(CommandExpr),
+    /// `command.status(handle)` / `command.output(handle)` / `command.cancel(handle)`
+    CommandMethod(Spanned<String>, Vec<Spanned<CallArg>>),
     /// `find "alias"` / `find all template [where lifecycle == state]`
     Find(Box<FindExpr>),
     /// `try expr or expr`

--- a/src/build.rs
+++ b/src/build.rs
@@ -468,9 +468,10 @@ async fn main() -> anyhow::Result<()> {{
     let config = resolve_config();
     let registry = forge::llm::registry::ProviderRegistry::from_config(config)
         .map_err(|e| anyhow::anyhow!("provider setup failed: {{}}", e))?;
+    let cmd_mgr = Arc::new(std::sync::Mutex::new(forge::runtime::command_manager::CommandManager::new()));
     let executor = forge::runtime::executor::TaskExecutor::new(
         program, Arc::new(registry), None,
-    );
+    ).with_command_manager(cmd_mgr);
     match executor.run().await {{
         Ok(_) => Ok(()),
         Err(e) => {{
@@ -802,9 +803,10 @@ async fn main() -> anyhow::Result<()> {{
 
     let registry = forge::llm::registry::ProviderRegistry::from_config(config.clone())
         .map_err(|e| anyhow::anyhow!("provider setup failed: {{}}", e))?;
+    let cmd_mgr = Arc::new(std::sync::Mutex::new(forge::runtime::command_manager::CommandManager::new()));
     let executor = forge::runtime::executor::TaskExecutor::new(
         program, Arc::new(registry), None,
-    );
+    ).with_command_manager(cmd_mgr);
     let event_bus = forge::runtime::event_bus::EventBus::new_shared(None);
     let mut server = forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref())
         .with_event_bus(event_bus);

--- a/src/checker/boundary_checker.rs
+++ b/src/checker/boundary_checker.rs
@@ -487,6 +487,11 @@ fn check_refs_in_expr(
                 }
             }
         }
+        Expr::CommandMethod(_, args) => {
+            for arg in args {
+                check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
+            }
+        }
         Expr::Search(inner) => {
             if boundary != BoundaryKind::Server {
                 let boundary_name = match boundary {

--- a/src/checker/pure_checker.rs
+++ b/src/checker/pure_checker.rs
@@ -334,7 +334,7 @@ fn check_pure_expr(
                 span_end: expr.span.end,
             });
         }
-        Expr::Command(_) => {
+        Expr::Command(_) | Expr::CommandMethod(_, _) => {
             errors.push(CheckError::PureUsesLlm {
                 name: fn_name.to_string(),
                 op: "command",

--- a/src/checker/requires_checker.rs
+++ b/src/checker/requires_checker.rs
@@ -183,7 +183,7 @@ fn check_requires_expr(
                 .with_help("use a `pure` function instead"),
             );
         }
-        Expr::Command(_) => {
+        Expr::Command(_) | Expr::CommandMethod(_, _) => {
             diagnostics.push(
                 Diagnostic::warning(
                     file,

--- a/src/checker/uncertain_checker.rs
+++ b/src/checker/uncertain_checker.rs
@@ -140,6 +140,7 @@ fn expr_is_oracle(expr: &Spanned<Expr>) -> bool {
             | Expr::Recall(_)
             | Expr::Exec(_)
             | Expr::Command(_)
+            | Expr::CommandMethod(_, _)
     )
 }
 

--- a/src/cost_estimator.rs
+++ b/src/cost_estimator.rs
@@ -208,7 +208,7 @@ impl CostWalker {
             Expr::Exec(_) => {
                 // exec has zero token cost (direct CLI, no LLM)
             }
-            Expr::Command(_) => {
+            Expr::Command(_) | Expr::CommandMethod(_, _) => {
                 // command has zero token cost (direct CLI, no LLM)
             }
             Expr::TryOr(a, b) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use forge::portability::{
     AgentSchema, SchemaField, SchemaKnowledgeConfig,
 };
 use forge::runtime::agent::AgentProcess;
+use forge::runtime::command_manager::CommandManager;
 use forge::runtime::confidence::{ConfidentValue, Value};
 use forge::runtime::knowledge_store::KnowledgeStore;
 
@@ -569,9 +570,11 @@ async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
     };
 
     let skill_exec = build_skill_executor(&config_clone, &providers, tracer.as_ref());
+    let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let mut executor =
         forge::runtime::executor::TaskExecutor::new(program, Arc::clone(&providers), tracer)
-            .with_config(config_clone);
+            .with_config(config_clone)
+            .with_command_manager(cmd_mgr);
     if let Some(se) = skill_exec {
         executor = executor.with_skill_executor(se);
     }
@@ -660,12 +663,14 @@ async fn run_manifest(manifest_path: &Path, trace: bool) -> anyhow::Result<()> {
     };
 
     let skill_exec = build_skill_executor(&config_clone, &providers, tracer.as_ref());
+    let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let mut executor = forge::runtime::executor::TaskExecutor::new(
         composed.program,
         Arc::clone(&providers),
         tracer,
     )
-    .with_config(config_clone);
+    .with_config(config_clone)
+    .with_command_manager(cmd_mgr);
     if let Some(se) = skill_exec {
         executor = executor.with_skill_executor(se);
     }
@@ -855,12 +860,14 @@ fn try_build_executor_multi(
     let providers = Arc::new(registry);
 
     let skill_exec = build_skill_executor(&config, &providers, tracer.as_ref());
+    let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let mut executor = forge::runtime::executor::TaskExecutor::new(
         composed.program,
         Arc::clone(&providers),
         tracer,
     )
-    .with_config(config.clone());
+    .with_config(config.clone())
+    .with_command_manager(cmd_mgr);
     if let Some(se) = skill_exec {
         executor = executor.with_skill_executor(se);
     }
@@ -925,9 +932,11 @@ fn try_build_executor(
     let providers = Arc::new(registry);
 
     let skill_exec = build_skill_executor(&config, &providers, tracer.as_ref());
+    let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let mut executor =
         forge::runtime::executor::TaskExecutor::new(program, Arc::clone(&providers), tracer)
-            .with_config(config.clone());
+            .with_config(config.clone())
+            .with_command_manager(cmd_mgr);
     if let Some(se) = skill_exec {
         executor = executor.with_skill_executor(se);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -552,6 +552,19 @@ fn build_command_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     ))
 }
 
+fn build_command_method_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
+    let span = to_span(&pair);
+    let mut inner = pair.into_inner();
+    let method_pair = inner.next().unwrap();
+    let method = spanned(method_pair.as_str().to_string(), &method_pair);
+    let args = if let Some(arg_list) = inner.next() {
+        build_arg_list(arg_list)?
+    } else {
+        Vec::new()
+    };
+    Ok(Spanned::new(Expr::CommandMethod(method, args), span))
+}
+
 fn build_reason_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     let span = to_span(&pair);
     let inner = pair.into_inner().next().unwrap();
@@ -609,6 +622,7 @@ fn build_try_or_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
 fn build_pipe_term(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     let inner = pair.into_inner().next().unwrap();
     match inner.as_rule() {
+        Rule::command_method_expr => build_command_method_expr(inner),
         Rule::command_expr => build_command_expr(inner),
         Rule::exec_expr => build_exec_expr(inner),
         Rule::find_expr => build_find_expr(inner),

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -204,6 +204,29 @@ impl CapabilityRegistry {
             },
         );
 
+        // command.status / command.output / command.cancel — issue #162
+        caps.insert(
+            "command.status".into(),
+            CapabilitySignature {
+                inputs: vec![ForgeType::Text],
+                output: ForgeType::Text,
+            },
+        );
+        caps.insert(
+            "command.output".into(),
+            CapabilitySignature {
+                inputs: vec![ForgeType::Text],
+                output: ForgeType::Text,
+            },
+        );
+        caps.insert(
+            "command.cancel".into(),
+            CapabilitySignature {
+                inputs: vec![ForgeType::Text],
+                output: ForgeType::Unit,
+            },
+        );
+
         Self { capabilities: caps }
     }
 
@@ -414,7 +437,7 @@ fn infer_type(expr: &Spanned<Expr>) -> Option<ForgeType> {
         Expr::Template(_) => Some(ForgeType::Text),
         Expr::Reason(_) => Some(ForgeType::Text),
         Expr::Exec(_) => Some(ForgeType::Text),
-        Expr::Command(_) => Some(ForgeType::Text),
+        Expr::Command(_) | Expr::CommandMethod(_, _) => Some(ForgeType::Text),
         Expr::Classify(_) => Some(ForgeType::Classification),
         Expr::Search(_) => Some(ForgeType::Results),
         Expr::Compose(parts) => parts.last().and_then(infer_type),
@@ -430,7 +453,7 @@ fn infer_input_type(expr: &Spanned<Expr>) -> Option<ForgeType> {
         Expr::Call(_) => Some(ForgeType::Text),
         Expr::Reason(_) => Some(ForgeType::Text),
         Expr::Exec(_) => Some(ForgeType::Text),
-        Expr::Command(_) => Some(ForgeType::Text),
+        Expr::Command(_) | Expr::CommandMethod(_, _) => Some(ForgeType::Text),
         Expr::Classify(_) => Some(ForgeType::Text),
         Expr::Search(_) => Some(ForgeType::Text),
         _ => None,

--- a/src/runtime/agent.rs
+++ b/src/runtime/agent.rs
@@ -360,9 +360,13 @@ impl AgentProcess {
             tracer.clone(),
         )));
 
+        let cmd_mgr = Arc::new(Mutex::new(
+            crate::runtime::command_manager::CommandManager::new(),
+        ));
         let mut executor = TaskExecutor::new(program, registry, tracer)
             .with_agent_context(context.clone())
-            .with_timer_engine(timer_engine.clone());
+            .with_timer_engine(timer_engine.clone())
+            .with_command_manager(cmd_mgr);
 
         // Wire instance registry into executor (issue #82)
         if let Some(ir) = instance_registry {

--- a/src/runtime/agent.rs
+++ b/src/runtime/agent.rs
@@ -656,6 +656,11 @@ impl AgentProcess {
         // Shutdown: cancel all active timers
         self.timer_engine.lock().unwrap().cancel_all();
 
+        // Shutdown: cancel all background commands (issue #162)
+        if let Some(mgr) = self.executor.command_manager() {
+            mgr.lock().unwrap().shutdown_all();
+        }
+
         // Wait for forwarder tasks to finish
         for h in handles {
             let _ = h.await;

--- a/src/runtime/command_manager.rs
+++ b/src/runtime/command_manager.rs
@@ -14,6 +14,7 @@ use tokio::sync::oneshot;
 use uuid::Uuid;
 
 use crate::runtime::confidence::{ConfidentValue, Value};
+use crate::tracer::Tracer;
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -80,6 +81,7 @@ impl CommandManager {
         mut child: Child,
         cmd_display: String,
         timeout: Option<Duration>,
+        tracer: Option<Tracer>,
     ) -> Result<HandleId, String> {
         let handle_id = Uuid::new_v4().to_string();
 
@@ -131,7 +133,10 @@ impl CommandManager {
         // Spawn watcher task — handles: natural exit, cancel, and timeout
         let state_for_wait = Arc::clone(&state);
         let timeout_dur = timeout;
+        let handle_for_trace = handle_id.clone();
         tokio::spawn(async move {
+            let start = std::time::Instant::now();
+
             // Create a future that sleeps for the timeout duration, or never
             // completes if no timeout is set.
             let timeout_fut = async {
@@ -141,24 +146,29 @@ impl CommandManager {
                 }
             };
 
-            tokio::select! {
+            let success = tokio::select! {
                 exit = child.wait() => {
                     let mut s = state_for_wait.lock().unwrap();
                     if s.status == ProcessStatus::Running {
                         match exit {
                             Ok(status) => {
+                                let ok = status.success();
                                 s.status = ProcessStatus::Completed {
                                     exit_code: status.code().unwrap_or(-1),
-                                    success: status.success(),
+                                    success: ok,
                                 };
+                                ok
                             }
                             Err(_) => {
                                 s.status = ProcessStatus::Completed {
                                     exit_code: -1,
                                     success: false,
                                 };
+                                false
                             }
                         }
+                    } else {
+                        false
                     }
                 }
                 _ = kill_rx => {
@@ -171,6 +181,7 @@ impl CommandManager {
                         s.status = ProcessStatus::Cancelled;
                     }
                     let _ = child.kill().await;
+                    false
                 }
                 _ = timeout_fut => {
                     // Timeout expired
@@ -182,7 +193,17 @@ impl CommandManager {
                         s.status = ProcessStatus::TimedOut;
                     }
                     let _ = child.kill().await;
+                    false
                 }
+            };
+
+            // Trace completion (Principle VIII — Accountability)
+            if let Some(ref t) = tracer {
+                t.command_bg_complete(
+                    &handle_for_trace,
+                    success,
+                    start.elapsed().as_millis() as u64,
+                );
             }
         });
 

--- a/src/runtime/command_manager.rs
+++ b/src/runtime/command_manager.rs
@@ -1,0 +1,298 @@
+// FORGE command manager — background process lifecycle (issue #162)
+//
+// Manages background command processes with UUID-based handles.
+// Processes are spawned with piped stdout/stderr; reader tasks accumulate
+// output lines into shared buffers that agents can poll via command.output().
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Child;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use crate::runtime::confidence::{ConfidentValue, Value};
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+pub type HandleId = String;
+pub type SharedCommandManager = Arc<Mutex<CommandManager>>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProcessStatus {
+    Running,
+    Completed { exit_code: i32, success: bool },
+    Cancelled,
+    TimedOut,
+}
+
+impl ProcessStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ProcessStatus::Running => "running",
+            ProcessStatus::Completed { .. } => "completed",
+            ProcessStatus::Cancelled => "cancelled",
+            ProcessStatus::TimedOut => "timed_out",
+        }
+    }
+}
+
+/// Shared interior state between the manager and background reader tasks.
+pub struct ProcessState {
+    pub id: HandleId,
+    pub status: ProcessStatus,
+    pub stdout_buf: Vec<String>,
+    pub stderr_buf: Vec<String>,
+    pub cmd_display: String,
+    pub started_at: Instant,
+}
+
+// ── CommandManager ───────────────────────────────────────────────────────────
+
+pub struct CommandManager {
+    processes: HashMap<HandleId, Arc<Mutex<ProcessState>>>,
+    /// Senders to request kill from the watcher task.
+    kill_senders: HashMap<HandleId, oneshot::Sender<()>>,
+}
+
+impl Default for CommandManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandManager {
+    pub fn new() -> Self {
+        Self {
+            processes: HashMap::new(),
+            kill_senders: HashMap::new(),
+        }
+    }
+
+    /// Spawn a background process. Returns a UUID handle immediately.
+    ///
+    /// The child must have stdout/stderr set to `Stdio::piped()` before calling.
+    /// Reader tasks buffer output lines; a watcher task collects exit status.
+    pub fn spawn_background(
+        &mut self,
+        mut child: Child,
+        cmd_display: String,
+        timeout: Option<Duration>,
+    ) -> Result<HandleId, String> {
+        let handle_id = Uuid::new_v4().to_string();
+
+        // Take piped streams from the child
+        let child_stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "child stdout not piped".to_string())?;
+        let child_stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| "child stderr not piped".to_string())?;
+
+        let state = Arc::new(Mutex::new(ProcessState {
+            id: handle_id.clone(),
+            status: ProcessStatus::Running,
+            stdout_buf: Vec::new(),
+            stderr_buf: Vec::new(),
+            cmd_display: cmd_display.clone(),
+            started_at: Instant::now(),
+        }));
+
+        // Kill channel: cancel sends (), watcher receives and kills child
+        let (kill_tx, kill_rx) = oneshot::channel::<()>();
+
+        self.processes.insert(handle_id.clone(), Arc::clone(&state));
+        self.kill_senders.insert(handle_id.clone(), kill_tx);
+
+        // Spawn stdout reader task
+        let state_for_stdout = Arc::clone(&state);
+        tokio::spawn(async move {
+            let reader = BufReader::new(child_stdout);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                state_for_stdout.lock().unwrap().stdout_buf.push(line);
+            }
+        });
+
+        // Spawn stderr reader task
+        let state_for_stderr = Arc::clone(&state);
+        tokio::spawn(async move {
+            let reader = BufReader::new(child_stderr);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                state_for_stderr.lock().unwrap().stderr_buf.push(line);
+            }
+        });
+
+        // Spawn watcher task — handles: natural exit, cancel, and timeout
+        let state_for_wait = Arc::clone(&state);
+        let timeout_dur = timeout;
+        tokio::spawn(async move {
+            // Create a future that sleeps for the timeout duration, or never
+            // completes if no timeout is set.
+            let timeout_fut = async {
+                match timeout_dur {
+                    Some(dur) => tokio::time::sleep(dur).await,
+                    None => std::future::pending::<()>().await,
+                }
+            };
+
+            tokio::select! {
+                exit = child.wait() => {
+                    let mut s = state_for_wait.lock().unwrap();
+                    if s.status == ProcessStatus::Running {
+                        match exit {
+                            Ok(status) => {
+                                s.status = ProcessStatus::Completed {
+                                    exit_code: status.code().unwrap_or(-1),
+                                    success: status.success(),
+                                };
+                            }
+                            Err(_) => {
+                                s.status = ProcessStatus::Completed {
+                                    exit_code: -1,
+                                    success: false,
+                                };
+                            }
+                        }
+                    }
+                }
+                _ = kill_rx => {
+                    // Cancel requested
+                    {
+                        let mut s = state_for_wait.lock().unwrap();
+                        if s.status != ProcessStatus::Running {
+                            return;
+                        }
+                        s.status = ProcessStatus::Cancelled;
+                    }
+                    let _ = child.kill().await;
+                }
+                _ = timeout_fut => {
+                    // Timeout expired
+                    {
+                        let mut s = state_for_wait.lock().unwrap();
+                        if s.status != ProcessStatus::Running {
+                            return;
+                        }
+                        s.status = ProcessStatus::TimedOut;
+                    }
+                    let _ = child.kill().await;
+                }
+            }
+        });
+
+        Ok(handle_id)
+    }
+
+    /// Get the status of a background process as a FORGE Record.
+    pub fn status(&self, handle: &str) -> Result<ConfidentValue, String> {
+        let state = self
+            .processes
+            .get(handle)
+            .ok_or_else(|| format!("unknown command handle: {}", handle))?;
+        let s = state.lock().unwrap();
+
+        let mut fields = HashMap::new();
+        fields.insert(
+            "status".to_string(),
+            ConfidentValue::from_exec(Value::Text(s.status.as_str().to_string()), 0.9),
+        );
+
+        match &s.status {
+            ProcessStatus::Completed { exit_code, success } => {
+                fields.insert(
+                    "exit_code".to_string(),
+                    ConfidentValue::from_exec(Value::Number(*exit_code as f64), 0.9),
+                );
+                fields.insert(
+                    "success".to_string(),
+                    ConfidentValue::from_exec(Value::Bool(*success), 0.9),
+                );
+            }
+            _ => {
+                fields.insert(
+                    "exit_code".to_string(),
+                    ConfidentValue::deterministic(Value::Unit),
+                );
+                fields.insert(
+                    "success".to_string(),
+                    ConfidentValue::deterministic(Value::Unit),
+                );
+            }
+        }
+
+        Ok(ConfidentValue::from_exec(Value::Record(fields), 0.9))
+    }
+
+    /// Get buffered output from a background process as a FORGE Record.
+    pub fn output(&self, handle: &str) -> Result<ConfidentValue, String> {
+        let state = self
+            .processes
+            .get(handle)
+            .ok_or_else(|| format!("unknown command handle: {}", handle))?;
+        let s = state.lock().unwrap();
+
+        let complete = s.status != ProcessStatus::Running;
+        let confidence = if complete { 0.9 } else { 0.5 };
+
+        let mut fields = HashMap::new();
+        fields.insert(
+            "stdout".to_string(),
+            ConfidentValue::from_exec(Value::Text(s.stdout_buf.join("\n")), confidence),
+        );
+        fields.insert(
+            "stderr".to_string(),
+            ConfidentValue::from_exec(Value::Text(s.stderr_buf.join("\n")), confidence),
+        );
+        fields.insert(
+            "complete".to_string(),
+            ConfidentValue::from_exec(Value::Bool(complete), 0.9),
+        );
+
+        Ok(ConfidentValue::from_exec(Value::Record(fields), confidence))
+    }
+
+    /// Cancel a background process. Sends kill signal via the oneshot channel.
+    pub fn cancel(&mut self, handle: &str) -> Result<(), String> {
+        let state = self
+            .processes
+            .get(handle)
+            .ok_or_else(|| format!("unknown command handle: {}", handle))?;
+        {
+            let s = state.lock().unwrap();
+            if s.status != ProcessStatus::Running {
+                return Ok(());
+            }
+        }
+
+        if let Some(tx) = self.kill_senders.remove(handle) {
+            let _ = tx.send(());
+        }
+
+        Ok(())
+    }
+
+    /// Shut down all running background processes.
+    pub fn shutdown_all(&mut self) {
+        let running_handles: Vec<HandleId> = self
+            .processes
+            .iter()
+            .filter(|(_, s)| {
+                let state = s.lock().unwrap();
+                state.status == ProcessStatus::Running
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        for handle in running_handles {
+            if let Some(tx) = self.kill_senders.remove(&handle) {
+                let _ = tx.send(());
+            }
+        }
+    }
+}

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -10,6 +10,7 @@ use crate::ast::*;
 use crate::llm::registry::ProviderRegistry;
 use crate::llm::CompletionRequest;
 use crate::runtime::agent::{AgentContext, EmittedEvent};
+use crate::runtime::command_manager::SharedCommandManager;
 use crate::runtime::confidence::{ConfidentValue, Value};
 use crate::runtime::instance_registry::{InstanceInfo, InstanceStatus};
 use crate::runtime::timer_engine::TimerEngine;
@@ -148,6 +149,8 @@ pub struct TaskExecutor {
     embedding_provider: Option<crate::llm::BoxedEmbeddingProvider>,
     /// Vector index for semantic search (issue #50).
     vector_index: Option<crate::runtime::vector_index::SharedVectorIndex>,
+    /// Command manager for background process lifecycle (issue #162).
+    command_manager: Option<SharedCommandManager>,
 }
 
 impl Clone for TaskExecutor {
@@ -175,6 +178,7 @@ impl Clone for TaskExecutor {
             skill_executor: self.skill_executor.clone(),
             embedding_provider: self.embedding_provider.clone(),
             vector_index: self.vector_index.clone(),
+            command_manager: self.command_manager.clone(),
         }
     }
 }
@@ -231,6 +235,7 @@ impl TaskExecutor {
             skill_executor: None,
             embedding_provider: None,
             vector_index: None,
+            command_manager: None,
         }
     }
 
@@ -296,6 +301,17 @@ impl TaskExecutor {
     /// Get a clone of the storage handle (used to preserve storage across hot-reloads).
     pub fn storage_handle(&self) -> Option<crate::runtime::storage::SharedStorage> {
         self.storage.clone()
+    }
+
+    /// Attach a command manager for background process lifecycle (issue #162).
+    pub fn with_command_manager(mut self, mgr: SharedCommandManager) -> Self {
+        self.command_manager = Some(mgr);
+        self
+    }
+
+    /// Get a reference to the command manager.
+    pub fn command_manager(&self) -> Option<&SharedCommandManager> {
+        self.command_manager.as_ref()
     }
 
     /// Configure persistent memory storage (issue #57).
@@ -2271,14 +2287,42 @@ impl TaskExecutor {
                         .map(|t| t.node.to_std())
                         .unwrap_or(std::time::Duration::from_secs(30));
 
-                    // 6. Reject background mode (see #162)
+                    // 6. Background mode — spawn and return handle (issue #162)
                     if matches!(cmd_expr.background, Some(ref s) if s.node) {
-                        return Err(RuntimeError::FlowError(
-                            "background commands not yet supported (see #162)".to_string(),
-                        ));
+                        let mgr = self.command_manager.as_ref().ok_or_else(|| {
+                            RuntimeError::Unsupported(
+                                "background commands require a command manager".to_string(),
+                            )
+                        })?;
+
+                        process.stdout(std::process::Stdio::piped());
+                        process.stderr(std::process::Stdio::piped());
+
+                        if let Some(ref tracer) = self.tracer {
+                            tracer.command_call(&cmd_display);
+                        }
+
+                        let child = process.spawn().map_err(|e| {
+                            RuntimeError::FlowError(format!(
+                                "background command failed to spawn: {}",
+                                e
+                            ))
+                        })?;
+
+                        let handle_id = mgr
+                            .lock()
+                            .unwrap()
+                            .spawn_background(child, cmd_display.clone(), Some(timeout_dur))
+                            .map_err(RuntimeError::FlowError)?;
+
+                        if let Some(ref tracer) = self.tracer {
+                            tracer.command_bg_spawn(&cmd_display, &handle_id);
+                        }
+
+                        return Ok(ConfidentValue::deterministic(Value::Text(handle_id)));
                     }
 
-                    // 7. Trace and spawn
+                    // 7. Trace and spawn (synchronous)
                     if let Some(ref tracer) = self.tracer {
                         tracer.command_call(&cmd_display);
                     }
@@ -2336,6 +2380,43 @@ impl TaskExecutor {
                             "command timed out after {:?}: {}",
                             timeout_dur, cmd_display
                         ))),
+                    }
+                }
+
+                // ── command.method() expressions (issue #162) ────────────────
+                Expr::CommandMethod(method, args) => {
+                    let mut arg_vals = Vec::new();
+                    for arg in args {
+                        arg_vals.push(self.eval_expr(&arg.node.value, env).await?);
+                    }
+                    let mgr = self.command_manager.as_ref().ok_or_else(|| {
+                        RuntimeError::Unsupported(
+                            "command.* requires a command manager".to_string(),
+                        )
+                    })?;
+                    let handle = arg_vals
+                        .first()
+                        .map(|v| format!("{}", v.value))
+                        .unwrap_or_default();
+                    match method.node.as_str() {
+                        "status" => mgr
+                            .lock()
+                            .unwrap()
+                            .status(&handle)
+                            .map_err(RuntimeError::FlowError),
+                        "output" => mgr
+                            .lock()
+                            .unwrap()
+                            .output(&handle)
+                            .map_err(RuntimeError::FlowError),
+                        "cancel" => {
+                            mgr.lock()
+                                .unwrap()
+                                .cancel(&handle)
+                                .map_err(RuntimeError::FlowError)?;
+                            Ok(ConfidentValue::deterministic(Value::Unit))
+                        }
+                        other => Err(RuntimeError::Unsupported(format!("command.{}()", other))),
                     }
                 }
 

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -2312,7 +2312,12 @@ impl TaskExecutor {
                         let handle_id = mgr
                             .lock()
                             .unwrap()
-                            .spawn_background(child, cmd_display.clone(), Some(timeout_dur))
+                            .spawn_background(
+                                child,
+                                cmd_display.clone(),
+                                Some(timeout_dur),
+                                self.tracer.clone(),
+                            )
                             .map_err(RuntimeError::FlowError)?;
 
                         if let Some(ref tracer) = self.tracer {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2,6 +2,7 @@
 // See issues #9 (executor), #11 (agent), #12 (pool) for full implementation
 
 pub mod agent;
+pub mod command_manager;
 pub mod confidence;
 pub mod cost_aggregator;
 pub mod event_bus;

--- a/src/runtime/pool.rs
+++ b/src/runtime/pool.rs
@@ -152,11 +152,15 @@ impl PoolExecutor {
         for _ in 0..self.worker_count {
             match &self.worker_kind {
                 WorkerKind::Task(task_decl) => {
+                    let cmd_mgr = std::sync::Arc::new(std::sync::Mutex::new(
+                        crate::runtime::command_manager::CommandManager::new(),
+                    ));
                     let executor = TaskExecutor::new(
                         self.program.clone(),
                         self.providers.clone(),
                         self.tracer.clone(),
-                    );
+                    )
+                    .with_command_manager(cmd_mgr);
                     let decl = task_decl.clone();
                     let args = args.to_vec();
                     join_set.spawn(async move { executor.call_task(&decl, args).await });
@@ -371,11 +375,15 @@ impl PoolExecutor {
 
     async fn try_fallback(&self, args: &[ConfidentValue]) -> Option<ConfidentValue> {
         let fallback_name = self.decl.fallback.as_ref()?;
+        let cmd_mgr = std::sync::Arc::new(std::sync::Mutex::new(
+            crate::runtime::command_manager::CommandManager::new(),
+        ));
         let executor = TaskExecutor::new(
             self.program.clone(),
             self.providers.clone(),
             self.tracer.clone(),
-        );
+        )
+        .with_command_manager(cmd_mgr);
 
         // Look up the fallback as a task
         let task = self

--- a/src/runtime/watcher.rs
+++ b/src/runtime/watcher.rs
@@ -206,9 +206,13 @@ fn attempt_reload(
         }
     };
 
+    let cmd_mgr = std::sync::Arc::new(std::sync::Mutex::new(
+        crate::runtime::command_manager::CommandManager::new(),
+    ));
     let mut new_executor =
         crate::runtime::executor::TaskExecutor::new(program, std::sync::Arc::new(registry), tracer)
-            .with_config(config);
+            .with_config(config)
+            .with_command_manager(cmd_mgr);
 
     // Preserve storage handle from the old executor (#140)
     {

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -381,6 +381,27 @@ impl Tracer {
         );
     }
 
+    pub fn command_bg_spawn(&self, command: &str, handle: &str) {
+        self.emit(
+            "command_bg_spawn",
+            serde_json::json!({
+                "command": command,
+                "handle": handle,
+            }),
+        );
+    }
+
+    pub fn command_bg_complete(&self, handle: &str, success: bool, duration_ms: u64) {
+        self.emit(
+            "command_bg_complete",
+            serde_json::json!({
+                "handle": handle,
+                "success": success,
+                "duration_ms": duration_ms,
+            }),
+        );
+    }
+
     // ── Skill tracing (issue #40) ──────────────────────────────────────────
 
     pub fn skill_call(&self, skill_name: &str) {

--- a/tests/command_background_tests.rs
+++ b/tests/command_background_tests.rs
@@ -1,0 +1,275 @@
+// FORGE command background mode acceptance tests — issue #162
+// Proves background execution works: spawn returns handle, status polling,
+// output buffering, cancel, timeout, and cleanup.
+
+use std::sync::{Arc, Mutex};
+
+use forge::llm::providers::mock::MockProvider;
+use forge::llm::registry::ProviderRegistry;
+use forge::runtime::command_manager::CommandManager;
+use forge::runtime::executor::TaskExecutor;
+use forge::tracer::Tracer;
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+fn parse_file(path: &str) -> forge::ast::Program {
+    let source =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("could not read {}: {}", path, e));
+    forge::parser::parse(&source).unwrap_or_else(|e| panic!("parse failed for {}: {:?}", path, e))
+}
+
+fn parse_source(src: &str) -> forge::ast::Program {
+    forge::parser::parse(src).unwrap_or_else(|e| panic!("parse failed: {:?}", e))
+}
+
+fn mock_registry(mock: MockProvider) -> Arc<ProviderRegistry> {
+    let mut reg = ProviderRegistry::new("mock");
+    reg.register("mock", Arc::new(mock));
+    Arc::new(reg)
+}
+
+fn executor_with_bg(program: forge::ast::Program) -> TaskExecutor {
+    let mock = MockProvider::new("mock").with_default("mock");
+    let mgr = Arc::new(Mutex::new(CommandManager::new()));
+    TaskExecutor::new(program, mock_registry(mock), None).with_command_manager(mgr)
+}
+
+fn executor_with_bg_and_tracer(program: forge::ast::Program, tracer: Tracer) -> TaskExecutor {
+    let mock = MockProvider::new("mock").with_default("mock");
+    let mgr = Arc::new(Mutex::new(CommandManager::new()));
+    TaskExecutor::new(program, mock_registry(mock), Some(tracer)).with_command_manager(mgr)
+}
+
+// ── Background: spawn returns handle ────────────────────────────
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn background_spawn_returns_handle() {
+    let program = parse_source(
+        r#"
+task run
+  gives Text
+  do
+    handle = command "echo hello" background true timeout 10s
+    give handle
+
+fn main
+  say run()
+"#,
+    );
+    let executor = executor_with_bg(program);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "background spawn should succeed: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    // Handle should be a UUID (36 chars with dashes)
+    assert!(
+        outputs.iter().any(|o| o.len() == 36 && o.contains('-')),
+        "should return a UUID handle, got: {:?}",
+        outputs
+    );
+}
+
+// ── Background: status shows completed after process exits ──────
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn background_status_completed() {
+    let program = parse_file("examples/command_background.forge");
+    let executor = executor_with_bg(program);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "command_background.forge should run without error: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    assert!(
+        outputs.iter().any(|o| o.contains("completed")),
+        "status should show 'completed', got: {:?}",
+        outputs
+    );
+    assert!(
+        outputs.iter().any(|o| o.contains("bg_hello")),
+        "output should contain 'bg_hello', got: {:?}",
+        outputs
+    );
+}
+
+// ── Background: cancel terminates process ───────────────────────
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn background_cancel() {
+    let program = parse_file("examples/command_background_cancel.forge");
+    let executor = executor_with_bg(program);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "command_background_cancel.forge should run without error: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    assert!(
+        outputs.iter().any(|o| o.contains("cancelled")),
+        "status should show 'cancelled', got: {:?}",
+        outputs
+    );
+}
+
+// ── Background: output buffering ────────────────────────────────
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn background_output_buffered() {
+    let program = parse_source(
+        r#"
+task run
+  gives Text
+  do
+    handle = command ["sh", "-c", "echo line1; echo line2; echo line3"] background true timeout 10s
+    wait = command "sleep 0.3"
+    output = command.output(handle)
+    when output.sure -> give output.stdout
+    else -> give "no_output"
+
+fn main
+  say run()
+"#,
+    );
+    let executor = executor_with_bg(program);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "output buffering should succeed: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    assert!(
+        outputs
+            .iter()
+            .any(|o| o.contains("line1") && o.contains("line2") && o.contains("line3")),
+        "should capture all output lines, got: {:?}",
+        outputs
+    );
+}
+
+// ── Background: timeout auto-cancels ────────────────────────────
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn background_timeout() {
+    let program = parse_source(
+        r#"
+task run
+  gives Text
+  do
+    handle = command "sleep 60" background true timeout 1s
+    wait = command "sleep 2"
+    status = command.status(handle)
+    when status.sure -> give status.status
+    else -> give "unknown"
+
+fn main
+  say run()
+"#,
+    );
+    let executor = executor_with_bg(program);
+    let result = executor.run().await;
+    assert!(
+        result.is_ok(),
+        "timeout test should succeed: {:?}",
+        result.err()
+    );
+    let outputs = executor.outputs();
+    assert!(
+        outputs.iter().any(|o| o.contains("timed_out")),
+        "status should show 'timed_out', got: {:?}",
+        outputs
+    );
+}
+
+// ── Background: tracing events ──────────────────────────────────
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn background_produces_trace_events() {
+    let program = parse_source(
+        r#"
+task run
+  gives Text
+  do
+    handle = command "echo traced" background true timeout 10s
+    give handle
+
+fn main
+  say run()
+"#,
+    );
+    let tracer = Tracer::with_capture();
+    let executor = executor_with_bg_and_tracer(program, tracer.clone());
+    let _result = executor.run().await;
+    let events = tracer.captured_events();
+    assert!(
+        events.contains(&"command_call".to_string()),
+        "should emit command_call trace event, got: {:?}",
+        events
+    );
+    assert!(
+        events.contains(&"command_bg_spawn".to_string()),
+        "should emit command_bg_spawn trace event, got: {:?}",
+        events
+    );
+}
+
+// ── Background: shutdown_all kills running processes ────────────
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn background_shutdown_all() {
+    let mgr = Arc::new(Mutex::new(CommandManager::new()));
+
+    // Spawn a long-running process directly via the manager
+    let mut child_cmd = tokio::process::Command::new("sleep");
+    child_cmd.arg("60");
+    child_cmd.stdout(std::process::Stdio::piped());
+    child_cmd.stderr(std::process::Stdio::piped());
+    let child = child_cmd.spawn().unwrap();
+
+    let handle = mgr
+        .lock()
+        .unwrap()
+        .spawn_background(child, "sleep 60".to_string(), None)
+        .unwrap();
+
+    // Verify it's running
+    {
+        let status = mgr.lock().unwrap().status(&handle).unwrap();
+        let status_text = format!("{}", status.value);
+        assert!(
+            status_text.contains("running"),
+            "should be running initially, got: {}",
+            status_text
+        );
+    }
+
+    // Shutdown all
+    mgr.lock().unwrap().shutdown_all();
+
+    // Give time for the kill to propagate
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Verify it's no longer running
+    {
+        let status = mgr.lock().unwrap().status(&handle).unwrap();
+        let status_text = format!("{}", status.value);
+        assert!(
+            !status_text.contains("running"),
+            "should not be running after shutdown, got: {}",
+            status_text
+        );
+    }
+}

--- a/tests/command_background_tests.rs
+++ b/tests/command_background_tests.rs
@@ -242,7 +242,7 @@ async fn background_shutdown_all() {
     let handle = mgr
         .lock()
         .unwrap()
-        .spawn_background(child, "sleep 60".to_string(), None)
+        .spawn_background(child, "sleep 60".to_string(), None, None)
         .unwrap();
 
     // Verify it's running

--- a/tests/conformance_runner.rs
+++ b/tests/conformance_runner.rs
@@ -9,6 +9,7 @@ use forge::checker::boundary_checker;
 use forge::diagnostic::{Diagnostic, DiagnosticKind};
 use forge::llm::providers::mock::MockProvider;
 use forge::llm::registry::ProviderRegistry;
+use forge::runtime::command_manager::CommandManager;
 use forge::runtime::executor::TaskExecutor;
 use forge::tracer::Tracer;
 
@@ -263,7 +264,9 @@ async fn test_run_ok(test: &ConformanceTest) -> Result<(), String> {
 
     let mock = build_mock(test);
     let tracer = Tracer::with_capture();
-    let executor = TaskExecutor::new(program, mock_registry(mock), Some(tracer.clone()));
+    let mgr = std::sync::Arc::new(std::sync::Mutex::new(CommandManager::new()));
+    let executor = TaskExecutor::new(program, mock_registry(mock), Some(tracer.clone()))
+        .with_command_manager(mgr);
 
     executor
         .run()
@@ -289,7 +292,9 @@ async fn test_run_error(test: &ConformanceTest) -> Result<(), String> {
 
     let mock = build_mock(test);
     let tracer = Tracer::with_capture();
-    let executor = TaskExecutor::new(program, mock_registry(mock), Some(tracer.clone()));
+    let mgr = std::sync::Arc::new(std::sync::Mutex::new(CommandManager::new()));
+    let executor = TaskExecutor::new(program, mock_registry(mock), Some(tracer.clone()))
+        .with_command_manager(mgr);
 
     match executor.run().await {
         Ok(_) => Err("expected run_error but execution succeeded".to_string()),


### PR DESCRIPTION
## Summary
- Add `CommandManager` with UUID handle-based background process lifecycle (spawn, poll, cancel)
- Implement `command.status(handle)`, `command.output(handle)`, `command.cancel(handle)` via dedicated `command_method_expr` grammar rule (resolves `command` keyword conflict)
- Background commands return handle immediately; incremental output buffering via tokio reader tasks
- Timeout auto-cancel, graceful shutdown on agent retire, 7 new acceptance tests + conformance test

## Test plan
- [x] `cargo test --test command_background_tests` — 7 tests (spawn, status, output, cancel, timeout, trace, shutdown)
- [x] `cargo test conformance_suite` — includes `command_background.json`
- [x] Full suite: 926 tests passing, 0 failures
- [x] `cargo clippy` clean, `cargo fmt` clean

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)