### PR TITLE
feat: pluggable skill architecture — project-level declarations (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- `forge.project.toml` gains `[skills]` section for project-level skill declarations with `path` and `source` options (#163)
+- Skill resolution chain: project local (`./skills/`) → installed (`.agents/skills/`) → global (`~/.forge/skills/`) with clear error on missing (#163)
+- `skills-lock.json` integrity verification — warns when installed skill content diverges from lock hash (#163)
+- Compile-time validation of `use skill.X` against project-declared skills via `CheckContext::with_skills()` (#163)
+- Pure checker rejects `skill.*` calls inside `pure` functions (Principle II — determinism boundary) (#163)
 - `command` expression primitive with optional `in`, `timeout`, and `background` modifiers (#160)
 - Structured argv form for `command`: `command ["git", "commit", "-m", msg]` — safe, no injection (#160)
 - `env` modifier for `command`: `command "build" env { RUST_LOG: "debug" }` (#160)

--- a/examples/skill_project/forge.project.toml
+++ b/examples/skill_project/forge.project.toml
@@ -1,0 +1,10 @@
+[project]
+name = "skill-project-demo"
+version = "0.1.0"
+description = "Demonstrates project-level skill declarations"
+
+[build]
+entry = "main.forge"
+
+[skills]
+repo_check = {}

--- a/examples/skill_project/main.forge
+++ b/examples/skill_project/main.forge
@@ -1,0 +1,14 @@
+use
+  skill.repo_check
+
+task check_repo
+  gives Text
+  do
+    report = skill.repo_check.analyze()
+    when report.sure -> give report
+    else -> give "skill returned uncertain result"
+
+fn main
+  say "=== FORGE Skill Project Demo ==="
+  say check_repo()
+  say "=== Done ==="

--- a/examples/skill_project/skills/repo_check/SKILL.md
+++ b/examples/skill_project/skills/repo_check/SKILL.md
@@ -1,20 +1,16 @@
 ---
 name: repo_check
-description: Runs git commands to report real repository data
+description: Runs a single git command to prove real tool execution
 allowed-tools: Bash
 timeout: 30
 ---
 
 # Repo Check Skill
 
-Run the following commands and report their EXACT output:
+Run this single command using the bash_exec tool:
 
-1. Run: `git rev-parse --abbrev-ref HEAD`
-2. Run: `git log --oneline -3`
-3. Run: `ls src/*.rs | wc -l`
+```
+git log --oneline -3
+```
 
-Return your answer in this exact format:
-
-BRANCH: <output of command 1>
-LAST_3_COMMITS: <output of command 2>
-RUST_FILES_IN_SRC: <output of command 3>
+Return ONLY the raw output of the command. Nothing else.

--- a/examples/skill_project/skills/repo_check/SKILL.md
+++ b/examples/skill_project/skills/repo_check/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: repo_check
+description: Runs git commands to report real repository data
+allowed-tools: Bash
+timeout: 30
+---
+
+# Repo Check Skill
+
+Run the following commands and report their EXACT output:
+
+1. Run: `git rev-parse --abbrev-ref HEAD`
+2. Run: `git log --oneline -3`
+3. Run: `ls src/*.rs | wc -l`
+
+Return your answer in this exact format:
+
+BRANCH: <output of command 1>
+LAST_3_COMMITS: <output of command 2>
+RUST_FILES_IN_SRC: <output of command 3>

--- a/src/checker/pure_checker.rs
+++ b/src/checker/pure_checker.rs
@@ -289,6 +289,15 @@ fn check_pure_expr(
             check_pure_expr(fn_name, a, task_names, errors);
             check_pure_expr(fn_name, b, task_names, errors);
         }
+        // Skill calls (skill.X.method()) are LLM-mediated oracle operations — reject in pure.
+        Expr::FieldAccess(inner, _) if matches!(&inner.node, Expr::Ident(s) if s == "skill") => {
+            errors.push(CheckError::PureUsesLlm {
+                name: fn_name.to_string(),
+                op: "skill",
+                span_start: expr.span.start,
+                span_end: expr.span.end,
+            });
+        }
         Expr::UnaryOp(_, a) | Expr::Paren(a) | Expr::FieldAccess(a, _) | Expr::GlobAccess(a) => {
             check_pure_expr(fn_name, a, task_names, errors);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,6 @@ pub mod planner;
 pub mod portability;
 pub mod resolver;
 pub mod runtime;
+pub mod skill_lock;
 pub mod tracer;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,19 +503,112 @@ fn parse_or_exit(source: &str, file: &Path) -> forge::ast::Program {
     }
 }
 
-/// Build a [`SkillExecutor`] from config when the `[skills]` section is present.
+/// Build a [`SkillExecutor`] and return skill capability signatures for compile-time validation.
+///
+/// When a manifest with `[skills]` is provided, only declared skills are loaded (project-level).
+/// Otherwise falls back to scanning `skill_dirs` from config (global-level).
 fn build_skill_executor(
     config: &forge::config::ForgeConfig,
     providers: &Arc<forge::llm::registry::ProviderRegistry>,
     tracer: Option<&forge::tracer::Tracer>,
-) -> Option<Arc<forge::runtime::skill_executor::SkillExecutor>> {
-    let skills_cfg = config.skills.as_ref()?;
-    let dirs = skills_cfg.skill_dirs_or_default();
-    let loaded = forge::runtime::skill_loader::SkillLoader::load_from_dirs(&dirs);
+    manifest: Option<&forge::manifest::ProjectManifest>,
+    base_dir: Option<&Path>,
+) -> (
+    Option<Arc<forge::runtime::skill_executor::SkillExecutor>>,
+    HashMap<String, forge::types::CapabilitySignature>,
+) {
+    let skills_cfg = match config.skills.as_ref() {
+        Some(cfg) => cfg,
+        None => {
+            // No [skills] in config — try project manifest alone
+            if let (Some(m), Some(bd)) = (manifest, base_dir) {
+                if m.skills.is_some() {
+                    // Manifest declares skills but no config [skills] section;
+                    // use defaults for runtime params.
+                    let default_cfg = forge::config::SkillsConfig {
+                        skill_dirs: None,
+                        timeout_secs: None,
+                        max_turns: None,
+                    };
+                    return build_skill_executor_inner(
+                        &default_cfg,
+                        providers,
+                        tracer,
+                        Some(m),
+                        Some(bd),
+                    );
+                }
+            }
+            return (None, HashMap::new());
+        }
+    };
+    build_skill_executor_inner(skills_cfg, providers, tracer, manifest, base_dir)
+}
+
+fn build_skill_executor_inner(
+    skills_cfg: &forge::config::SkillsConfig,
+    providers: &Arc<forge::llm::registry::ProviderRegistry>,
+    tracer: Option<&forge::tracer::Tracer>,
+    manifest: Option<&forge::manifest::ProjectManifest>,
+    base_dir: Option<&Path>,
+) -> (
+    Option<Arc<forge::runtime::skill_executor::SkillExecutor>>,
+    HashMap<String, forge::types::CapabilitySignature>,
+) {
     let mut registry = forge::runtime::skill_registry::SkillRegistry::new();
-    for skill in loaded {
-        registry.register(skill);
+
+    // Project-level skill resolution (authoritative when present)
+    let has_project_skills = if let (Some(m), Some(bd)) = (manifest, base_dir) {
+        if m.skills.is_some() {
+            let global_dirs = skills_cfg.skill_dirs_or_default();
+            match m.resolve_skills(bd, &global_dirs) {
+                Ok(resolved) => {
+                    // Verify against lock file
+                    let lock_path = bd.join("skills-lock.json");
+                    if let Ok(Some(lock)) = forge::skill_lock::SkillLockFile::load(&lock_path) {
+                        let mismatched = lock.verify(&resolved);
+                        for name in &mismatched {
+                            eprintln!(
+                                "warning: skill '{}' has changed since lock. Run `npx skills add` to update skills-lock.json.",
+                                name
+                            );
+                        }
+                    }
+
+                    // Load each resolved skill
+                    for (_, skill_path) in &resolved {
+                        match forge::runtime::skill_loader::SkillLoader::parse_skill_md(skill_path)
+                        {
+                            Ok(skill) => registry.register(skill),
+                            Err(e) => {
+                                eprintln!("warning: failed to load {}: {}", skill_path.display(), e)
+                            }
+                        }
+                    }
+                    true
+                }
+                Err(e) => {
+                    eprintln!("error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    // Fallback: scan skill_dirs (global-level, only when no project skills)
+    if !has_project_skills {
+        let dirs = skills_cfg.skill_dirs_or_default();
+        let loaded = forge::runtime::skill_loader::SkillLoader::load_from_dirs(&dirs);
+        for skill in loaded {
+            registry.register(skill);
+        }
     }
+
+    let signatures = registry.capability_signatures();
     let shared = Arc::new(Mutex::new(registry));
     let mut executor =
         forge::runtime::skill_executor::SkillExecutor::new(Arc::clone(providers), shared);
@@ -524,7 +617,7 @@ fn build_skill_executor(
     if let Some(t) = tracer {
         executor = executor.with_tracer(Arc::new(t.clone()));
     }
-    Some(Arc::new(executor))
+    (Some(Arc::new(executor)), signatures)
 }
 
 async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
@@ -532,10 +625,35 @@ async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
     let program = parse_or_exit(&source, file);
     let fname = file.display().to_string();
 
-    // Validate before execution
+    // Load config and skills early — needed for compile-time skill validation
+    let config = forge::config::ForgeConfig::load_or_default();
+    let config_clone = config.clone();
+    let registry = forge::llm::registry::ProviderRegistry::from_config(config)
+        .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
+    let providers = Arc::new(registry);
+
+    let tracer = if trace
+        || std::env::var("FORGE_TRACE")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    {
+        Some(forge::tracer::Tracer::new())
+    } else {
+        None
+    };
+
+    // Build skill executor to get capability signatures for compile-time validation
+    let (skill_exec, skill_sigs) =
+        build_skill_executor(&config_clone, &providers, tracer.as_ref(), None, None);
+
+    // Validate before execution (with skill-aware capability registry)
     let mut diagnostics = Vec::new();
 
-    let ctx = forge::resolver::CheckContext::new(&fname);
+    let ctx = if skill_sigs.is_empty() {
+        forge::resolver::CheckContext::new(&fname)
+    } else {
+        forge::resolver::CheckContext::with_skills(&fname, skill_sigs)
+    };
     if let Err(errors) = ctx.check(&program) {
         let registry = forge::resolver::CapabilityRegistry::builtin();
         diagnostics.extend(errors.iter().map(|e| e.to_diagnostic(&fname, &registry)));
@@ -553,23 +671,6 @@ async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
         std::process::exit(1);
     }
 
-    let config = forge::config::ForgeConfig::load_or_default();
-    let config_clone = config.clone();
-    let registry = forge::llm::registry::ProviderRegistry::from_config(config)
-        .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
-    let providers = Arc::new(registry);
-
-    let tracer = if trace
-        || std::env::var("FORGE_TRACE")
-            .map(|v| v == "1")
-            .unwrap_or(false)
-    {
-        Some(forge::tracer::Tracer::new())
-    } else {
-        None
-    };
-
-    let skill_exec = build_skill_executor(&config_clone, &providers, tracer.as_ref());
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let mut executor =
         forge::runtime::executor::TaskExecutor::new(program, Arc::clone(&providers), tracer)
@@ -595,6 +696,32 @@ async fn run_manifest(manifest_path: &Path, trace: bool) -> anyhow::Result<()> {
     let base_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
     let source_paths = manifest.resolve_sources(base_dir)?;
 
+    // Load config and skills early — needed for compile-time skill validation
+    let config = forge::config::ForgeConfig::load_or_default();
+    let config_clone = config.clone();
+    let registry = forge::llm::registry::ProviderRegistry::from_config(config)
+        .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
+    let providers = Arc::new(registry);
+
+    let tracer = if trace
+        || std::env::var("FORGE_TRACE")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    {
+        Some(forge::tracer::Tracer::new())
+    } else {
+        None
+    };
+
+    // Build skill executor with project-level declarations
+    let (skill_exec, skill_sigs) = build_skill_executor(
+        &config_clone,
+        &providers,
+        tracer.as_ref(),
+        Some(&manifest),
+        Some(base_dir),
+    );
+
     // Parse all source files
     let mut source_files = Vec::new();
     let mut diagnostics = Vec::new();
@@ -604,11 +731,23 @@ async fn run_manifest(manifest_path: &Path, trace: bool) -> anyhow::Result<()> {
         let fname = path.display().to_string();
         let program = parse_or_exit(&source, path);
 
-        // Per-file validation
-        let ctx = forge::resolver::CheckContext::new(&fname);
+        // Per-file validation (with skill-aware capability registry)
+        let ctx = if skill_sigs.is_empty() {
+            forge::resolver::CheckContext::new(&fname)
+        } else {
+            forge::resolver::CheckContext::with_skills(&fname, skill_sigs.clone())
+        };
         if let Err(errors) = ctx.check(&program) {
-            let registry = forge::resolver::CapabilityRegistry::builtin();
-            diagnostics.extend(errors.iter().map(|e| e.to_diagnostic(&fname, &registry)));
+            let cap_registry = if skill_sigs.is_empty() {
+                forge::resolver::CapabilityRegistry::builtin()
+            } else {
+                forge::resolver::CapabilityRegistry::with_skills(skill_sigs.clone())
+            };
+            diagnostics.extend(
+                errors
+                    .iter()
+                    .map(|e| e.to_diagnostic(&fname, &cap_registry)),
+            );
         }
         diagnostics.extend(forge::checker::check_all(&program, &fname));
 
@@ -646,23 +785,6 @@ async fn run_manifest(manifest_path: &Path, trace: bool) -> anyhow::Result<()> {
         )
     })?;
 
-    let config = forge::config::ForgeConfig::load_or_default();
-    let config_clone = config.clone();
-    let registry = forge::llm::registry::ProviderRegistry::from_config(config)
-        .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
-    let providers = Arc::new(registry);
-
-    let tracer = if trace
-        || std::env::var("FORGE_TRACE")
-            .map(|v| v == "1")
-            .unwrap_or(false)
-    {
-        Some(forge::tracer::Tracer::new())
-    } else {
-        None
-    };
-
-    let skill_exec = build_skill_executor(&config_clone, &providers, tracer.as_ref());
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let mut executor = forge::runtime::executor::TaskExecutor::new(
         composed.program,
@@ -859,7 +981,8 @@ fn try_build_executor_multi(
         .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
     let providers = Arc::new(registry);
 
-    let skill_exec = build_skill_executor(&config, &providers, tracer.as_ref());
+    let (skill_exec, _skill_sigs) =
+        build_skill_executor(&config, &providers, tracer.as_ref(), None, None);
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let mut executor = forge::runtime::executor::TaskExecutor::new(
         composed.program,
@@ -931,7 +1054,8 @@ fn try_build_executor(
         .map_err(|e| anyhow::anyhow!("provider setup failed: {}", e))?;
     let providers = Arc::new(registry);
 
-    let skill_exec = build_skill_executor(&config, &providers, tracer.as_ref());
+    let (skill_exec, _skill_sigs) =
+        build_skill_executor(&config, &providers, tracer.as_ref(), None, None);
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let mut executor =
         forge::runtime::executor::TaskExecutor::new(program, Arc::clone(&providers), tracer)

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,6 +2,7 @@
 // See issue #74 for specification
 
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 // ── Manifest types ────────────────────────────────────────────
@@ -12,6 +13,17 @@ pub struct ProjectManifest {
     pub project: ProjectMeta,
     pub build: Option<BuildConfig>,
     pub config: Option<ConfigEmbed>,
+    pub skills: Option<HashMap<String, SkillDeclaration>>,
+}
+
+/// A single skill declaration in the [skills] table.
+/// Keys are skill names; values control where to find the skill.
+#[derive(Debug, Deserialize, Clone)]
+pub struct SkillDeclaration {
+    /// Local path to skill directory (relative to project root).
+    pub path: Option<String>,
+    /// Remote source identifier (e.g., "microsoft/playwright-cli").
+    pub source: Option<String>,
 }
 
 /// [project] section — required.
@@ -108,6 +120,98 @@ impl ProjectManifest {
         Ok(None)
     }
 
+    /// Resolve declared skills to their SKILL.md paths on disk.
+    ///
+    /// Resolution chain per skill:
+    ///   1. Explicit `path` (if declared) → `{base_dir}/{path}/SKILL.md`
+    ///   2. Project local: `{base_dir}/skills/{name}/SKILL.md`
+    ///   3. Project installed: `{base_dir}/.agents/skills/{name}/SKILL.md`
+    ///   4. Global dirs (from config `skill_dirs`, default `~/.forge/skills/`)
+    ///
+    /// Returns `(skill_name, path_to_skill_md)` for each declared skill,
+    /// or an error listing all searched paths for missing skills.
+    pub fn resolve_skills(
+        &self,
+        base_dir: &Path,
+        global_dirs: &[PathBuf],
+    ) -> anyhow::Result<Vec<(String, PathBuf)>> {
+        let skills = match &self.skills {
+            Some(s) => s,
+            None => return Ok(Vec::new()),
+        };
+
+        let mut resolved = Vec::new();
+
+        for (name, decl) in skills {
+            let mut searched = Vec::new();
+
+            // 1. Explicit path
+            if let Some(ref path) = decl.path {
+                let skill_md = base_dir.join(path).join("SKILL.md");
+                searched.push(skill_md.clone());
+                if skill_md.exists() {
+                    resolved.push((name.clone(), skill_md));
+                    continue;
+                }
+                // Explicit path is authoritative — don't fall through
+                anyhow::bail!(
+                    "skill '{}' path not found: {}\n  hint: create {}/SKILL.md or fix the path in [skills.{}]",
+                    name,
+                    skill_md.display(),
+                    base_dir.join(path).display(),
+                    name,
+                );
+            }
+
+            // 2. Project local: ./skills/{name}/
+            let local = base_dir.join("skills").join(name).join("SKILL.md");
+            searched.push(local.clone());
+            if local.exists() {
+                resolved.push((name.clone(), local));
+                continue;
+            }
+
+            // 3. Project installed: .agents/skills/{name}/
+            let agents = base_dir.join(".agents/skills").join(name).join("SKILL.md");
+            searched.push(agents.clone());
+            if agents.exists() {
+                resolved.push((name.clone(), agents));
+                continue;
+            }
+
+            // 4. Global dirs
+            let mut found = false;
+            for dir in global_dirs {
+                let global = dir.join(name).join("SKILL.md");
+                searched.push(global.clone());
+                if global.exists() {
+                    resolved.push((name.clone(), global));
+                    found = true;
+                    break;
+                }
+            }
+            if found {
+                continue;
+            }
+
+            // Not found anywhere
+            let searched_list = searched
+                .iter()
+                .map(|p| format!("    {}", p.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            anyhow::bail!(
+                "skill '{}' declared in forge.project.toml but not found\n  searched:\n{}\n  hint: run `npx skills add {}` or set path = \"...\" in [skills.{}]",
+                name,
+                searched_list,
+                name,
+                name,
+            );
+        }
+
+        Ok(resolved)
+    }
+
     /// Create a virtual manifest for single-file builds (no forge.project.toml needed).
     pub fn from_single_file(file: &Path, output: Option<&str>) -> Self {
         let name = output
@@ -132,6 +236,7 @@ impl ProjectManifest {
                 sources: None,
             }),
             config: None,
+            skills: None,
         }
     }
 }
@@ -211,5 +316,246 @@ entry = "main.forge"
         );
         assert_eq!(manifest.project.name, "forge-tutor");
         assert_eq!(manifest.output_name(), "forge-tutor");
+    }
+
+    #[test]
+    fn parse_manifest_with_skills() {
+        let toml = r#"
+[project]
+name = "myapp"
+
+[skills]
+github = {}
+slack = { path = "skills/slack" }
+playwright = { source = "microsoft/playwright-cli" }
+"#;
+        let manifest: ProjectManifest = toml::from_str(toml).unwrap();
+        let skills = manifest.skills.as_ref().unwrap();
+        assert_eq!(skills.len(), 3);
+        assert!(skills["github"].path.is_none());
+        assert!(skills["github"].source.is_none());
+        assert_eq!(skills["slack"].path.as_deref(), Some("skills/slack"));
+        assert_eq!(
+            skills["playwright"].source.as_deref(),
+            Some("microsoft/playwright-cli")
+        );
+    }
+
+    #[test]
+    fn parse_manifest_without_skills() {
+        let toml = r#"
+[project]
+name = "hello"
+"#;
+        let manifest: ProjectManifest = toml::from_str(toml).unwrap();
+        assert!(manifest.skills.is_none());
+    }
+
+    #[test]
+    fn resolve_skills_from_local_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("skills/myskill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: myskill\n---\nHello").unwrap();
+
+        let manifest = ProjectManifest {
+            project: ProjectMeta {
+                name: "test".into(),
+                version: None,
+                description: None,
+            },
+            build: None,
+            config: None,
+            skills: Some(HashMap::from([(
+                "myskill".into(),
+                SkillDeclaration {
+                    path: None,
+                    source: None,
+                },
+            )])),
+        };
+
+        let resolved = manifest.resolve_skills(tmp.path(), &[]).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].0, "myskill");
+        assert!(resolved[0].1.ends_with("SKILL.md"));
+    }
+
+    #[test]
+    fn resolve_skills_from_agents_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join(".agents/skills/myskill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: myskill\n---\nHello").unwrap();
+
+        let manifest = ProjectManifest {
+            project: ProjectMeta {
+                name: "test".into(),
+                version: None,
+                description: None,
+            },
+            build: None,
+            config: None,
+            skills: Some(HashMap::from([(
+                "myskill".into(),
+                SkillDeclaration {
+                    path: None,
+                    source: None,
+                },
+            )])),
+        };
+
+        let resolved = manifest.resolve_skills(tmp.path(), &[]).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].1.to_string_lossy().contains(".agents/skills"));
+    }
+
+    #[test]
+    fn resolve_skills_explicit_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom = tmp.path().join("custom/loc");
+        std::fs::create_dir_all(&custom).unwrap();
+        std::fs::write(custom.join("SKILL.md"), "---\nname: x\n---\nOk").unwrap();
+
+        let manifest = ProjectManifest {
+            project: ProjectMeta {
+                name: "test".into(),
+                version: None,
+                description: None,
+            },
+            build: None,
+            config: None,
+            skills: Some(HashMap::from([(
+                "x".into(),
+                SkillDeclaration {
+                    path: Some("custom/loc".into()),
+                    source: None,
+                },
+            )])),
+        };
+
+        let resolved = manifest.resolve_skills(tmp.path(), &[]).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].1.to_string_lossy().contains("custom/loc"));
+    }
+
+    #[test]
+    fn resolve_skills_local_wins_over_global() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create both local and global
+        let local = tmp.path().join("skills/myskill");
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::write(local.join("SKILL.md"), "---\nname: myskill\n---\nLocal").unwrap();
+
+        let global_dir = tmp.path().join("global");
+        let global = global_dir.join("myskill");
+        std::fs::create_dir_all(&global).unwrap();
+        std::fs::write(global.join("SKILL.md"), "---\nname: myskill\n---\nGlobal").unwrap();
+
+        let manifest = ProjectManifest {
+            project: ProjectMeta {
+                name: "test".into(),
+                version: None,
+                description: None,
+            },
+            build: None,
+            config: None,
+            skills: Some(HashMap::from([(
+                "myskill".into(),
+                SkillDeclaration {
+                    path: None,
+                    source: None,
+                },
+            )])),
+        };
+
+        let resolved = manifest.resolve_skills(tmp.path(), &[global_dir]).unwrap();
+        assert_eq!(resolved.len(), 1);
+        // Should find local, not global
+        assert!(resolved[0].1.to_string_lossy().contains("skills/myskill"));
+        assert!(!resolved[0].1.to_string_lossy().contains("global"));
+    }
+
+    #[test]
+    fn resolve_skills_missing_gives_clear_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = ProjectManifest {
+            project: ProjectMeta {
+                name: "test".into(),
+                version: None,
+                description: None,
+            },
+            build: None,
+            config: None,
+            skills: Some(HashMap::from([(
+                "nonexistent".into(),
+                SkillDeclaration {
+                    path: None,
+                    source: None,
+                },
+            )])),
+        };
+
+        let err = manifest.resolve_skills(tmp.path(), &[]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("nonexistent"));
+        assert!(msg.contains("declared in forge.project.toml but not found"));
+        assert!(msg.contains("searched:"));
+    }
+
+    #[test]
+    fn resolve_skills_explicit_path_missing_gives_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = ProjectManifest {
+            project: ProjectMeta {
+                name: "test".into(),
+                version: None,
+                description: None,
+            },
+            build: None,
+            config: None,
+            skills: Some(HashMap::from([(
+                "x".into(),
+                SkillDeclaration {
+                    path: Some("does/not/exist".into()),
+                    source: None,
+                },
+            )])),
+        };
+
+        let err = manifest.resolve_skills(tmp.path(), &[]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("path not found"));
+        assert!(msg.contains("does/not/exist"));
+    }
+
+    #[test]
+    fn resolve_skills_from_global_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global_dir = tmp.path().join("global-skills");
+        let skill = global_dir.join("myskill");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(skill.join("SKILL.md"), "---\nname: myskill\n---\nGlobal").unwrap();
+
+        let manifest = ProjectManifest {
+            project: ProjectMeta {
+                name: "test".into(),
+                version: None,
+                description: None,
+            },
+            build: None,
+            config: None,
+            skills: Some(HashMap::from([(
+                "myskill".into(),
+                SkillDeclaration {
+                    path: None,
+                    source: None,
+                },
+            )])),
+        };
+
+        let resolved = manifest.resolve_skills(tmp.path(), &[global_dir]).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].1.to_string_lossy().contains("global-skills"));
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -471,9 +471,14 @@ name = "hello"
 
         let resolved = manifest.resolve_skills(tmp.path(), &[global_dir]).unwrap();
         assert_eq!(resolved.len(), 1);
-        // Should find local, not global
-        assert!(resolved[0].1.to_string_lossy().contains("skills/myskill"));
-        assert!(!resolved[0].1.to_string_lossy().contains("global"));
+        // Should find local, not global (use OS-agnostic path check)
+        let path_str = resolved[0].1.to_string_lossy();
+        assert!(
+            path_str.contains("skills/myskill") || path_str.contains("skills\\myskill"),
+            "should resolve from local skills dir, got: {}",
+            path_str
+        );
+        assert!(!path_str.contains("global"));
     }
 
     #[test]

--- a/src/skill_lock.rs
+++ b/src/skill_lock.rs
@@ -1,0 +1,167 @@
+// FORGE skill lock file — integrity verification for installed skills.
+// Compatible with the skills-lock.json format produced by `npx skills add`.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SkillLockFile {
+    pub version: u32,
+    pub skills: HashMap<String, LockedSkill>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LockedSkill {
+    pub source: Option<String>,
+    #[serde(rename = "sourceType")]
+    pub source_type: Option<String>,
+    #[serde(rename = "computedHash")]
+    pub computed_hash: String,
+}
+
+impl SkillLockFile {
+    /// Load a lock file from disk. Returns `Ok(None)` if the file doesn't exist.
+    pub fn load(path: &Path) -> anyhow::Result<Option<Self>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("cannot read {}: {}", path.display(), e))?;
+        let lock: SkillLockFile = serde_json::from_str(&content)
+            .map_err(|e| anyhow::anyhow!("invalid lock file {}: {}", path.display(), e))?;
+        Ok(Some(lock))
+    }
+
+    /// Verify resolved skills against lock file hashes.
+    /// Returns the names of skills whose SKILL.md content doesn't match.
+    pub fn verify(&self, resolved_skills: &[(String, PathBuf)]) -> Vec<String> {
+        let mut mismatched = Vec::new();
+        for (name, path) in resolved_skills {
+            if let Some(locked) = self.skills.get(name) {
+                if let Ok(hash) = Self::hash_file(path) {
+                    if hash != locked.computed_hash {
+                        mismatched.push(name.clone());
+                    }
+                }
+            }
+        }
+        mismatched
+    }
+
+    /// Compute SHA-256 hash of a file's contents, returned as hex string.
+    pub fn hash_file(path: &Path) -> anyhow::Result<String> {
+        let content = std::fs::read(path)
+            .map_err(|e| anyhow::anyhow!("cannot read {}: {}", path.display(), e))?;
+        let mut hasher = Sha256::new();
+        hasher.update(&content);
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_existing_lock_format() {
+        let json = r#"{
+  "version": 1,
+  "skills": {
+    "playwright-cli": {
+      "source": "microsoft/playwright-cli",
+      "sourceType": "github",
+      "computedHash": "45b90b409fb80cf08ee4e8b72377bddacfac3d1c1fac69bff5fd5342fad26adf"
+    }
+  }
+}"#;
+        let lock: SkillLockFile = serde_json::from_str(json).unwrap();
+        assert_eq!(lock.version, 1);
+        assert_eq!(lock.skills.len(), 1);
+        let skill = &lock.skills["playwright-cli"];
+        assert_eq!(skill.source.as_deref(), Some("microsoft/playwright-cli"));
+        assert_eq!(skill.source_type.as_deref(), Some("github"));
+        assert!(!skill.computed_hash.is_empty());
+    }
+
+    #[test]
+    fn load_missing_file_returns_none() {
+        let result = SkillLockFile::load(Path::new("/tmp/nonexistent-lock-file.json")).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn hash_file_produces_consistent_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("test.md");
+        std::fs::write(&file, "hello world").unwrap();
+
+        let h1 = SkillLockFile::hash_file(&file).unwrap();
+        let h2 = SkillLockFile::hash_file(&file).unwrap();
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64); // SHA-256 hex
+    }
+
+    #[test]
+    fn verify_matching_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("SKILL.md");
+        std::fs::write(&file, "---\nname: test\n---\nContent").unwrap();
+        let hash = SkillLockFile::hash_file(&file).unwrap();
+
+        let lock = SkillLockFile {
+            version: 1,
+            skills: HashMap::from([(
+                "test".into(),
+                LockedSkill {
+                    source: None,
+                    source_type: None,
+                    computed_hash: hash,
+                },
+            )]),
+        };
+
+        let mismatched = lock.verify(&[("test".into(), file)]);
+        assert!(mismatched.is_empty());
+    }
+
+    #[test]
+    fn verify_mismatched_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("SKILL.md");
+        std::fs::write(&file, "---\nname: test\n---\nChanged content").unwrap();
+
+        let lock = SkillLockFile {
+            version: 1,
+            skills: HashMap::from([(
+                "test".into(),
+                LockedSkill {
+                    source: None,
+                    source_type: None,
+                    computed_hash:
+                        "0000000000000000000000000000000000000000000000000000000000000000".into(),
+                },
+            )]),
+        };
+
+        let mismatched = lock.verify(&[("test".into(), file)]);
+        assert_eq!(mismatched, vec!["test"]);
+    }
+
+    #[test]
+    fn verify_unlocked_skill_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("SKILL.md");
+        std::fs::write(&file, "content").unwrap();
+
+        let lock = SkillLockFile {
+            version: 1,
+            skills: HashMap::new(),
+        };
+
+        // Skill not in lock file → not checked, no mismatch
+        let mismatched = lock.verify(&[("unlocked".into(), file)]);
+        assert!(mismatched.is_empty());
+    }
+}

