### PR TITLE
feat: AgentResult built-in type (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- `AgentResult` built-in type — standard typed result contract for agent/session runs with 9 fields: `plan`, `patch_summary`, `files_changed`, `tests_run`, `tests_passed`, `cost_usd`, `confidence`, `approval_needed`, `metadata` (#193)
+- `AgentResult` constructor with default fields: `AgentResult()` or `AgentResult(plan: "fix bug", confidence: 0.9)` — unspecified fields get zero/empty defaults (#193)
+- `AgentResult` confidence sync: the `confidence` field value propagates to the `ConfidentValue` wrapper, enabling `when result.sure ->` branching (#193)
 - Agent-to-CLI delegation research doc for Claude Code and Codex, including session adapter and AgentResult mapping tables plus live-tested invocation patterns (#165)
 - Reference typed SKILL.md wrappers for Claude Code and Codex under `skills/` (#165)
 - Rich SKILL.md capability signatures with multi-capability registration and compile-time validation of `skill.namespace.method(...)` calls (#164)

--- a/conformance/runtime/agent_result_array_field.json
+++ b/conformance/runtime/agent_result_array_field.json
@@ -1,0 +1,7 @@
+{
+  "name": "agent_result_array_field",
+  "category": "runtime",
+  "description": "AgentResult files_changed array field with length access",
+  "input": "fn main\n  r = AgentResult(files_changed: [\"src/main.rs\", \"src/lib.rs\"])\n  say \"{r.files_changed.len}\"\n",
+  "expected": { "outcome": "run_ok" }
+}

--- a/conformance/runtime/agent_result_construct.json
+++ b/conformance/runtime/agent_result_construct.json
@@ -1,0 +1,7 @@
+{
+  "name": "agent_result_construct",
+  "category": "runtime",
+  "description": "AgentResult built-in type: construction with named args and field access",
+  "input": "fn main\n  r = AgentResult(plan: \"fix the bug\", confidence: 0.85, tests_run: 3, tests_passed: 3)\n  say r.plan\n  say \"{r.confidence}\"\n  say \"{r.tests_passed}\"\n  say \"{r.approval_needed}\"\n",
+  "expected": { "outcome": "run_ok" }
+}

--- a/conformance/runtime/agent_result_default.json
+++ b/conformance/runtime/agent_result_default.json
@@ -1,0 +1,7 @@
+{
+  "name": "agent_result_default",
+  "category": "runtime",
+  "description": "AgentResult with no args produces all fields at default values",
+  "input": "fn main\n  r = AgentResult()\n  say r.plan\n  say \"{r.tests_run}\"\n  say \"{r.approval_needed}\"\n  say \"{r.cost_usd}\"\n",
+  "expected": { "outcome": "run_ok" }
+}

--- a/conformance/runtime/agent_result_type_annotation.json
+++ b/conformance/runtime/agent_result_type_annotation.json
@@ -1,0 +1,7 @@
+{
+  "name": "agent_result_type_annotation",
+  "category": "runtime",
+  "description": "AgentResult used as return type annotation in a pure function",
+  "input": "pure make_result\n  needs plan_text: Text\n  gives AgentResult\n  do\n    give AgentResult(plan: plan_text, confidence: 0.9)\n\nfn main\n  r = make_result(\"deploy fix\")\n  say r.plan\n",
+  "expected": { "outcome": "run_ok" }
+}

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -77,7 +77,8 @@ template_text   = @{ (!("\"" | "{" | "\\") ~ ANY)+ }
 builtin_type = @{
     ( "Text" | "Number" | "Bool" | "Results" | "Report" | "Intent"
     | "Summary" | "Failure" | "Classification" | "Conversation"
-    | "Profile" | "SearchResults" | "Request" | "Response" | "Headers" | "Html" )
+    | "Profile" | "SearchResults" | "Request" | "Response" | "Headers" | "Html"
+    | "AgentResult" )
     ~ !(ASCII_ALPHANUMERIC | "_")
 }
 type_name    = { (builtin_type | ident) ~ array_suffix? }

--- a/roadmap.md
+++ b/roadmap.md
@@ -629,9 +629,10 @@ result = session "implement the login page" via claude in "/repo" timeout 30m
 ### AgentResult (new — #193)
 
 Built-in typed result contract for session returns:
-- Fields: `success`, `output`, `artifacts`, `cost`, `confidence`, `approval_needed`
+- Fields: `plan`, `patch_summary`, `files_changed`, `tests_run`, `tests_passed`, `cost_usd`, `confidence`, `approval_needed`, `metadata`
 - Replaces ad-hoc text parsing of agent output
 - Enables confident branching: `when result.sure -> ...`
+- `metadata: Map` extensibility hook for #203 (claim/evidence/verification contract)
 
 ### sandbox (new — #194)
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -454,6 +454,7 @@ pub enum TypeName {
     Response,
     Headers,
     Html,
+    AgentResult,
     Custom(String),
     /// Array type: `Text[9]` = Array(Text, Some(9)), `Player[]` = Array(Custom("Player"), None)
     Array(Box<TypeName>, Option<usize>),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -149,6 +149,7 @@ fn build_type_name(pair: Pair) -> anyhow::Result<Spanned<TypeName>> {
             "Response" => TypeName::Response,
             "Headers" => TypeName::Headers,
             "Html" => TypeName::Html,
+            "AgentResult" => TypeName::AgentResult,
             other => TypeName::Custom(other.to_string()),
         },
         Rule::ident => TypeName::Custom(first.as_str().to_string()),
@@ -361,6 +362,7 @@ fn build_atom(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
                 "Response" => TypeName::Response,
                 "Headers" => TypeName::Headers,
                 "Html" => TypeName::Html,
+                "AgentResult" => TypeName::AgentResult,
                 other => TypeName::Custom(other.to_string()),
             };
             Ok(Spanned::new(
@@ -453,6 +455,7 @@ fn build_constructor_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
         "Response" => TypeName::Response,
         "Headers" => TypeName::Headers,
         "Html" => TypeName::Html,
+        "AgentResult" => TypeName::AgentResult,
         other => TypeName::Custom(other.to_string()),
     };
     let args = if let Some(arg_list) = inner.next() {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -608,6 +608,7 @@ fn infer_type(
         Expr::Compose(parts) => parts
             .last()
             .and_then(|expr| infer_type(expr, env, registry)),
+        Expr::Constructor(ctor) => Some(crate::types::from_type_name(&ctor.type_name.node)),
         Expr::ArrayLit(_) => None, // would need element type inference
         _ => None,
     }

--- a/src/runtime/confidence.rs
+++ b/src/runtime/confidence.rs
@@ -172,6 +172,80 @@ impl ConfidentValue {
         }
     }
 
+    /// Create a default AgentResult with all fields at zero/empty values.
+    pub fn default_agent_result() -> Self {
+        let fields = Self::default_agent_result_fields();
+        Self {
+            value: Value::Record(fields),
+            confidence: 0.0,
+            source: ConfidenceSource::Derived(0.0),
+        }
+    }
+
+    /// Build the default fields HashMap for AgentResult.
+    pub fn default_agent_result_fields() -> HashMap<String, ConfidentValue> {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "plan".to_string(),
+            ConfidentValue::deterministic(Value::Text(String::new())),
+        );
+        fields.insert(
+            "patch_summary".to_string(),
+            ConfidentValue::deterministic(Value::Text(String::new())),
+        );
+        fields.insert(
+            "files_changed".to_string(),
+            ConfidentValue::deterministic(Value::Array(Vec::new())),
+        );
+        fields.insert(
+            "tests_run".to_string(),
+            ConfidentValue::deterministic(Value::Number(0.0)),
+        );
+        fields.insert(
+            "tests_passed".to_string(),
+            ConfidentValue::deterministic(Value::Number(0.0)),
+        );
+        fields.insert(
+            "cost_usd".to_string(),
+            ConfidentValue::deterministic(Value::Number(0.0)),
+        );
+        fields.insert(
+            "confidence".to_string(),
+            ConfidentValue::deterministic(Value::Number(0.0)),
+        );
+        fields.insert(
+            "approval_needed".to_string(),
+            ConfidentValue::deterministic(Value::Bool(false)),
+        );
+        fields.insert(
+            "metadata".to_string(),
+            ConfidentValue::deterministic(Value::Record(HashMap::new())),
+        );
+        fields
+    }
+
+    /// Create an AgentResult from adapter output, merging with defaults and syncing confidence.
+    pub fn from_agent_result(fields: HashMap<String, ConfidentValue>) -> Self {
+        let mut result_fields = Self::default_agent_result_fields();
+        for (k, v) in fields {
+            result_fields.insert(k, v);
+        }
+        // Sync wrapper confidence from the confidence field
+        let conf = result_fields
+            .get("confidence")
+            .and_then(|cv| match &cv.value {
+                Value::Number(n) => Some(*n as f32),
+                _ => None,
+            })
+            .unwrap_or(0.0);
+        let conf = clamp_confidence(conf);
+        Self {
+            value: Value::Record(result_fields),
+            confidence: conf,
+            source: ConfidenceSource::Derived(conf),
+        }
+    }
+
     /// Create from external skill invocation — never deterministic (Principle I).
     /// Capped at 0.99 because external systems are oracles.
     pub fn from_skill(value: Value, confidence: f32) -> Self {
@@ -411,5 +485,79 @@ mod tests {
         let cv = ConfidentValue::from_skill(text_val("result"), 0.85);
         assert_eq!(cv.confidence, 0.85);
         assert!(cv.sure());
+    }
+
+    // ── AgentResult tests ──────────────────────────────────────
+
+    #[test]
+    fn default_agent_result_has_all_fields() {
+        let cv = ConfidentValue::default_agent_result();
+        if let Value::Record(fields) = &cv.value {
+            assert_eq!(fields.len(), 9);
+            assert!(fields.contains_key("plan"));
+            assert!(fields.contains_key("patch_summary"));
+            assert!(fields.contains_key("files_changed"));
+            assert!(fields.contains_key("tests_run"));
+            assert!(fields.contains_key("tests_passed"));
+            assert!(fields.contains_key("cost_usd"));
+            assert!(fields.contains_key("confidence"));
+            assert!(fields.contains_key("approval_needed"));
+            assert!(fields.contains_key("metadata"));
+        } else {
+            panic!("expected Record");
+        }
+    }
+
+    #[test]
+    fn default_agent_result_confidence_zero() {
+        let cv = ConfidentValue::default_agent_result();
+        assert_eq!(cv.confidence, 0.0);
+    }
+
+    #[test]
+    fn default_agent_result_field_defaults() {
+        let cv = ConfidentValue::default_agent_result();
+        if let Value::Record(fields) = &cv.value {
+            assert!(matches!(&fields["plan"].value, Value::Text(s) if s.is_empty()));
+            assert!(matches!(&fields["tests_run"].value, Value::Number(n) if *n == 0.0));
+            assert!(matches!(
+                &fields["approval_needed"].value,
+                Value::Bool(false)
+            ));
+            assert!(matches!(&fields["files_changed"].value, Value::Array(v) if v.is_empty()));
+            assert!(matches!(&fields["metadata"].value, Value::Record(m) if m.is_empty()));
+        } else {
+            panic!("expected Record");
+        }
+    }
+
+    #[test]
+    fn from_agent_result_syncs_confidence() {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "confidence".to_string(),
+            ConfidentValue::deterministic(Value::Number(0.85)),
+        );
+        let cv = ConfidentValue::from_agent_result(fields);
+        assert_eq!(cv.confidence, 0.85);
+        assert!(cv.sure());
+    }
+
+    #[test]
+    fn from_agent_result_merges_with_defaults() {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "plan".to_string(),
+            ConfidentValue::deterministic(Value::Text("fix bug".to_string())),
+        );
+        let cv = ConfidentValue::from_agent_result(fields);
+        if let Value::Record(f) = &cv.value {
+            assert_eq!(f.len(), 9);
+            assert!(matches!(&f["plan"].value, Value::Text(s) if s == "fix bug"));
+            // Unspecified fields should be defaults
+            assert!(matches!(&f["tests_run"].value, Value::Number(n) if *n == 0.0));
+        } else {
+            panic!("expected Record");
+        }
     }
 }

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -2037,9 +2037,15 @@ impl TaskExecutor {
                     }
                 }
 
-                Expr::TypeAccess(_type_name, variant) => Ok(ConfidentValue::deterministic(
-                    Value::Text(variant.node.clone()),
-                )),
+                Expr::TypeAccess(type_name, variant) => {
+                    if matches!(type_name.node, TypeName::AgentResult) && variant.node == "default"
+                    {
+                        return Ok(ConfidentValue::default_agent_result());
+                    }
+                    Ok(ConfidentValue::deterministic(Value::Text(
+                        variant.node.clone(),
+                    )))
+                }
 
                 Expr::GlobAccess(inner) => self.eval_expr(inner, env).await,
 
@@ -2184,6 +2190,26 @@ impl TaskExecutor {
                             .map(|l| l.node.clone())
                             .unwrap_or_else(|| format!("_{}", i));
                         fields.insert(key, val);
+                    }
+                    // AgentResult: merge with defaults and sync confidence
+                    if matches!(ctor.type_name.node, TypeName::AgentResult) {
+                        let mut defaults = ConfidentValue::default_agent_result_fields();
+                        for (k, v) in fields {
+                            defaults.insert(k, v);
+                        }
+                        let wrapper_conf = defaults
+                            .get("confidence")
+                            .and_then(|cv| match &cv.value {
+                                Value::Number(n) => Some(*n as f32),
+                                _ => None,
+                            })
+                            .unwrap_or(0.0);
+                        let conf = wrapper_conf.clamp(0.0, 1.0);
+                        return Ok(ConfidentValue {
+                            value: Value::Record(defaults),
+                            confidence: conf,
+                            source: crate::types::ConfidenceSource::Derived(conf),
+                        });
                     }
                     Ok(ConfidentValue::deterministic(Value::Record(fields)))
                 }

--- a/src/runtime/memory.rs
+++ b/src/runtime/memory.rs
@@ -124,6 +124,9 @@ fn default_for_type(ty: &TypeName) -> ConfidentValue {
         | TypeName::Custom(_) => Value::Record(HashMap::new()),
         TypeName::Results | TypeName::SearchResults => Value::List(vec![]),
         TypeName::Failure => Value::Text(String::new()),
+        TypeName::AgentResult => {
+            return ConfidentValue::default_agent_result();
+        }
         TypeName::Array(inner, size) => {
             let len = size.unwrap_or(0);
             let element_default = default_for_type(inner);

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,7 @@ pub enum ForgeType {
     Html,
     Embedding,
     Duration,
+    AgentResult,
     Named(String),
     Array(Box<ForgeType>, Option<usize>),
 }
@@ -53,6 +54,7 @@ impl std::fmt::Display for ForgeType {
             ForgeType::Html => write!(f, "Html"),
             ForgeType::Embedding => write!(f, "Embedding"),
             ForgeType::Duration => write!(f, "Duration"),
+            ForgeType::AgentResult => write!(f, "AgentResult"),
             ForgeType::Named(s) => write!(f, "{s}"),
             ForgeType::Array(inner, Some(n)) => write!(f, "{inner}[{n}]"),
             ForgeType::Array(inner, None) => write!(f, "{inner}[]"),
@@ -113,6 +115,7 @@ pub fn from_type_name(tn: &TypeName) -> ForgeType {
         TypeName::Response => ForgeType::Response,
         TypeName::Headers => ForgeType::Headers,
         TypeName::Html => ForgeType::Html,
+        TypeName::AgentResult => ForgeType::AgentResult,
         TypeName::Custom(s) => ForgeType::Named(s.clone()),
         TypeName::Array(inner, size) => ForgeType::Array(Box::new(from_type_name(inner)), *size),
     }
@@ -136,11 +139,35 @@ pub fn is_compatible(from: &ForgeType, to: &ForgeType) -> bool {
     if *from == ForgeType::Html && *to == ForgeType::Text {
         return true;
     }
+    // AgentResult is compatible with Text (for >> composition into text-consuming tasks)
+    if *from == ForgeType::AgentResult && *to == ForgeType::Text {
+        return true;
+    }
     // Arrays: compatible if element types match (ignore size)
     if let (ForgeType::Array(a, _), ForgeType::Array(b, _)) = (from, to) {
         return is_compatible(a, b);
     }
     false
+}
+
+// ── AgentResult field schema ────────────────────────────────
+
+/// Returns the known field names and their types for the built-in AgentResult type.
+pub fn agent_result_fields() -> Vec<(&'static str, ForgeType)> {
+    vec![
+        ("plan", ForgeType::Text),
+        ("patch_summary", ForgeType::Text),
+        (
+            "files_changed",
+            ForgeType::Array(Box::new(ForgeType::Text), None),
+        ),
+        ("tests_run", ForgeType::Number),
+        ("tests_passed", ForgeType::Number),
+        ("cost_usd", ForgeType::Number),
+        ("confidence", ForgeType::Number),
+        ("approval_needed", ForgeType::Bool),
+        ("metadata", ForgeType::Named("Map".to_string())),
+    ]
 }
 
 #[cfg(test)]
@@ -214,5 +241,54 @@ mod tests {
             ForgeType::Array(Box::new(ForgeType::Number), None).to_string(),
             "Number[]"
         );
+    }
+
+    // ── AgentResult tests ──────────────────────────────────────
+
+    #[test]
+    fn agent_result_display() {
+        assert_eq!(ForgeType::AgentResult.to_string(), "AgentResult");
+    }
+
+    #[test]
+    fn agent_result_from_type_name() {
+        assert_eq!(
+            from_type_name(&TypeName::AgentResult),
+            ForgeType::AgentResult
+        );
+    }
+
+    #[test]
+    fn agent_result_compatible_with_self() {
+        assert!(is_compatible(
+            &ForgeType::AgentResult,
+            &ForgeType::AgentResult
+        ));
+    }
+
+    #[test]
+    fn agent_result_compatible_with_text() {
+        assert!(is_compatible(&ForgeType::AgentResult, &ForgeType::Text));
+    }
+
+    #[test]
+    fn agent_result_fields_has_nine_entries() {
+        let fields = agent_result_fields();
+        assert_eq!(fields.len(), 9);
+    }
+
+    #[test]
+    fn agent_result_fields_contains_expected_names() {
+        let fields = agent_result_fields();
+        let names: Vec<&str> = fields.iter().map(|(n, _)| *n).collect();
+        assert!(names.contains(&"plan"));
+        assert!(names.contains(&"patch_summary"));
+        assert!(names.contains(&"files_changed"));
+        assert!(names.contains(&"tests_run"));
+        assert!(names.contains(&"tests_passed"));
+        assert!(names.contains(&"cost_usd"));
+        assert!(names.contains(&"confidence"));
+        assert!(names.contains(&"approval_needed"));
+        assert!(names.contains(&"metadata"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `AgentResult` as a built-in type with 9 fields: `plan`, `patch_summary`, `files_changed`, `tests_run`, `tests_passed`, `cost_usd`, `confidence`, `approval_needed`, `metadata`
- Constructor with defaults: `AgentResult()` or `AgentResult(plan: "fix", confidence: 0.9)` — unspecified fields get zero/empty defaults
- Confidence sync: the `confidence` Number field propagates to the `ConfidentValue` wrapper, enabling `when result.sure ->` branching

## Principles alignment

| Principle | How |
|-----------|-----|
| P-I Honesty | `confidence` field syncs to `ConfidentValue` wrapper; sessions (#189) will return `uncertain<AgentResult>` |
| P-III Token Economy | `cost_usd` field carries economic cost |
| P-IV Composition | `AgentResult >> Text` compatibility for `>>` chains |
| P-VII Human Ceiling | `approval_needed: Bool` signals when to stop and ask |

## Changes across layers

- **Grammar** (`forge.pest`): `AgentResult` in `builtin_type` rule
- **AST** (`ast.rs`): `TypeName::AgentResult` variant
- **Types** (`types.rs`): `ForgeType::AgentResult` + `agent_result_fields()` schema + `is_compatible` rule
- **Parser** (`parser.rs`): Three match arms (type annotation, constructor, type access)
- **Runtime** (`confidence.rs`): `default_agent_result()` + `from_agent_result()` constructors
- **Executor** (`executor.rs`): Constructor merges with defaults, syncs confidence; `AgentResult.default` via TypeAccess
- **Resolver** (`resolver.rs`): Constructor type inference
- **Memory** (`memory.rs`): `default_for_type` handles `AgentResult`

## Test plan

- [x] 6 new unit tests in `types.rs` (display, conversion, compatibility, field schema)
- [x] 5 new unit tests in `confidence.rs` (defaults, field values, confidence sync)
- [x] 4 new conformance tests (construct, default, array field, type annotation)
- [x] All 233 lib tests pass
- [x] Full test suite green (900+ tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)