### PR TITLE
fix: Anthropic provider tool_use support for skill execution (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Anthropic provider now sends tool definitions and parses `tool_use` response blocks, enabling skill executor agentic loop (#198)
+
 ### Added
 - `command` expression primitive with optional `in`, `timeout`, and `background` modifiers (#160)
 - Structured argv form for `command`: `command ["git", "commit", "-m", msg]` — safe, no injection (#160)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Anthropic provider now sends tool definitions and parses `tool_use` response blocks, enabling skill executor agentic loop (#198)
+- OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
 - `command` expression primitive with optional `in`, `timeout`, and `background` modifiers (#160)

--- a/src/llm/providers/anthropic.rs
+++ b/src/llm/providers/anthropic.rs
@@ -1,7 +1,7 @@
 use crate::config::ProviderConfig;
 use crate::llm::{
     CompletionRequest, CompletionResponse, LLMProvider, ProviderCapabilities, ProviderError,
-    QualityTier,
+    QualityTier, ToolCallRequest,
 };
 use async_trait::async_trait;
 use reqwest::Client;
@@ -86,6 +86,19 @@ impl AnthropicProvider {
 // ── Anthropic wire types ──────────────────────────────────────────────────────
 
 #[derive(Serialize)]
+struct AnthropicTool<'a> {
+    name: &'a str,
+    description: &'a str,
+    input_schema: &'a serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct AnthropicToolChoice {
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Serialize)]
 struct AnthropicRequest<'a> {
     model: &'a str,
     max_tokens: u32,
@@ -95,6 +108,10 @@ struct AnthropicRequest<'a> {
     temperature: f32,
     #[serde(skip_serializing_if = "<[String]>::is_empty")]
     stop_sequences: &'a [String],
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<AnthropicTool<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<AnthropicToolChoice>,
 }
 
 #[derive(Serialize)]
@@ -115,6 +132,10 @@ struct AnthropicContent {
     #[serde(rename = "type")]
     type_: String,
     text: Option<String>,
+    // Present on tool_use content blocks:
+    id: Option<String>,
+    name: Option<String>,
+    input: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -148,6 +169,24 @@ impl LLMProvider for AnthropicProvider {
     }
 
     async fn complete(&self, req: CompletionRequest) -> Result<CompletionResponse, ProviderError> {
+        let tools: Vec<AnthropicTool> = req
+            .tools
+            .iter()
+            .map(|t| AnthropicTool {
+                name: &t.name,
+                description: &t.description,
+                input_schema: &t.input_schema,
+            })
+            .collect();
+
+        let tool_choice = if tools.is_empty() {
+            None
+        } else {
+            Some(AnthropicToolChoice {
+                type_: "auto".to_string(),
+            })
+        };
+
         let body = AnthropicRequest {
             model: &self.model,
             max_tokens: req.max_tokens,
@@ -158,6 +197,8 @@ impl LLMProvider for AnthropicProvider {
             system: req.system.as_deref(),
             temperature: req.temperature,
             stop_sequences: &req.stop_sequences,
+            tools,
+            tool_choice,
         };
 
         let start = Instant::now();
@@ -220,12 +261,31 @@ impl LLMProvider for AnthropicProvider {
                     reason: e.to_string(),
                 })?;
 
-        let content = resp
-            .content
-            .into_iter()
-            .find(|c| c.type_ == "text")
-            .and_then(|c| c.text)
-            .unwrap_or_default();
+        let mut text_parts: Vec<String> = Vec::new();
+        let mut tool_calls: Vec<ToolCallRequest> = Vec::new();
+
+        for block in resp.content {
+            match block.type_.as_str() {
+                "text" => {
+                    if let Some(text) = block.text {
+                        text_parts.push(text);
+                    }
+                }
+                "tool_use" => {
+                    if let (Some(id), Some(name), Some(input)) = (block.id, block.name, block.input)
+                    {
+                        tool_calls.push(ToolCallRequest {
+                            id,
+                            name,
+                            arguments: input,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let content = text_parts.join("\n");
 
         let tokens_in = resp.usage.input_tokens;
         let tokens_out = resp.usage.output_tokens;
@@ -234,7 +294,7 @@ impl LLMProvider for AnthropicProvider {
 
         Ok(CompletionResponse {
             content,
-            tool_calls: vec![],
+            tool_calls,
             tokens_in,
             tokens_out,
             latency_ms,

--- a/src/llm/providers/openai_compat.rs
+++ b/src/llm/providers/openai_compat.rs
@@ -1,7 +1,7 @@
 use crate::config::ProviderConfig;
 use crate::llm::{
     CompletionRequest, CompletionResponse, EmbeddingProvider, EmbeddingRequest, EmbeddingResponse,
-    LLMProvider, ProviderCapabilities, ProviderError, QualityTier,
+    LLMProvider, ProviderCapabilities, ProviderError, QualityTier, ToolCallRequest,
 };
 use async_trait::async_trait;
 use reqwest::Client;
@@ -106,6 +106,20 @@ impl OpenAICompatProvider {
 // ── OpenAI wire types ─────────────────────────────────────────────────────────
 
 #[derive(Serialize)]
+struct OAITool<'a> {
+    #[serde(rename = "type")]
+    type_: &'static str,
+    function: OAIToolFunction<'a>,
+}
+
+#[derive(Serialize)]
+struct OAIToolFunction<'a> {
+    name: &'a str,
+    description: &'a str,
+    parameters: &'a serde_json::Value,
+}
+
+#[derive(Serialize)]
 struct OAIRequest<'a> {
     model: &'a str,
     messages: Vec<OAIMessage<'a>>,
@@ -114,6 +128,10 @@ struct OAIRequest<'a> {
     #[serde(skip_serializing_if = "<[String]>::is_empty")]
     stop: &'a [String],
     stream: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<OAITool<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<&'static str>,
 }
 
 #[derive(Serialize)]
@@ -137,6 +155,20 @@ struct OAIChoice {
 #[derive(Deserialize)]
 struct OAIResponseMessage {
     content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<OAIToolCall>,
+}
+
+#[derive(Deserialize)]
+struct OAIToolCall {
+    id: String,
+    function: OAIToolCallFunction,
+}
+
+#[derive(Deserialize)]
+struct OAIToolCallFunction {
+    name: String,
+    arguments: String, // OpenAI returns arguments as a JSON string
 }
 
 #[derive(Deserialize)]
@@ -180,6 +212,21 @@ impl LLMProvider for OpenAICompatProvider {
             content: &req.prompt,
         });
 
+        let tools: Vec<OAITool> = req
+            .tools
+            .iter()
+            .map(|t| OAITool {
+                type_: "function",
+                function: OAIToolFunction {
+                    name: &t.name,
+                    description: &t.description,
+                    parameters: &t.input_schema,
+                },
+            })
+            .collect();
+
+        let tool_choice = if tools.is_empty() { None } else { Some("auto") };
+
         let body = OAIRequest {
             model: &self.model,
             messages,
@@ -187,6 +234,8 @@ impl LLMProvider for OpenAICompatProvider {
             temperature: req.temperature,
             stop: &req.stop_sequences,
             stream: false,
+            tools,
+            tool_choice,
         };
 
         let url = format!("{}/chat/completions", self.base_url);
@@ -262,11 +311,29 @@ impl LLMProvider for OpenAICompatProvider {
                     reason: e.to_string(),
                 })?;
 
-        let content = resp
-            .choices
-            .into_iter()
-            .next()
-            .and_then(|c| c.message.content)
+        let first_choice = resp.choices.into_iter().next();
+
+        let content = first_choice
+            .as_ref()
+            .and_then(|c| c.message.content.clone())
+            .unwrap_or_default();
+
+        let tool_calls: Vec<ToolCallRequest> = first_choice
+            .map(|c| {
+                c.message
+                    .tool_calls
+                    .into_iter()
+                    .filter_map(|tc| {
+                        let arguments: serde_json::Value =
+                            serde_json::from_str(&tc.function.arguments).ok()?;
+                        Some(ToolCallRequest {
+                            id: tc.id,
+                            name: tc.function.name,
+                            arguments,
+                        })
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
         let tokens_in = resp.usage.prompt_tokens;
@@ -276,7 +343,7 @@ impl LLMProvider for OpenAICompatProvider {
 
         Ok(CompletionResponse {
             content,
-            tool_calls: vec![],
+            tool_calls,
             tokens_in,
             tokens_out,
             latency_ms,

--- a/src/runtime/skill_executor.rs
+++ b/src/runtime/skill_executor.rs
@@ -12,6 +12,7 @@ use crate::llm::{CompletionRequest, ToolDefinition};
 use crate::runtime::confidence::ConfidentValue;
 use crate::runtime::skill::{LoadedSkill, SkillError};
 use crate::runtime::skill_registry::SharedSkillRegistry;
+use crate::tracer::LLMResponseInfo;
 use crate::tracer::Tracer;
 
 /// Executes skills by running an agentic loop:
@@ -139,6 +140,10 @@ impl SkillExecutor {
         user: &str,
         default_confidence: &f32,
     ) -> Result<ConfidentValue, SkillError> {
+        if let Some(ref tracer) = self.tracer {
+            tracer.llm_request("skill", user);
+        }
+
         let request = CompletionRequest::simple(user).with_system(system.to_string());
         let response = self
             .providers
@@ -147,6 +152,20 @@ impl SkillExecutor {
             .map_err(|e| SkillError::ProviderError(e.to_string()))?;
 
         let confidence = response.estimate_confidence().min(*default_confidence);
+
+        if let Some(ref tracer) = self.tracer {
+            tracer.llm_response(&LLMResponseInfo {
+                operation: "skill",
+                provider: &response.provider_name,
+                model: &response.model_used,
+                tokens_in: response.tokens_in,
+                tokens_out: response.tokens_out,
+                cost_usd: response.cost_usd,
+                confidence,
+                agent_name: None,
+            });
+        }
+
         Ok(ConfidentValue::from_skill(
             crate::runtime::confidence::Value::Text(response.content),
             confidence,
@@ -163,6 +182,10 @@ impl SkillExecutor {
         let mut prompt = initial_prompt.to_string();
 
         for turn in 0..self.max_turns {
+            if let Some(ref tracer) = self.tracer {
+                tracer.llm_request("skill_tool", &prompt);
+            }
+
             let request = CompletionRequest::simple(&prompt)
                 .with_system(system.to_string())
                 .with_tools(tools.to_vec());
@@ -171,6 +194,20 @@ impl SkillExecutor {
                 .resolve_and_complete(request, None)
                 .await
                 .map_err(|e| SkillError::ProviderError(e.to_string()))?;
+
+            if let Some(ref tracer) = self.tracer {
+                let confidence = response.estimate_confidence().min(*default_confidence);
+                tracer.llm_response(&LLMResponseInfo {
+                    operation: "skill_tool",
+                    provider: &response.provider_name,
+                    model: &response.model_used,
+                    tokens_in: response.tokens_in,
+                    tokens_out: response.tokens_out,
+                    cost_usd: response.cost_usd,
+                    confidence,
+                    agent_name: None,
+                });
+            }
 
             // If no tool calls, the LLM is done
             if response.tool_calls.is_empty() {


### PR DESCRIPTION
## Summary
- Add `tools` and `tool_choice` fields to Anthropic API requests, serialized from `CompletionRequest.tools`
- Parse `tool_use` content blocks from Anthropic responses into `ToolCallRequest` structs (mapping Anthropic's `input` → our `arguments`)
- Add tool definitions as OpenAI function-calling format to OpenAI-compat provider, parse `tool_calls` from response messages (mapping JSON string `arguments` → parsed `serde_json::Value`)
- Add Principle VIII `llm_request`/`llm_response` tracing to skill executor's `simple_completion` and `agentic_loop`
- Backward compatible: no-tool requests produce identical wire format via `skip_serializing_if`

Closes #198

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — 52 tests pass, no regressions
- [x] Real-world: Anthropic (claude-haiku-4-5) — tool calls parsed, bash_exec executed, real git data returned
- [x] Real-world: OpenAI (gpt-4o-mini) — tool calls parsed, bash_exec executed, real git data returned
- [x] Real-world: OpenAI-compatible endpoint (nemotron-120b) — tool calls parsed, bash_exec executed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)