--- a/tests/pure_checker_tests.rs
+++ b/tests/pure_checker_tests.rs
@@ -155,3 +155,15 @@ pure bad1\n  needs x: Text\n  gives Text\n  do\n    give reason x\n\
     assert!(names.contains(&"bad1"));
     assert!(names.contains(&"bad2"));
 }
+
+#[test]
+fn pure_rejects_skill_call() {
+    // skill.X is an LLM-mediated oracle operation — must be rejected in pure functions.
+    let source = "pure bad\n  needs x: Text\n  gives Text\n  do\n    result = skill.analyzer\n    give result\n";
+    let program = parse(source).unwrap();
+    let errors = check(&program);
+    assert_eq!(errors.len(), 1);
+    assert!(
+        matches!(&errors[0], CheckError::PureUsesLlm { name, op, .. } if name == "bad" && *op == "skill")
+    );
+}

--- a/tests/skill_integration_tests.rs
+++ b/tests/skill_integration_tests.rs
@@ -314,6 +314,268 @@ fn main
     );
 }
 
+// ── Project-level skill declarations (issue #163) ──────────────
+
+#[test]
+fn manifest_skills_resolved_from_project_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Create skills/myskill/SKILL.md
+    let skill_dir = tmp.path().join("skills/myskill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: myskill\ndescription: Test\n---\nInstructions.",
+    )
+    .unwrap();
+
+    let manifest = forge::manifest::ProjectManifest {
+        project: forge::manifest::ProjectMeta {
+            name: "test".into(),
+            version: None,
+            description: None,
+        },
+        build: None,
+        config: None,
+        skills: Some(std::collections::HashMap::from([(
+            "myskill".into(),
+            forge::manifest::SkillDeclaration {
+                path: None,
+                source: None,
+            },
+        )])),
+    };
+
+    let resolved = manifest.resolve_skills(tmp.path(), &[]).unwrap();
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].0, "myskill");
+
+    // Load the resolved skill through SkillLoader
+    let skill = SkillLoader::parse_skill_md(&resolved[0].1).unwrap();
+    assert_eq!(skill.manifest.name, "myskill");
+}
+
+#[test]
+fn manifest_skills_resolved_from_agents_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_dir = tmp.path().join(".agents/skills/agent-skill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: agent-skill\ndescription: Installed\n---\nDo stuff.",
+    )
+    .unwrap();
+
+    let manifest = forge::manifest::ProjectManifest {
+        project: forge::manifest::ProjectMeta {
+            name: "test".into(),
+            version: None,
+            description: None,
+        },
+        build: None,
+        config: None,
+        skills: Some(std::collections::HashMap::from([(
+            "agent-skill".into(),
+            forge::manifest::SkillDeclaration {
+                path: None,
+                source: Some("org/agent-skill".into()),
+            },
+        )])),
+    };
+
+    let resolved = manifest.resolve_skills(tmp.path(), &[]).unwrap();
+    assert_eq!(resolved.len(), 1);
+    assert!(resolved[0].1.to_string_lossy().contains(".agents/skills"));
+}
+
+#[test]
+fn manifest_skills_missing_gives_clear_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manifest = forge::manifest::ProjectManifest {
+        project: forge::manifest::ProjectMeta {
+            name: "test".into(),
+            version: None,
+            description: None,
+        },
+        build: None,
+        config: None,
+        skills: Some(std::collections::HashMap::from([(
+            "nonexistent".into(),
+            forge::manifest::SkillDeclaration {
+                path: None,
+                source: None,
+            },
+        )])),
+    };
+
+    let err = manifest.resolve_skills(tmp.path(), &[]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("nonexistent"), "error should name the skill");
+    assert!(
+        msg.contains("declared in forge.project.toml but not found"),
+        "error should mention manifest: {}",
+        msg
+    );
+    assert!(
+        msg.contains("searched:"),
+        "error should list paths: {}",
+        msg
+    );
+}
+
+#[test]
+fn manifest_skills_explicit_path_wins() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Create skill at custom path AND at default location
+    let custom = tmp.path().join("custom/myskill");
+    std::fs::create_dir_all(&custom).unwrap();
+    std::fs::write(
+        custom.join("SKILL.md"),
+        "---\nname: myskill\ndescription: Custom\n---\nCustom instructions.",
+    )
+    .unwrap();
+
+    let default = tmp.path().join("skills/myskill");
+    std::fs::create_dir_all(&default).unwrap();
+    std::fs::write(
+        default.join("SKILL.md"),
+        "---\nname: myskill\ndescription: Default\n---\nDefault instructions.",
+    )
+    .unwrap();
+
+    let manifest = forge::manifest::ProjectManifest {
+        project: forge::manifest::ProjectMeta {
+            name: "test".into(),
+            version: None,
+            description: None,
+        },
+        build: None,
+        config: None,
+        skills: Some(std::collections::HashMap::from([(
+            "myskill".into(),
+            forge::manifest::SkillDeclaration {
+                path: Some("custom/myskill".into()),
+                source: None,
+            },
+        )])),
+    };
+
+    let resolved = manifest.resolve_skills(tmp.path(), &[]).unwrap();
+    assert_eq!(resolved.len(), 1);
+    assert!(
+        resolved[0].1.to_string_lossy().contains("custom/myskill"),
+        "should use custom path, got: {}",
+        resolved[0].1.display()
+    );
+}
+
+#[test]
+fn lock_file_verification_detects_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_path = tmp.path().join("SKILL.md");
+    std::fs::write(&skill_path, "---\nname: test\n---\nOriginal content").unwrap();
+
+    // Get the hash of the original content
+    let original_hash = forge::skill_lock::SkillLockFile::hash_file(&skill_path).unwrap();
+
+    // Modify the file
+    std::fs::write(&skill_path, "---\nname: test\n---\nModified content").unwrap();
+
+    let lock = forge::skill_lock::SkillLockFile {
+        version: 1,
+        skills: std::collections::HashMap::from([(
+            "test".into(),
+            forge::skill_lock::LockedSkill {
+                source: None,
+                source_type: None,
+                computed_hash: original_hash,
+            },
+        )]),
+    };
+
+    let mismatched = lock.verify(&[("test".into(), skill_path)]);
+    assert_eq!(mismatched, vec!["test"]);
+}
+
+#[test]
+fn manifest_skills_loaded_into_registry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_dir = tmp.path().join("skills/echo-test");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: echo-test\ndescription: Echo\nallowed-tools: Bash\n---\nEcho things.",
+    )
+    .unwrap();
+
+    let manifest = forge::manifest::ProjectManifest {
+        project: forge::manifest::ProjectMeta {
+            name: "test".into(),
+            version: None,
+            description: None,
+        },
+        build: None,
+        config: None,
+        skills: Some(std::collections::HashMap::from([(
+            "echo-test".into(),
+            forge::manifest::SkillDeclaration {
+                path: None,
+                source: None,
+            },
+        )])),
+    };
+
+    let resolved = manifest.resolve_skills(tmp.path(), &[]).unwrap();
+
+    // Load into registry
+    let mut registry = SkillRegistry::new();
+    for (_, path) in &resolved {
+        let skill = SkillLoader::parse_skill_md(path).unwrap();
+        registry.register(skill);
+    }
+
+    assert_eq!(registry.skill_count(), 1);
+    assert!(registry.get("echo-test").is_some());
+
+    // Capability signatures should be generated
+    let sigs = registry.capability_signatures();
+    assert!(
+        sigs.contains_key("skill.echo-test"),
+        "should expose skill.echo-test capability"
+    );
+}
+
+#[test]
+fn use_skill_validated_at_compile_time() {
+    // A program with `use skill.myskill` should pass validation when skill is registered
+    let source = "use\n  skill.myskill\n\ntask greet\n  gives Text\n  do\n    give \"hello\"\n\nfn main\n  say greet()\n";
+    let program = forge::parser::parse(source).unwrap();
+
+    // Without skills: should fail
+    let ctx_no_skills = forge::resolver::CheckContext::new("test.forge");
+    let result_no_skills = ctx_no_skills.check(&program);
+    assert!(
+        result_no_skills.is_err(),
+        "use skill.myskill should fail without skill registered"
+    );
+
+    // With skills: should pass
+    let mut sigs = std::collections::HashMap::new();
+    sigs.insert(
+        "skill.myskill".into(),
+        forge::types::CapabilitySignature {
+            inputs: vec![forge::types::ForgeType::Text],
+            output: forge::types::ForgeType::Text,
+        },
+    );
+    let ctx_with_skills = forge::resolver::CheckContext::with_skills("test.forge", sigs);
+    let result_with_skills = ctx_with_skills.check(&program);
+    assert!(
+        result_with_skills.is_ok(),
+        "use skill.myskill should pass with skill registered: {:?}",
+        result_with_skills.err()
+    );
+}
+
 // ── Full pipeline: skill_finder.forge example ───────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `forge.project.toml` gains `[skills]` section for declaring project-level skill dependencies with `path` and `source` options
