### PR TITLE
feat: add typed skill capability signatures (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- Rich SKILL.md capability signatures with multi-capability registration and compile-time validation of `skill.namespace.method(...)` calls (#164)
 - `forge.project.toml` gains `[skills]` section for project-level skill declarations with `path` and `source` options (#163)
 - Skill resolution chain: project local (`./skills/`) → installed (`.agents/skills/`) → global (`~/.forge/skills/`) with clear error on missing (#163)
 - `skills-lock.json` integrity verification — warns when installed skill content diverges from lock hash (#163)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "subtle",
  "tempfile",
@@ -1510,6 +1511,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +1898,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ pest_derive = "2"
 tokio = { version = "1", features = ["full", "test-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"

--- a/roadmap.md
+++ b/roadmap.md
@@ -76,7 +76,7 @@ Everything in this document exists to reach that moment.
 | P2.M4 — Session Adapters + Events | Agent adapters, polling, and event integration | #191, #192 | Open |
 | P2.M5 — Verification + Contradictions | Verification engine and contradiction/warden integration | #204, #205 | Open |
 | P2.M6 — Sandbox | `sandbox` isolation: spawn modifier + worktree | #194 | Open |
-| P2.M7 — Skills Foundation | Pluggable skill architecture, capability types, CLI delegation research | #163 ✅ #164 #165 | In Progress |
+| P2.M7 — Skills Foundation | Pluggable skill architecture, capability types, CLI delegation research | #163 ✅ #164 ✅ #165 | In Progress |
 | P2.M8 — CLI Skills | GitHub, Slack, Claude Code, Codex/Ollama SKILL.md files | #176-#179 | Open |
 | P2.M9 — Orchestration | Slack Monitor, Inbound Triager, approval gate | #180-#182 | Open |
 | P2.M10 — Dev System | ProjectAgent, Executor, FORGE + forge-wiki two-project proof | #183-#185 | Open |
@@ -691,7 +691,7 @@ Worktree isolation for safe agent execution:
 | Issue | Title | Status |
 |-------|-------|--------|
 | #163 | Pluggable skill architecture — project-level declarations | Done |
-| #164 | Skill capability type system — rich signatures | Open |
+| #164 | Skill capability type system — rich signatures | Done |
 | #165 | Explore agent-to-CLI delegation patterns (Claude Code, Codex) | Open |
 
 ### P2.M8: CLI Skills (SKILL.md)
@@ -937,7 +937,7 @@ P2.M3  Result+Contract ░░░░░░░░░░░░░░░░░░░
 P2.M4  Adapters+Events ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M5  Verify+Contra   ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M6  Sandbox         ░░░░░░░░░░░░░░░░░░░░  0/1  (  0%)
-P2.M7  Skills          ███████░░░░░░░░░░░░░  1/3  ( 33%)
+P2.M7  Skills          █████████████░░░░░░░  2/3  ( 67%)
 P2.M8  CLI Skills      ░░░░░░░░░░░░░░░░░░░░  0/4  (  0%)
 P2.M9  Orchestration   ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
 P2.M10 Dev System      ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
@@ -1317,14 +1317,14 @@ Phase 1 (Layer 1): Build FORGE — **SHIPPED v0.1.0 on 2026-04-09**
   ⬜ WASM compilation (Cranelift backend) — deferred, not blocking Phase 2
   Goal: tic-tac-toe system runs end-to-end ✅
 
-Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (4/37 issues done)**
+Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (5/37 issues done)**
   ✅ P2.M1: `command` primitive — grammar, sync, background (#160-#162)
   ⬜ P2.M2: `session` core — grammar and lifecycle manager (#189-#190)
   ⬜ P2.M3: `AgentResult` + reliability contract — claims, evidence, verification (#193, #203)
   ⬜ P2.M4: session adapters + events — Claude/Codex/generic and event hooks (#191-#192)
   ⬜ P2.M5: verification + contradictions — trusted gating before repo mutations (#204-#205)
   ⬜ P2.M6: `sandbox` — worktree isolation for safe execution (#194)
-  ◐ P2.M7: Skills foundation — pluggable architecture, rich types (#163 ✅, #164-#165 open)
+  ◐ P2.M7: Skills foundation — pluggable architecture, rich types (#163 ✅, #164 ✅, #165 open)
   ⬜ P2.M8: CLI skills — GitHub, Slack, Claude Code, Codex/Ollama (#176-#179)
   ⬜ P2.M9: Orchestration — Slack Monitor, Triager, Approval gate (#180-#182)
   ⬜ P2.M10: Dev system — ProjectAgent, Executor, two-project proof (#183-#185)

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use crate::ast::{Expr, Program, Spanned, Stmt, TopLevel};
 use crate::diagnostic::Diagnostic;
-use crate::types::{is_compatible, CapabilitySignature, ForgeType};
+use crate::types::{from_type_name, is_compatible, CapabilitySignature, ForgeType};
 
 // ── Errors ───────────────────────────────────────────────────
 
@@ -22,6 +22,24 @@ pub enum ResolveError {
     CompositionMismatch {
         left: String,
         right: String,
+        span_start: usize,
+        span_end: usize,
+    },
+
+    #[error("capability `{name}` expects {expected} arguments but got {actual}")]
+    ArgumentCountMismatch {
+        name: String,
+        expected: usize,
+        actual: usize,
+        span_start: usize,
+        span_end: usize,
+    },
+
+    #[error("argument type mismatch for `{name}`: expected `{expected}`, got `{actual}`")]
+    ArgumentTypeMismatch {
+        name: String,
+        expected: String,
+        actual: String,
         span_start: usize,
         span_end: usize,
     },
@@ -72,6 +90,36 @@ impl ResolveError {
                 format!("composition type mismatch: `{}` → `{}`", left, right),
                 *span_start..*span_end,
                 format!("`{}` is not compatible with `{}`", left, right),
+            ),
+            ResolveError::ArgumentCountMismatch {
+                name,
+                expected,
+                actual,
+                span_start,
+                span_end,
+            } => Diagnostic::error(
+                file,
+                format!(
+                    "capability '{}' expects {} arguments but got {}",
+                    name, expected, actual
+                ),
+                *span_start..*span_end,
+                "adjust the skill call to match the declared signature",
+            ),
+            ResolveError::ArgumentTypeMismatch {
+                name,
+                expected,
+                actual,
+                span_start,
+                span_end,
+            } => Diagnostic::error(
+                file,
+                format!(
+                    "argument type mismatch for '{}': expected `{}`, got `{}`",
+                    name, expected, actual
+                ),
+                *span_start..*span_end,
+                "change the argument or update the skill capability signature",
             ),
         }
     }
@@ -282,26 +330,33 @@ impl CheckContext {
         for item in &program.items {
             match &item.node {
                 TopLevel::Task(task) => {
-                    self.check_stmts_composition(&task_body_stmts(task));
+                    let mut env = params_env(&task.needs);
+                    self.check_stmts_composition(&task_body_stmts(task), &mut env);
                 }
                 TopLevel::Pure(pure) => {
-                    self.check_stmts_composition(&pure.body);
+                    let mut env = params_env(&pure.needs);
+                    self.check_stmts_composition(&pure.body, &mut env);
                 }
                 TopLevel::Flow(flow) => {
+                    let base_env = params_env(&flow.needs);
                     for stage in &flow.stages {
-                        self.check_stmts_composition(&stage.node.body);
+                        let mut env = base_env.clone();
+                        self.check_stmts_composition(&stage.node.body, &mut env);
                     }
                 }
                 TopLevel::Agent(agent) => {
                     for handler in &agent.handlers {
-                        self.check_stmts_composition(&handler.node.body);
+                        let mut env = HashMap::new();
+                        self.check_stmts_composition(&handler.node.body, &mut env);
                     }
                 }
                 TopLevel::Endpoint(ep) => {
-                    self.check_stmts_composition(&ep.body);
+                    let mut env = params_env(&ep.params);
+                    self.check_stmts_composition(&ep.body, &mut env);
                 }
                 TopLevel::FnMain(main) => {
-                    self.check_stmts_composition(&main.body);
+                    let mut env = HashMap::new();
+                    self.check_stmts_composition(&main.body, &mut env);
                 }
                 _ => {}
             }
@@ -315,64 +370,88 @@ impl CheckContext {
     }
 
     /// Walk statements looking for Compose expressions and check type compatibility.
-    fn check_stmts_composition(&mut self, stmts: &[Spanned<Stmt>]) {
+    fn check_stmts_composition(
+        &mut self,
+        stmts: &[Spanned<Stmt>],
+        env: &mut HashMap<String, ForgeType>,
+    ) {
         for stmt in stmts {
-            self.check_stmt_composition(stmt);
+            self.check_stmt_composition(stmt, env);
         }
     }
 
-    fn check_stmt_composition(&mut self, stmt: &Spanned<Stmt>) {
+    fn check_stmt_composition(
+        &mut self,
+        stmt: &Spanned<Stmt>,
+        env: &mut HashMap<String, ForgeType>,
+    ) {
         match &stmt.node {
-            Stmt::Bind(_, expr) | Stmt::Say(expr) | Stmt::ExprStmt(expr) => {
-                self.check_expr_composition(expr);
+            Stmt::Bind(name, expr) => {
+                self.check_expr_composition(expr, env);
+                if let Some(ty) = infer_type(expr, env, &self.registry) {
+                    env.insert(name.node.clone(), ty);
+                }
+            }
+            Stmt::Say(expr) | Stmt::ExprStmt(expr) => {
+                self.check_expr_composition(expr, env);
             }
             Stmt::Give(expr, metas) => {
-                self.check_expr_composition(expr);
+                self.check_expr_composition(expr, env);
                 for meta in metas {
-                    self.check_expr_composition(&meta.node.value);
+                    self.check_expr_composition(&meta.node.value, env);
                 }
             }
             Stmt::When(when) => {
                 for clause in &when.clauses {
-                    self.check_stmt_composition(&clause.node.body);
+                    let mut branch_env = env.clone();
+                    self.check_stmt_composition(&clause.node.body, &mut branch_env);
                 }
                 if let Some(else_clause) = &when.else_body {
-                    self.check_stmt_composition(&else_clause.node.body);
+                    let mut branch_env = env.clone();
+                    self.check_stmt_composition(&else_clause.node.body, &mut branch_env);
                 }
             }
             Stmt::Match(m) => {
-                self.check_expr_composition(&m.subject);
+                self.check_expr_composition(&m.subject, env);
                 for arm in &m.arms {
-                    self.check_stmt_composition(&arm.node.body);
+                    let mut branch_env = env.clone();
+                    self.check_stmt_composition(&arm.node.body, &mut branch_env);
                 }
             }
             Stmt::IfElse(ie) => {
-                self.check_expr_composition(&ie.condition);
-                self.check_stmts_composition(&ie.then_body);
+                self.check_expr_composition(&ie.condition, env);
+                let mut then_env = env.clone();
+                self.check_stmts_composition(&ie.then_body, &mut then_env);
                 for (cond, body) in &ie.else_ifs {
-                    self.check_expr_composition(cond);
-                    self.check_stmts_composition(body);
+                    self.check_expr_composition(cond, env);
+                    let mut branch_env = env.clone();
+                    self.check_stmts_composition(body, &mut branch_env);
                 }
                 if let Some(body) = &ie.else_body {
-                    self.check_stmts_composition(body);
+                    let mut else_env = env.clone();
+                    self.check_stmts_composition(body, &mut else_env);
                 }
             }
             Stmt::For(f) => {
-                self.check_expr_composition(&f.iterable);
-                self.check_stmts_composition(&f.body);
+                self.check_expr_composition(&f.iterable, env);
+                let mut loop_env = env.clone();
+                self.check_stmts_composition(&f.body, &mut loop_env);
             }
             _ => {}
         }
     }
 
-    fn check_expr_composition(&mut self, expr: &Spanned<Expr>) {
+    fn check_expr_composition(&mut self, expr: &Spanned<Expr>, env: &HashMap<String, ForgeType>) {
         match &expr.node {
             Expr::Compose(parts) => {
                 // Check adjacent pairs for type compatibility
                 for window in parts.windows(2) {
                     let left = &window[0];
                     let right = &window[1];
-                    if let (Some(lt), Some(rt)) = (infer_type(left), infer_input_type(right)) {
+                    if let (Some(lt), Some(rt)) = (
+                        infer_type(left, env, &self.registry),
+                        infer_input_type(right, env, &self.registry),
+                    ) {
                         if !is_compatible(&lt, &rt) {
                             self.errors.push(ResolveError::CompositionMismatch {
                                 left: lt.to_string(),
@@ -385,44 +464,101 @@ impl CheckContext {
                 }
                 // Recurse into sub-expressions
                 for p in parts {
-                    self.check_expr_composition(p);
+                    self.check_expr_composition(p, env);
                 }
             }
             Expr::TryOr(a, b) => {
-                self.check_expr_composition(a);
-                self.check_expr_composition(b);
+                self.check_expr_composition(a, env);
+                self.check_expr_composition(b, env);
             }
             Expr::FanOut(parts) => {
                 for p in parts {
-                    self.check_expr_composition(p);
+                    self.check_expr_composition(p, env);
                 }
             }
             Expr::BinOp(a, _, b) => {
-                self.check_expr_composition(a);
-                self.check_expr_composition(b);
+                self.check_expr_composition(a, env);
+                self.check_expr_composition(b, env);
             }
             Expr::UnaryOp(_, a) => {
-                self.check_expr_composition(a);
+                self.check_expr_composition(a, env);
             }
             Expr::Call(c) => {
                 for arg in &c.args {
-                    self.check_expr_composition(&arg.node.value);
+                    self.check_expr_composition(&arg.node.value, env);
                 }
             }
             Expr::Paren(inner) | Expr::FieldAccess(inner, _) | Expr::GlobAccess(inner) => {
-                self.check_expr_composition(inner);
+                self.check_expr_composition(inner, env);
             }
             Expr::Index(a, b) => {
-                self.check_expr_composition(a);
-                self.check_expr_composition(b);
+                self.check_expr_composition(a, env);
+                self.check_expr_composition(b, env);
             }
-            Expr::MethodCall(inner, _, args) => {
-                self.check_expr_composition(inner);
+            Expr::MethodCall(inner, method, args) => {
+                self.check_skill_call(inner, method, args, env);
+                self.check_expr_composition(inner, env);
                 for arg in args {
-                    self.check_expr_composition(&arg.node.value);
+                    self.check_expr_composition(&arg.node.value, env);
                 }
             }
             _ => {}
+        }
+    }
+
+    fn check_skill_call(
+        &mut self,
+        inner: &Spanned<Expr>,
+        method: &Spanned<String>,
+        args: &[Spanned<crate::ast::CallArg>],
+        env: &HashMap<String, ForgeType>,
+    ) {
+        let Expr::FieldAccess(target, namespace) = &inner.node else {
+            return;
+        };
+        let Expr::Ident(prefix) = &target.node else {
+            return;
+        };
+        if prefix != "skill" {
+            return;
+        }
+
+        let full_name = format!("skill.{}.{}", namespace.node, method.node);
+        if let Some(sig) = self.registry.resolve(&full_name) {
+            if sig.inputs.len() != args.len() {
+                self.errors.push(ResolveError::ArgumentCountMismatch {
+                    name: full_name,
+                    expected: sig.inputs.len(),
+                    actual: args.len(),
+                    span_start: method.span.start,
+                    span_end: method.span.end,
+                });
+                return;
+            }
+
+            for (arg, expected) in args.iter().zip(&sig.inputs) {
+                if let Some(actual) = infer_type(&arg.node.value, env, &self.registry) {
+                    if !is_compatible(&actual, expected) {
+                        self.errors.push(ResolveError::ArgumentTypeMismatch {
+                            name: full_name.clone(),
+                            expected: expected.to_string(),
+                            actual: actual.to_string(),
+                            span_start: arg.span.start,
+                            span_end: arg.span.end,
+                        });
+                    }
+                }
+            }
+            return;
+        }
+
+        let legacy_name = format!("skill.{}", namespace.node);
+        if self.registry.resolve(&legacy_name).is_none() {
+            self.errors.push(ResolveError::UnknownCapability {
+                name: full_name,
+                span_start: method.span.start,
+                span_end: method.span.end,
+            });
         }
     }
 }
@@ -430,24 +566,59 @@ impl CheckContext {
 // ── Type inference (partial, POC) ────────────────────────────
 
 /// Infer the output type of an expression (partial — returns None for unknowns).
-fn infer_type(expr: &Spanned<Expr>) -> Option<ForgeType> {
+fn infer_type(
+    expr: &Spanned<Expr>,
+    env: &HashMap<String, ForgeType>,
+    registry: &CapabilityRegistry,
+) -> Option<ForgeType> {
     match &expr.node {
         Expr::NumberLit(_) => Some(ForgeType::Number),
         Expr::BoolLit(_) => Some(ForgeType::Bool),
+        Expr::Ident(name) => env.get(name).cloned(),
         Expr::Template(_) => Some(ForgeType::Text),
         Expr::Reason(_) => Some(ForgeType::Text),
         Expr::Exec(_) => Some(ForgeType::Text),
         Expr::Command(_) | Expr::CommandMethod(_, _) => Some(ForgeType::Text),
         Expr::Classify(_) => Some(ForgeType::Classification),
         Expr::Search(_) => Some(ForgeType::Results),
-        Expr::Compose(parts) => parts.last().and_then(infer_type),
+        Expr::Paren(inner) => infer_type(inner, env, registry),
+        Expr::FieldAccess(inner, field) => {
+            if matches!(&inner.node, Expr::Ident(prefix) if prefix == "skill") {
+                return registry
+                    .resolve(&format!("skill.{}", field.node))
+                    .map(|sig| sig.output.clone());
+            }
+            None
+        }
+        Expr::MethodCall(inner, method, _) => {
+            if let Expr::FieldAccess(target, namespace) = &inner.node {
+                if matches!(&target.node, Expr::Ident(prefix) if prefix == "skill") {
+                    return registry
+                        .resolve(&format!("skill.{}.{}", namespace.node, method.node))
+                        .map(|sig| sig.output.clone())
+                        .or_else(|| {
+                            registry
+                                .resolve(&format!("skill.{}", namespace.node))
+                                .map(|sig| sig.output.clone())
+                        });
+                }
+            }
+            None
+        }
+        Expr::Compose(parts) => parts
+            .last()
+            .and_then(|expr| infer_type(expr, env, registry)),
         Expr::ArrayLit(_) => None, // would need element type inference
         _ => None,
     }
 }
 
 /// Infer the expected input type for an expression when used as the RHS of `>>`.
-fn infer_input_type(expr: &Spanned<Expr>) -> Option<ForgeType> {
+fn infer_input_type(
+    expr: &Spanned<Expr>,
+    _env: &HashMap<String, ForgeType>,
+    registry: &CapabilityRegistry,
+) -> Option<ForgeType> {
     match &expr.node {
         // Most callables accept Text in the POC
         Expr::Call(_) => Some(ForgeType::Text),
@@ -456,8 +627,35 @@ fn infer_input_type(expr: &Spanned<Expr>) -> Option<ForgeType> {
         Expr::Command(_) | Expr::CommandMethod(_, _) => Some(ForgeType::Text),
         Expr::Classify(_) => Some(ForgeType::Text),
         Expr::Search(_) => Some(ForgeType::Text),
+        Expr::MethodCall(inner, method, _) => {
+            if let Expr::FieldAccess(target, namespace) = &inner.node {
+                if matches!(&target.node, Expr::Ident(prefix) if prefix == "skill") {
+                    return registry
+                        .resolve(&format!("skill.{}.{}", namespace.node, method.node))
+                        .and_then(|sig| sig.inputs.first().cloned())
+                        .or_else(|| {
+                            registry
+                                .resolve(&format!("skill.{}", namespace.node))
+                                .and_then(|sig| sig.inputs.first().cloned())
+                        });
+                }
+            }
+            None
+        }
         _ => None,
     }
+}
+
+fn params_env(params: &[Spanned<crate::ast::Param>]) -> HashMap<String, ForgeType> {
+    params
+        .iter()
+        .map(|param| {
+            (
+                param.node.name.clone(),
+                from_type_name(&param.node.type_name.node),
+            )
+        })
+        .collect()
 }
 
 /// Extract statements from a task body.

--- a/src/runtime/skill.rs
+++ b/src/runtime/skill.rs
@@ -3,15 +3,23 @@
 
 use crate::types::CapabilitySignature;
 
+#[derive(Debug, Clone)]
+pub struct SkillCapability {
+    pub name: String,
+    pub signature: CapabilitySignature,
+}
+
 /// Metadata about a skill, loaded from SKILL.md frontmatter or config.
 #[derive(Debug, Clone)]
 pub struct SkillManifest {
-    /// Fully-qualified name: "slack.post_message"
+    /// Namespace name: "slack"
     pub name: String,
     /// Human-readable description
     pub description: String,
-    /// Type signature for compile-time validation
-    pub signature: CapabilitySignature,
+    /// Explicit typed capabilities exposed by this skill.
+    pub capabilities: Vec<SkillCapability>,
+    /// Legacy single-capability compatibility surface for skills without explicit capabilities.
+    pub legacy_signature: Option<CapabilitySignature>,
     /// Default confidence for results (capped at 0.99)
     pub default_confidence: f32,
     /// Timeout in seconds for skill execution
@@ -35,6 +43,9 @@ pub struct LoadedSkill {
 pub enum SkillError {
     #[error("skill not found: {name}")]
     NotFound { name: String },
+
+    #[error("skill method not found: {skill}.{method}")]
+    UnknownMethod { skill: String, method: String },
 
     #[error("skill execution failed: {name}: {reason}")]
     ExecutionFailed { name: String, reason: String },

--- a/src/runtime/skill_executor.rs
+++ b/src/runtime/skill_executor.rs
@@ -59,6 +59,19 @@ impl SkillExecutor {
                 })?
         };
 
+        if skill.manifest.legacy_signature.is_none()
+            && !skill
+                .manifest
+                .capabilities
+                .iter()
+                .any(|cap| cap.name == method)
+        {
+            return Err(SkillError::UnknownMethod {
+                skill: skill_name.to_string(),
+                method: method.to_string(),
+            });
+        }
+
         if let Some(ref tracer) = self.tracer {
             tracer.skill_call(&format!("{}.{}", skill_name, method));
         }

--- a/src/runtime/skill_loader.rs
+++ b/src/runtime/skill_loader.rs
@@ -3,8 +3,9 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::runtime::skill::{LoadedSkill, SkillManifest};
+use crate::runtime::skill::{LoadedSkill, SkillCapability, SkillManifest};
 use crate::types::{CapabilitySignature, ForgeType};
+use serde::Deserialize;
 
 /// Loads SKILL.md files from configured directories.
 pub struct SkillLoader;
@@ -51,14 +52,21 @@ impl SkillLoader {
             .map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
 
         let (frontmatter, body) = split_frontmatter(&content)?;
+        let capabilities = frontmatter.parse_capabilities()?;
+        let legacy_signature = if frontmatter.capabilities.is_some() {
+            None
+        } else {
+            Some(CapabilitySignature {
+                inputs: vec![ForgeType::Text],
+                output: ForgeType::Text,
+            })
+        };
 
         let manifest = SkillManifest {
             name: frontmatter.name,
-            description: frontmatter.description,
-            signature: CapabilitySignature {
-                inputs: vec![ForgeType::Text],
-                output: ForgeType::Text,
-            },
+            description: frontmatter.description.unwrap_or_default(),
+            capabilities,
+            legacy_signature,
             default_confidence: 0.85,
             timeout_secs: frontmatter.timeout.unwrap_or(30),
             allowed_tools: frontmatter.allowed_tools,
@@ -73,12 +81,57 @@ impl SkillLoader {
 }
 
 /// Parsed SKILL.md YAML frontmatter.
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 struct SkillFrontmatter {
     name: String,
-    description: String,
+    description: Option<String>,
     timeout: Option<u64>,
+    #[serde(
+        rename = "allowed-tools",
+        default,
+        deserialize_with = "deserialize_tools"
+    )]
     allowed_tools: Vec<String>,
+    capabilities: Option<Vec<SkillCapabilityFrontmatter>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillCapabilityFrontmatter {
+    name: String,
+    inputs: Vec<String>,
+    output: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ToolList {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl SkillFrontmatter {
+    fn parse_capabilities(&self) -> Result<Vec<SkillCapability>, String> {
+        self.capabilities
+            .as_ref()
+            .map(|caps| {
+                caps.iter()
+                    .map(|cap| {
+                        Ok(SkillCapability {
+                            name: cap.name.clone(),
+                            signature: CapabilitySignature {
+                                inputs: cap
+                                    .inputs
+                                    .iter()
+                                    .map(|ty| parse_forge_type(ty))
+                                    .collect::<Result<Vec<_>, _>>()?,
+                                output: parse_forge_type(&cap.output)?,
+                            },
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_else(|| Ok(Vec::new()))
+    }
 }
 
 /// Split a SKILL.md file into frontmatter and body.
@@ -100,43 +153,54 @@ fn split_frontmatter(content: &str) -> Result<(SkillFrontmatter, String), String
     Ok((frontmatter, body))
 }
 
-/// Simple YAML-like frontmatter parser (no serde_yaml dependency).
 fn parse_frontmatter(yaml: &str) -> Result<SkillFrontmatter, String> {
-    let mut name = String::new();
-    let mut description = String::new();
-    let mut timeout = None;
-    let mut allowed_tools = Vec::new();
-
-    for line in yaml.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        if let Some((key, value)) = line.split_once(':') {
-            let key = key.trim();
-            let value = value.trim();
-            match key {
-                "name" => name = value.to_string(),
-                "description" => description = value.to_string(),
-                "timeout" => timeout = value.parse().ok(),
-                "allowed-tools" => {
-                    allowed_tools = value.split_whitespace().map(|s| s.to_string()).collect();
-                }
-                _ => {} // Ignore unknown fields
-            }
-        }
-    }
-
-    if name.is_empty() {
+    let frontmatter: SkillFrontmatter =
+        serde_yaml::from_str(yaml).map_err(|e| format!("invalid SKILL.md frontmatter: {e}"))?;
+    if frontmatter.name.trim().is_empty() {
         return Err("SKILL.md frontmatter must have a 'name' field".to_string());
     }
+    Ok(frontmatter)
+}
 
-    Ok(SkillFrontmatter {
-        name,
-        description,
-        timeout,
-        allowed_tools,
+fn deserialize_tools<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let tools = Option::<ToolList>::deserialize(deserializer)?;
+    Ok(match tools {
+        Some(ToolList::One(tool)) => tool.split_whitespace().map(|s| s.to_string()).collect(),
+        Some(ToolList::Many(tools)) => tools,
+        None => Vec::new(),
     })
+}
+
+fn parse_forge_type(name: &str) -> Result<ForgeType, String> {
+    let name = name.trim();
+    if let Some(inner) = name.strip_suffix("[]") {
+        return Ok(ForgeType::Array(Box::new(parse_forge_type(inner)?), None));
+    }
+    match name {
+        "Text" => Ok(ForgeType::Text),
+        "Number" => Ok(ForgeType::Number),
+        "Bool" => Ok(ForgeType::Bool),
+        "Unit" => Ok(ForgeType::Unit),
+        "Results" => Ok(ForgeType::Results),
+        "Report" => Ok(ForgeType::Report),
+        "Intent" => Ok(ForgeType::Intent),
+        "Classification" => Ok(ForgeType::Classification),
+        "Summary" => Ok(ForgeType::Summary),
+        "Failure" => Ok(ForgeType::Failure),
+        "Conversation" => Ok(ForgeType::Conversation),
+        "Profile" => Ok(ForgeType::Profile),
+        "SearchResults" => Ok(ForgeType::SearchResults),
+        "Request" => Ok(ForgeType::Request),
+        "Response" => Ok(ForgeType::Response),
+        "Headers" => Ok(ForgeType::Headers),
+        "Html" => Ok(ForgeType::Html),
+        "Embedding" => Ok(ForgeType::Embedding),
+        "Duration" => Ok(ForgeType::Duration),
+        other => Ok(ForgeType::Named(other.to_string())),
+    }
 }
 
 #[cfg(test)]
@@ -149,7 +213,9 @@ mod tests {
 name: slack-post
 description: Post messages to Slack channels
 timeout: 15
-allowed-tools: Bash WebFetch
+allowed-tools:
+  - Bash
+  - WebFetch
 ---
 
 Follow these instructions to post a message to Slack.
@@ -158,7 +224,10 @@ Use curl to call the Slack API.
 "#;
         let (fm, body) = split_frontmatter(content).unwrap();
         assert_eq!(fm.name, "slack-post");
-        assert_eq!(fm.description, "Post messages to Slack channels");
+        assert_eq!(
+            fm.description.as_deref(),
+            Some("Post messages to Slack channels")
+        );
         assert_eq!(fm.timeout, Some(15));
         assert_eq!(fm.allowed_tools, vec!["Bash", "WebFetch"]);
         assert!(body.contains("Follow these instructions"));
@@ -169,7 +238,7 @@ Use curl to call the Slack API.
         let content = "---\nname: test-skill\n---\nBody here.";
         let (fm, body) = split_frontmatter(content).unwrap();
         assert_eq!(fm.name, "test-skill");
-        assert!(fm.description.is_empty());
+        assert!(fm.description.is_none());
         assert_eq!(fm.timeout, None);
         assert!(fm.allowed_tools.is_empty());
         assert_eq!(body, "Body here.");
@@ -185,5 +254,27 @@ Use curl to call the Slack API.
     fn reject_missing_frontmatter() {
         let content = "No frontmatter here.";
         assert!(split_frontmatter(content).is_err());
+    }
+
+    #[test]
+    fn parse_typed_capabilities() {
+        let content = r#"---
+name: github
+capabilities:
+  - name: create_issue
+    inputs: [Text, Text, Text]
+    output: Text
+  - name: list_issues
+    inputs: [Text]
+    output: Text
+---
+Body.
+"#;
+        let (fm, _) = split_frontmatter(content).unwrap();
+        let caps = fm.parse_capabilities().unwrap();
+        assert_eq!(caps.len(), 2);
+        assert_eq!(caps[0].name, "create_issue");
+        assert_eq!(caps[0].signature.inputs.len(), 3);
+        assert_eq!(caps[1].signature.output, ForgeType::Text);
     }
 }

--- a/src/runtime/skill_registry.rs
+++ b/src/runtime/skill_registry.rs
@@ -29,10 +29,19 @@ impl SkillRegistry {
 
     /// Return capability signatures for resolver integration (compile-time validation).
     pub fn capability_signatures(&self) -> HashMap<String, CapabilitySignature> {
-        self.skills
-            .iter()
-            .map(|(k, v)| (format!("skill.{}", k), v.manifest.signature.clone()))
-            .collect()
+        let mut signatures = HashMap::new();
+        for (name, skill) in &self.skills {
+            if let Some(sig) = &skill.manifest.legacy_signature {
+                signatures.insert(format!("skill.{}", name), sig.clone());
+            }
+            for capability in &skill.manifest.capabilities {
+                signatures.insert(
+                    format!("skill.{}.{}", name, capability.name),
+                    capability.signature.clone(),
+                );
+            }
+        }
+        signatures
     }
 
     pub fn skill_count(&self) -> usize {

--- a/tests/skill_integration_tests.rs
+++ b/tests/skill_integration_tests.rs
@@ -42,6 +42,19 @@ fn create_temp_skill(name: &str, description: &str, body: &str) -> tempfile::Tem
     dir
 }
 
+fn create_typed_temp_skill(name: &str, body: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let skill_dir = dir.path().join(name);
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    let mut file = std::fs::File::create(skill_dir.join("SKILL.md")).unwrap();
+    write!(
+        file,
+        "---\nname: {name}\ncapabilities:\n  - name: create_issue\n    inputs: [Text, Text, Text]\n    output: Text\n  - name: list_issues\n    inputs: [Text]\n    output: Text\nallowed-tools:\n  - Bash\n---\n\n{body}"
+    )
+    .unwrap();
+    dir
+}
+
 // ── SKILL.md Loading Tests ──────────────────────────────────────
 
 #[test]
@@ -154,6 +167,22 @@ fn skill_registry_generates_capability_signatures() {
         "should have skill.echo-skill capability, got: {:?}",
         sigs.keys().collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn skill_registry_generates_multi_capability_signatures() {
+    let dir = create_typed_temp_skill("github", "Manage GitHub issues.");
+
+    let skills = SkillLoader::load_from_dirs(&[dir.path().to_path_buf()]);
+    let mut registry = SkillRegistry::new();
+    for skill in skills {
+        registry.register(skill);
+    }
+
+    let sigs = registry.capability_signatures();
+    assert!(sigs.contains_key("skill.github.create_issue"));
+    assert!(sigs.contains_key("skill.github.list_issues"));
+    assert!(!sigs.contains_key("skill.github"));
 }
 
 // ── Confidence Model Tests ──────────────────────────────────────
@@ -574,6 +603,94 @@ fn use_skill_validated_at_compile_time() {
         "use skill.myskill should pass with skill registered: {:?}",
         result_with_skills.err()
     );
+}
+
+#[test]
+fn use_typed_skill_capability_validated_at_compile_time() {
+    let source = "use\n  skill.github.create_issue\n\ntask run\n  gives Text\n  do\n    give skill.github.create_issue(\"repo\", \"title\", \"body\")\n";
+    let program = forge::parser::parse(source).unwrap();
+
+    let mut sigs = std::collections::HashMap::new();
+    sigs.insert(
+        "skill.github.create_issue".into(),
+        forge::types::CapabilitySignature {
+            inputs: vec![
+                forge::types::ForgeType::Text,
+                forge::types::ForgeType::Text,
+                forge::types::ForgeType::Text,
+            ],
+            output: forge::types::ForgeType::Text,
+        },
+    );
+    let ctx = forge::resolver::CheckContext::with_skills("test.forge", sigs);
+    assert!(ctx.check(&program).is_ok());
+}
+
+#[test]
+fn typed_skill_call_rejects_argument_count_mismatch() {
+    let source = "use\n  skill.github.create_issue\n\ntask run\n  gives Text\n  do\n    give skill.github.create_issue(\"repo\", \"title\")\n";
+    let program = forge::parser::parse(source).unwrap();
+
+    let mut sigs = std::collections::HashMap::new();
+    sigs.insert(
+        "skill.github.create_issue".into(),
+        forge::types::CapabilitySignature {
+            inputs: vec![
+                forge::types::ForgeType::Text,
+                forge::types::ForgeType::Text,
+                forge::types::ForgeType::Text,
+            ],
+            output: forge::types::ForgeType::Text,
+        },
+    );
+    let ctx = forge::resolver::CheckContext::with_skills("test.forge", sigs);
+    let errs = ctx.check(&program).unwrap_err();
+    assert!(errs.iter().any(|err| {
+        matches!(
+            err,
+            forge::resolver::ResolveError::ArgumentCountMismatch { name, expected, actual, .. }
+            if name == "skill.github.create_issue" && *expected == 3 && *actual == 2
+        )
+    }));
+}
+
+#[test]
+fn typed_skill_call_rejects_argument_type_mismatch() {
+    let source = "use\n  skill.github.create_issue\n\ntask run\n  needs title: Number\n  gives Text\n  do\n    give skill.github.create_issue(\"repo\", title, \"body\")\n";
+    let program = forge::parser::parse(source).unwrap();
+
+    let mut sigs = std::collections::HashMap::new();
+    sigs.insert(
+        "skill.github.create_issue".into(),
+        forge::types::CapabilitySignature {
+            inputs: vec![
+                forge::types::ForgeType::Text,
+                forge::types::ForgeType::Text,
+                forge::types::ForgeType::Text,
+            ],
+            output: forge::types::ForgeType::Text,
+        },
+    );
+    let ctx = forge::resolver::CheckContext::with_skills("test.forge", sigs);
+    let errs = ctx.check(&program).unwrap_err();
+    assert!(errs.iter().any(|err| {
+        matches!(
+            err,
+            forge::resolver::ResolveError::ArgumentTypeMismatch { name, expected, actual, .. }
+            if name == "skill.github.create_issue" && expected == "Text" && actual == "Number"
+        )
+    }));
+}
+
+#[test]
+fn typed_skill_loader_parses_capabilities() {
+    let dir = create_typed_temp_skill("github", "Manage GitHub issues.");
+    let skills = SkillLoader::load_from_dirs(&[dir.path().to_path_buf()]);
+    assert_eq!(skills.len(), 1);
+    let skill = &skills[0];
+    assert_eq!(skill.manifest.capabilities.len(), 2);
+    assert!(skill.manifest.legacy_signature.is_none());
+    assert_eq!(skill.manifest.capabilities[0].name, "create_issue");
 }
 
 // ── Full pipeline: skill_finder.forge example ───────────────────


### PR DESCRIPTION
## Summary
- add multi-capability SKILL.md parsing with typed `inputs`/`output` signatures
- register typed skill capabilities as `skill.namespace.method` while keeping legacy `skill.namespace` compatibility
- validate skill method call arity/types at compile time and guard runtime dispatch for explicit-capability skills

## Test plan
- cargo test --quiet
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- live run: `examples/skill_project` with real provider config
- live run: temporary typed-capability skill project using `use skill.git_typed.recent_log` with real provider config

Refs #164