- Deterministic resolution chain: project local (`./skills/`) → installed (`.agents/skills/`) → global (`~/.forge/skills/`) → clear error with searched paths
- `skills-lock.json` SHA-256 integrity verification — warns on content drift
- Compile-time validation of `use skill.X` via `CheckContext::with_skills()` (was previously runtime-only)
- **Principle II fix**: pure checker now rejects `skill.*` calls inside `pure` functions (LLM-mediated oracle operations)

## Principles Alignment

| Principle | Action |
|---|---|
| P1 Honesty | Preserved — skills still capped at 0.99 confidence |
| P2 Determinism Boundary | **Fixed** — `skill.X` now rejected in `pure` functions |
| P6 Self-Reference | Missing-skill errors use structured diagnostics with searched paths |
| P8 Accountability | Lock file verification traces integrity |
| P9 Boundary | Skills callable only from `task`/`agent` contexts |

## Test plan

- [x] 949 tests pass (0 failures)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] 8 new manifest unit tests (parse, resolve from each tier, priority, missing error)
- [x] 6 new skill_lock unit tests (parse, hash, verify match/mismatch)
- [x] 7 new integration tests (resolution, registry loading, compile-time validation, lock file)
- [x] 1 new pure checker test (`pure_rejects_skill_call`)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)