### PR TITLE
feat: add session expression front-end (#189)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# FORGE Repository Workflow
+
+This file defines repository-local agent instructions for FORGE. These instructions override broader default workflow guidance when working in this repository.
+
+## Canonical Sources
+
+- Re-read `docs/training-development-workflow.md` at the start of every session.
+- Read `workflows/dev-cycle.forge` at the start of every session and map work to the `IssueLifecycle` state machine:
+  - `open -> planning -> in_progress -> testing -> review_ready -> merged`
+- Treat these files as the primary grounding sources for implementation details and design intent:
+  - `docs/forge-reference.md`
+  - `forge-principles.md`
+  - `roadmap.md`
+  - `CHANGELOG.md`
+
+## Session Start
+
+Before making substantive changes:
+
+1. Read `docs/training-development-workflow.md`.
+2. Read `workflows/dev-cycle.forge`.
+3. Read the relevant GitHub issue with `gh issue view <N>`.
+4. Read the issue acceptance criteria carefully; they are the exit gate.
+5. Cross-check the issue against `docs/forge-reference.md` because the spec may be newer than the issue.
+
+## Issue-First Workflow
+
+- Every code change starts from a GitHub issue. No exceptions.
+- Treat the GitHub issue as the working thread for the task.
+- If the issue and spec diverge, the spec is the source of truth unless explicitly superseded by authoritative design input from Claudiu.
+- Claudiu (`4bidden`) is the language designer. Treat his design answers as authoritative implementation input. Do not redesign or soften them.
+
+## Planning Rules
+
+- Use plan mode before implementation.
+- Explore the codebase before asking questions. Read files; do not guess.
+- Check `forge-principles.md` for every design decision and derive the answer from principles and `roadmap.md` whenever possible.
+- Do not ask Claudiu to choose between design approaches when the answer is derivable from repo principles, roadmap, or spec.
+- If a design question is asked and Claudiu answers with grammar, AST types, or rationale, incorporate that answer directly.
+- Include a principles checklist in the plan using whichever principles are relevant:
+  - Principle I: confidence values assigned correctly
+  - Principle II: expression handled in `pure_checker`
+  - Principle III: token cost tracked
+  - Principle VIII: lifecycle events traced
+
+## Git And Branch Rules
+
+- Always branch from `development`, never `main`.
+- Always open PRs against `development`, never `main`.
+- Branch naming:
+  - `feature/<issue-id>-<short-description>` for features
+  - `fix/<issue-id>-<short-description>` for bug fixes
+- Do not commit `CLAUDE.md` or `.claude/` contents.
+- Do not commit `.env` files, credentials, or other secrets.
+
+## Workspace Hygiene And Self-Healing
+
+- Treat the repository root checkout as a shared base clone, not the default implementation workspace.
+- Before starting issue work, sync the base clone first:
+  - `git fetch origin`
+  - `git checkout development`
+  - `git pull --ff-only origin development`
+- Then create a fresh issue-specific worktree from `origin/development` and do the implementation there, not in the shared root checkout.
+- Standard worktree locations:
+  - `../forge-<issue-id>` for the working tree
+  - `feature/<issue-id>-<short-description>` or `fix/<issue-id>-<short-description>` for the branch
+- Required bootstrap sequence for every issue:
+  - `git fetch origin`
+  - `git checkout development`
+  - `git pull --ff-only origin development`
+  - `git worktree add ../forge-<issue-id> -b <branch-name> origin/development`
+  - `cd ../forge-<issue-id>`
+- If the current checkout is dirty, do not try to clean it, inspect it repeatedly, or work around it in place. Self-heal by moving the task into a fresh worktree.
+- Do not use destructive cleanup commands such as `git reset --hard` or `git checkout --` to recover from the shared checkout state.
+- After merge, remove the issue worktree and delete the local branch from the base clone:
+  - `git worktree remove ../forge-<issue-id>`
+  - `git branch -d <branch-name>`
+
+## Implementation Rules
+
+- Follow existing FORGE codebase patterns instead of introducing new ones casually.
+- Common patterns to preserve:
+  - `Spanned<T>` for AST nodes with source spans
+  - `Result<T, anyhow::Error>` for public API error propagation
+  - `Arc<Mutex<T>>` for shared async state
+  - `HashMap<String, Decl>` for registries by declaration name
+  - `Env` scope stack for block scoping
+  - `async/await` with tokio for I/O
+  - `MockProvider` in tests instead of real API keys
+- Keep scope tight. Do not add features, refactor unrelated code, or add configurability beyond the issue.
+
+## TaskExecutor Wiring Rule
+
+When adding a new runtime component through a `with_*` builder on `TaskExecutor`:
+
+1. Grep for all `TaskExecutor::new()` call sites across the entire codebase.
+2. Wire the new dependency into every call site.
+3. Do not assume passing tests are sufficient if real construction paths were not exercised.
+
+## Verification Gates
+
+All three verification gates are required unless the task is explicitly exempted:
+
+1. Test:
+   - `cargo test`
+2. Format and lint:
+   - `cargo fmt --check`
+   - `cargo clippy --all-targets -- -D warnings`
+3. Real-world validation:
+   - For language, runtime, and skill changes, run a real `.forge` example with `cargo run -- run ...` against a real LLM.
+   - For skill changes, use a project with `forge.project.toml` declaring skills.
+   - For language features, write or use a `.forge` program that exercises the feature.
+   - For UI work, validate in a real browser via Playwright: screenshot each page, interact with controls, and check the browser console for errors.
+
+- Re-read the issue acceptance criteria during testing and verify each one explicitly.
+- If any acceptance criterion is ambiguous, resolve that ambiguity before shipping.
+
+## Principles Audit
+
+Run a principles audit after implementation and before commit. Treat principle violations as test failures.
+
+- Principle I. Honesty: confidence values are correct and uncertainty is explicit
+- Principle II. Purity: new expressions are handled in `pure_checker` where required
+- Principle III. Economy: token cost is tracked and zero for non-LLM paths
+- Principle IV. Determinism: pure functions do not perform LLM or side effects
+- Principle V. Containment: cleanup happens on agent retire
+- Principle VII. Accountability: spawned agents are tracked
+- Principle VIII. Traceability: all lifecycle events are traced
+- Principle IX. Separation: checker/runtime separation is preserved
+
+## Changelog And Shipping
+
+- Update `CHANGELOG.md` for every user-facing change.
+- When an issue is confirmed done, update `roadmap.md` in the same closeout loop so the relevant milestone, issue status, and Phase progress counters stay accurate.
+- Use Keep a Changelog categories:
+  - `Added`
+  - `Changed`
+  - `Fixed`
+  - `Removed`
+  - `Deprecated`
+  - `Security`
+- Every PR description must include:
+  - a short summary of the implementation
+  - the issue acceptance criteria copied or restated as a checklist
+  - an explicit outcome for each acceptance criterion
+  - the exact verification performed (`cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, real-world validation, and any targeted tests)
+  - any known gaps, follow-up issues, or intentionally deferred behavior
+- When acceptance criteria pass and verification is green, commit, push, and open the PR to `development` without asking for additional permission.
+- Monitor CI after opening the PR.
+- If CI fails, inspect the failed logs, fix the issue, push again, and re-check CI.
+- After merge, close the GitHub issue manually because PRs targeting `development` do not auto-close issues reliably.
+
+## Collaboration Style
+
+- Naming new constructs may require multiple rounds. Favor precise, forge-era naming and present honest trade-offs.
+- FORGE owns orchestration semantics such as agents, systems, events, wardens, skills, state machines, and tracing.
+- Apps built with FORGE own delivery surfaces such as Slack, TUI, browser, and CLI UX.
+- Do not add UI milestones to the language issue tracker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- `session` expression front-end: grammar, AST, parser, checker, resolver, cost estimation, and runtime placeholder support with `agent`, `prompt`, `tools`, `timeout`, `budget`, `gives AgentResult`, and `on progress`/`on complete` emit hooks (#189)
 - `AgentResult` built-in type — standard typed result contract for agent/session runs with 9 fields: `plan`, `patch_summary`, `files_changed`, `tests_run`, `tests_passed`, `cost_usd`, `confidence`, `approval_needed`, `metadata` (#193)
 - `AgentResult` constructor with default fields: `AgentResult()` or `AgentResult(plan: "fix bug", confidence: 0.9)` — unspecified fields get zero/empty defaults (#193)
 - `AgentResult` confidence sync: the `confidence` field value propagates to the `ConfidentValue` wrapper, enabling `when result.sure ->` branching (#193)

--- a/conformance/parser/session_expression.json
+++ b/conformance/parser/session_expression.json
@@ -1,0 +1,9 @@
+{
+  "name": "session_expression",
+  "category": "parser",
+  "description": "Session expression with prompt, agent, tools, timeout, budget, gives, and progress/complete hooks",
+  "input": "task test_session\n  gives Text\n  do\n    result = session \"code-review\" prompt review_prompt\n    result = session \"code-review\" prompt review_prompt agent \"claude\" tools [\"Read\", \"Glob\"] timeout 30m budget 2.0\n    result = session session_name prompt review_prompt gives AgentResult on progress -> emit ReviewUpdate(it) on complete -> emit ReviewDone(it)\n",
+  "expected": {
+    "outcome": "parse_ok"
+  }
+}

--- a/examples/session_placeholder.forge
+++ b/examples/session_placeholder.forge
@@ -1,0 +1,16 @@
+# session front-end acceptance example for issue #189
+event ReviewUpdate
+  payload: Text
+
+event ReviewDone
+  payload: Text
+
+task run_review
+  gives Text
+  do
+    result = session "code-review" prompt "Review src/parser.rs" agent "claude" tools ["Read", "Grep"] timeout 5m budget 1.5 on progress -> emit ReviewUpdate(it) on complete -> emit ReviewDone(it)
+    when result.sure -> give result
+    else -> give "session failed"
+
+fn main
+  say run_review()

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -55,7 +55,8 @@ keyword = @{
     | "requires" | "emit" | "forward" | "subscribe" | "transition"
     | "start" | "cancel" | "reset" | "for" | "in" | "not" | "and"
     | "match" | "recall" | "learn" | "spawn" | "find" | "retire"
-    | "exec" | "exportable" | "import" | "from" | "as" | "command" | "background" )
+    | "exec" | "exportable" | "import" | "from" | "as" | "command" | "background"
+    | "session" )
     ~ !(ASCII_ALPHANUMERIC | "_")
 }
 
@@ -562,6 +563,7 @@ postfix_op   = {
 pipe_term = {
     command_method_expr
   | command_expr
+  | session_expr
   | exec_expr
   | find_expr
   | reason_expr
@@ -593,6 +595,25 @@ command_modifier = {
 command_expr = { "command" ~ _s ~ command_arg ~ (_s ~ command_modifier)* }
 command_method_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 command_method_expr = { "command" ~ "." ~ command_method_name ~ "(" ~ _s_opt ~ arg_list? ~ _s_opt ~ ")" }
+session_expr = { "session" ~ _s ~ string_arg ~ (_s ~ session_modifier)* }
+session_modifier = _{
+    session_agent_modifier
+  | session_prompt_modifier
+  | session_tools_modifier
+  | session_timeout_modifier
+  | session_budget_modifier
+  | session_gives_modifier
+  | session_hook_modifier
+}
+session_agent_modifier = { "agent" ~ _s ~ string_arg }
+session_prompt_modifier = { "prompt" ~ _s ~ string_arg }
+session_tools_modifier = { "tools" ~ _s ~ expr }
+session_timeout_modifier = { "timeout" ~ _s ~ duration }
+session_budget_modifier = { "budget" ~ _s ~ expr }
+session_gives_modifier = { "gives" ~ _s ~ "AgentResult" }
+session_hook_modifier = { "on" ~ _s ~ session_hook_kind ~ _s_opt ~ "->" ~ _s_opt ~ session_emit_hook }
+session_hook_kind = { "progress" | "complete" }
+session_emit_hook = { "emit" ~ _s ~ ident ~ "(" ~ _s_opt ~ arg_list? ~ _s_opt ~ ")" }
 env_map      = { "{" ~ _s_opt ~ env_entry ~ (_s_opt ~ "," ~ _s_opt ~ env_entry)* ~ _s_opt ~ "}" }
 env_entry    = { ident ~ _s_opt ~ ":" ~ _s_opt ~ expr }
 reason_expr   = { "reason" ~ _s ~ string_arg }

--- a/roadmap.md
+++ b/roadmap.md
@@ -71,7 +71,7 @@ Everything in this document exists to reach that moment.
 | Milestone | Description | Issues | Status |
 |-----------|-------------|--------|--------|
 | P2.M1 — Command | `command` primitive: grammar, sync execution, background mode | #160 ✅ #161 ✅ #162 ✅ | Done |
-| P2.M2 — Session Core | `session` primitive: grammar and lifecycle manager | #189, #190 | Open |
+| P2.M2 — Session Core | `session` primitive: grammar and lifecycle manager | #189 ✅, #190 | In Progress |
 | P2.M3 — AgentResult + Contract | Typed result contract plus claims/evidence/verification model | #193, #203 | Open |
 | P2.M4 — Session Adapters + Events | Agent adapters, polling, and event integration | #191, #192 | Open |
 | P2.M5 — Verification + Contradictions | Verification engine and contradiction/warden integration | #204, #205 | Open |
@@ -657,7 +657,7 @@ Worktree isolation for safe agent execution:
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| #189 | session primitive — grammar, AST, and parser | Open |
+| #189 | session primitive — grammar, AST, and parser | Done |
 | #190 | session runtime — lifecycle manager | Open |
 
 ### P2.M3: AgentResult + Reliability Contract
@@ -933,7 +933,7 @@ command (#160-162) ✅
 
 ```
 P2.M1  Command         ████████████████████  3/3  (100%)  DONE
-P2.M2  Session Core    ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
+P2.M2  Session Core    ██████████░░░░░░░░░░  1/2  ( 50%)
 P2.M3  Result+Contract ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M4  Adapters+Events ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M5  Verify+Contra   ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
@@ -946,7 +946,7 @@ P2.M11 Knowledge       ░░░░░░░░░░░░░░░░░░░
 P2.M12 Toolkit         ░░░░░░░░░░░░░░░░░░░░  0/8  (  0%)
 P2.M13 Polish          ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 ─────────────────────────────────────────────────────────
-Phase 2 Overall         ██░░░░░░░░░░░░░░░░░░  4/37 ( 11%)
+Phase 2 Overall         ████░░░░░░░░░░░░░░░░  7/37 ( 19%)
 ```
 
 ---
@@ -1318,9 +1318,9 @@ Phase 1 (Layer 1): Build FORGE — **SHIPPED v0.1.0 on 2026-04-09**
   ⬜ WASM compilation (Cranelift backend) — deferred, not blocking Phase 2
   Goal: tic-tac-toe system runs end-to-end ✅
 
-Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (6/37 issues done)**
+Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (7/37 issues done)**
   ✅ P2.M1: `command` primitive — grammar, sync, background (#160-#162)
-  ⬜ P2.M2: `session` core — grammar and lifecycle manager (#189-#190)
+  🚧 P2.M2: `session` core — grammar done, runtime pending (#189 ✅, #190)
   ⬜ P2.M3: `AgentResult` + reliability contract — claims, evidence, verification (#193, #203)
   ⬜ P2.M4: session adapters + events — Claude/Codex/generic and event hooks (#191-#192)
   ⬜ P2.M5: verification + contradictions — trusted gating before repo mutations (#204-#205)
@@ -1371,5 +1371,5 @@ Everything in this document exists to reach that moment.
 
 *FORGE — Making It Real · Master Roadmap v3.0*
 *Layers: Substrate → Toolkit → Factory → Self-improvement*
-*Layer 1: v0.1.0 shipped (32/36 tracks, 89%) · Phase 2: 3/37 issues (8%) · Next: session core → AgentResult/reliability contract → verification*
+*Layer 1: v0.1.0 shipped (32/36 tracks, 89%) · Phase 2: 7/37 issues (19%) · Next: session runtime → AgentResult/reliability contract → verification*
 *Last updated: 2026-04-10*

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -269,6 +269,7 @@ pub struct RequiresClause {
     pub on_fail: Option<Spanned<FailPolicy>>,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum FailPolicy {
     Silent,
@@ -490,6 +491,8 @@ pub enum Expr {
     Command(CommandExpr),
     /// `command.status(handle)` / `command.output(handle)` / `command.cancel(handle)`
     CommandMethod(Spanned<String>, Vec<Spanned<CallArg>>),
+    /// `session "label" prompt prompt_text agent "claude" ...`
+    Session(SessionExpr),
     /// `find "alias"` / `find all template [where lifecycle == state]`
     Find(Box<FindExpr>),
     /// `try expr or expr`
@@ -525,6 +528,25 @@ pub struct CommandExpr {
     pub timeout: Option<Spanned<Duration>>,
     pub background: Option<Spanned<bool>>,
     pub env: Option<Vec<Spanned<EnvEntry>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionExpr {
+    pub name: Box<Spanned<Expr>>,
+    pub agent: Option<Box<Spanned<Expr>>>,
+    pub prompt: Option<Box<Spanned<Expr>>>,
+    pub tools: Option<Box<Spanned<Expr>>>,
+    pub timeout: Option<Spanned<Duration>>,
+    pub budget: Option<Box<Spanned<Expr>>>,
+    pub gives: Option<Spanned<TypeName>>,
+    pub on_progress: Option<Spanned<SessionHook>>,
+    pub on_complete: Option<Spanned<SessionHook>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionHook {
+    pub event: Spanned<String>,
+    pub args: Vec<Spanned<CallArg>>,
 }
 
 #[derive(Debug, Clone)]
@@ -730,6 +752,7 @@ pub struct FindExpr {
 }
 
 /// The kind of find query.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum FindKind {
     /// `find "alias"` — single lookup by alias

--- a/src/checker/boundary_checker.rs
+++ b/src/checker/boundary_checker.rs
@@ -492,6 +492,31 @@ fn check_refs_in_expr(
                 check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
             }
         }
+        Expr::Session(session_expr) => {
+            check_refs_in_expr(&session_expr.name, boundary, registry, file, diagnostics);
+            if let Some(ref agent) = session_expr.agent {
+                check_refs_in_expr(agent, boundary, registry, file, diagnostics);
+            }
+            if let Some(ref prompt) = session_expr.prompt {
+                check_refs_in_expr(prompt, boundary, registry, file, diagnostics);
+            }
+            if let Some(ref tools) = session_expr.tools {
+                check_refs_in_expr(tools, boundary, registry, file, diagnostics);
+            }
+            if let Some(ref budget) = session_expr.budget {
+                check_refs_in_expr(budget, boundary, registry, file, diagnostics);
+            }
+            if let Some(ref hook) = session_expr.on_progress {
+                for arg in &hook.node.args {
+                    check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
+                }
+            }
+            if let Some(ref hook) = session_expr.on_complete {
+                for arg in &hook.node.args {
+                    check_refs_in_expr(&arg.node.value, boundary, registry, file, diagnostics);
+                }
+            }
+        }
         Expr::Search(inner) => {
             if boundary != BoundaryKind::Server {
                 let boundary_name = match boundary {

--- a/src/checker/pure_checker.rs
+++ b/src/checker/pure_checker.rs
@@ -351,6 +351,14 @@ fn check_pure_expr(
                 span_end: expr.span.end,
             });
         }
+        Expr::Session(_) => {
+            errors.push(CheckError::PureUsesLlm {
+                name: fn_name.to_string(),
+                op: "session",
+                span_start: expr.span.start,
+                span_end: expr.span.end,
+            });
+        }
         // Leaves: literals, idents, type access — always pure
         Expr::NumberLit(_) | Expr::BoolLit(_) | Expr::Ident(_) | Expr::TypeAccess(_, _) => {}
     }

--- a/src/checker/requires_checker.rs
+++ b/src/checker/requires_checker.rs
@@ -194,6 +194,17 @@ fn check_requires_expr(
                 .with_help("use a `pure` function instead"),
             );
         }
+        Expr::Session(_) => {
+            diagnostics.push(
+                Diagnostic::warning(
+                    file,
+                    "requires clause uses `session` which delegates to an external agent",
+                    expr.span.start..expr.span.end,
+                    "external agent sessions are non-deterministic — preconditions should be deterministic",
+                )
+                .with_help("use a `pure` function instead"),
+            );
+        }
         // Leaves: literals, idents, type access — always deterministic
         Expr::NumberLit(_) | Expr::BoolLit(_) | Expr::Ident(_) | Expr::TypeAccess(_, _) => {}
     }

--- a/src/checker/uncertain_checker.rs
+++ b/src/checker/uncertain_checker.rs
@@ -140,6 +140,7 @@ fn expr_is_oracle(expr: &Spanned<Expr>) -> bool {
             | Expr::Recall(_)
             | Expr::Exec(_)
             | Expr::Command(_)
+            | Expr::Session(_)
             | Expr::CommandMethod(_, _)
     )
 }

--- a/src/cost_estimator.rs
+++ b/src/cost_estimator.rs
@@ -83,6 +83,17 @@ impl CostWalker {
         let cost = (tokens_in as f32 * self.cost_per_1k_in
             + tokens_out as f32 * self.cost_per_1k_out)
             / 1000.0;
+        self.add_explicit_cost(kind, location, tokens_in, tokens_out, cost);
+    }
+
+    fn add_explicit_cost(
+        &mut self,
+        kind: &'static str,
+        location: String,
+        tokens_in: u32,
+        tokens_out: u32,
+        cost: f32,
+    ) {
         self.operations.push(OpEstimate {
             kind,
             location,
@@ -211,6 +222,40 @@ impl CostWalker {
             Expr::Command(_) | Expr::CommandMethod(_, _) => {
                 // command has zero token cost (direct CLI, no LLM)
             }
+            Expr::Session(session) => {
+                self.walk_expr(&session.name, context, multiplier);
+                if let Some(ref agent) = session.agent {
+                    self.walk_expr(agent, context, multiplier);
+                }
+                if let Some(ref prompt) = session.prompt {
+                    self.walk_expr(prompt, context, multiplier);
+                }
+                if let Some(ref tools) = session.tools {
+                    self.walk_expr(tools, context, multiplier);
+                }
+                if let Some(ref budget) = session.budget {
+                    self.walk_expr(budget, context, multiplier);
+                    if let Expr::NumberLit(amount) = &budget.node {
+                        self.add_explicit_cost(
+                            "session",
+                            context.to_string(),
+                            0,
+                            0,
+                            *amount as f32 * multiplier as f32,
+                        );
+                    }
+                }
+                if let Some(ref hook) = session.on_progress {
+                    for arg in &hook.node.args {
+                        self.walk_expr(&arg.node.value, context, multiplier);
+                    }
+                }
+                if let Some(ref hook) = session.on_complete {
+                    for arg in &hook.node.args {
+                        self.walk_expr(&arg.node.value, context, multiplier);
+                    }
+                }
+            }
             Expr::TryOr(a, b) => {
                 self.walk_expr(a, context, multiplier);
                 self.walk_expr(b, context, multiplier);
@@ -316,5 +361,41 @@ pub fn estimate(program: &Program, config: &ForgeConfig) -> CostEstimate {
         total_tokens_in: total_in,
         total_tokens_out: total_out,
         total_cost_usd: total_cost,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::ForgeConfig;
+    use crate::parser::parse;
+
+    #[test]
+    fn session_budget_literal_adds_explicit_cost() {
+        let program =
+            parse("task t\n  gives Text\n  do\n    result = session \"review\" prompt \"check\" budget 2.5\n    give result\n")
+                .unwrap();
+        let estimate =
+            crate::cost_estimator::estimate(&program, &ForgeConfig::default_mock_config());
+        assert!(
+            estimate.operations.iter().any(
+                |op| op.kind == "session" && (op.estimated_cost_usd - 2.5).abs() < f32::EPSILON
+            ),
+            "expected explicit session budget cost, got {:?}",
+            estimate.operations
+        );
+    }
+
+    #[test]
+    fn session_without_budget_does_not_invent_cost() {
+        let program =
+            parse("task t\n  gives Text\n  do\n    result = session \"review\" prompt \"check\"\n    give result\n")
+                .unwrap();
+        let estimate =
+            crate::cost_estimator::estimate(&program, &ForgeConfig::default_mock_config());
+        assert!(
+            estimate.operations.iter().all(|op| op.kind != "session"),
+            "session without explicit budget should not create a synthetic cost: {:?}",
+            estimate.operations
+        );
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -555,6 +555,89 @@ fn build_command_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     ))
 }
 
+fn build_session_hook(pair: Pair) -> anyhow::Result<Spanned<SessionHook>> {
+    let span = to_span(&pair);
+    let mut inner = pair.into_inner();
+    let event_pair = inner.next().unwrap();
+    let event = spanned(event_pair.as_str().to_string(), &event_pair);
+    let args = if let Some(arg_list) = inner.next() {
+        build_arg_list(arg_list)?
+    } else {
+        Vec::new()
+    };
+    Ok(Spanned::new(SessionHook { event, args }, span))
+}
+
+fn build_session_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
+    let span = to_span(&pair);
+    let mut inner = pair.into_inner();
+    let name = build_string_arg(inner.next().unwrap())?;
+    let mut agent = None;
+    let mut prompt = None;
+    let mut tools = None;
+    let mut timeout = None;
+    let mut budget = None;
+    let mut gives = None;
+    let mut on_progress = None;
+    let mut on_complete = None;
+
+    for modifier in inner {
+        match modifier.as_rule() {
+            Rule::session_agent_modifier => {
+                let value_pair = modifier.into_inner().next().unwrap();
+                agent = Some(Box::new(build_string_arg(value_pair)?));
+            }
+            Rule::session_prompt_modifier => {
+                let value_pair = modifier.into_inner().next().unwrap();
+                prompt = Some(Box::new(build_string_arg(value_pair)?));
+            }
+            Rule::session_tools_modifier => {
+                let value_pair = modifier.into_inner().next().unwrap();
+                tools = Some(Box::new(build_expr(value_pair)?));
+            }
+            Rule::session_timeout_modifier => {
+                let value_pair = modifier.into_inner().next().unwrap();
+                timeout = Some(build_duration(value_pair)?);
+            }
+            Rule::session_budget_modifier => {
+                let value_pair = modifier.into_inner().next().unwrap();
+                budget = Some(Box::new(build_expr(value_pair)?));
+            }
+            Rule::session_gives_modifier => {
+                gives = Some(Spanned::new(TypeName::AgentResult, to_span(&modifier)));
+            }
+            Rule::session_hook_modifier => {
+                let modifier_span = to_span(&modifier);
+                let mut parts = modifier.into_inner();
+                let kind_pair = parts.next().unwrap();
+                let hook_pair = parts.next().unwrap();
+                let hook = build_session_hook(hook_pair)?;
+                match kind_pair.as_str() {
+                    "progress" => on_progress = Some(Spanned::new(hook.node, modifier_span)),
+                    "complete" => on_complete = Some(Spanned::new(hook.node, modifier_span)),
+                    _ => return Err(parse_error(&kind_pair, "unknown session hook kind")),
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(Spanned::new(
+        Expr::Session(SessionExpr {
+            name: Box::new(name),
+            agent,
+            prompt,
+            tools,
+            timeout,
+            budget,
+            gives,
+            on_progress,
+            on_complete,
+        }),
+        span,
+    ))
+}
+
 fn build_command_method_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     let span = to_span(&pair);
     let mut inner = pair.into_inner();
@@ -627,6 +710,7 @@ fn build_pipe_term(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     match inner.as_rule() {
         Rule::command_method_expr => build_command_method_expr(inner),
         Rule::command_expr => build_command_expr(inner),
+        Rule::session_expr => build_session_expr(inner),
         Rule::exec_expr => build_exec_expr(inner),
         Rule::find_expr => build_find_expr(inner),
         Rule::reason_expr => build_reason_expr(inner),

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -579,6 +579,13 @@ fn infer_type(
         Expr::Reason(_) => Some(ForgeType::Text),
         Expr::Exec(_) => Some(ForgeType::Text),
         Expr::Command(_) | Expr::CommandMethod(_, _) => Some(ForgeType::Text),
+        Expr::Session(session) => {
+            if session.gives.is_some() {
+                Some(ForgeType::AgentResult)
+            } else {
+                Some(ForgeType::Text)
+            }
+        }
         Expr::Classify(_) => Some(ForgeType::Classification),
         Expr::Search(_) => Some(ForgeType::Results),
         Expr::Paren(inner) => infer_type(inner, env, registry),
@@ -626,6 +633,7 @@ fn infer_input_type(
         Expr::Reason(_) => Some(ForgeType::Text),
         Expr::Exec(_) => Some(ForgeType::Text),
         Expr::Command(_) | Expr::CommandMethod(_, _) => Some(ForgeType::Text),
+        Expr::Session(_) => Some(ForgeType::Text),
         Expr::Classify(_) => Some(ForgeType::Text),
         Expr::Search(_) => Some(ForgeType::Text),
         Expr::MethodCall(inner, method, _) => {
@@ -719,5 +727,39 @@ mod tests {
         assert!(registry.resolve("data.embed").is_some());
         assert!(registry.resolve("data.search").is_some());
         assert!(registry.resolve("magic.wand").is_none());
+    }
+
+    #[test]
+    fn infer_session_type_defaults_to_text() {
+        let program = parse("task t\n  gives Text\n  do\n    result = session \"review\" prompt \"check\"\n    give result\n").unwrap();
+        let expr = match &program.items[0].node {
+            TopLevel::Task(task) => match &task.body.node {
+                crate::ast::TaskBody::Do(stmts) => match &stmts[0].node {
+                    Stmt::Bind(_, expr) => expr,
+                    other => panic!("expected bind, got {:?}", other),
+                },
+                _ => panic!("expected do block"),
+            },
+            _ => panic!("expected task"),
+        };
+        let ty = infer_type(expr, &HashMap::new(), &CapabilityRegistry::builtin());
+        assert_eq!(ty, Some(ForgeType::Text));
+    }
+
+    #[test]
+    fn infer_session_type_with_gives_is_agent_result() {
+        let program = parse("task t\n  gives Text\n  do\n    result = session \"review\" prompt \"check\" gives AgentResult\n    give result\n").unwrap();
+        let expr = match &program.items[0].node {
+            TopLevel::Task(task) => match &task.body.node {
+                crate::ast::TaskBody::Do(stmts) => match &stmts[0].node {
+                    Stmt::Bind(_, expr) => expr,
+                    other => panic!("expected bind, got {:?}", other),
+                },
+                _ => panic!("expected do block"),
+            },
+            _ => panic!("expected task"),
+        };
+        let ty = infer_type(expr, &HashMap::new(), &CapabilityRegistry::builtin());
+        assert_eq!(ty, Some(ForgeType::AgentResult));
     }
 }

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -2414,6 +2414,10 @@ impl TaskExecutor {
                     }
                 }
 
+                Expr::Session(_) => Err(RuntimeError::Unsupported(
+                    "session runtime is not implemented yet; see issue #190".to_string(),
+                )),
+
                 // ── command.method() expressions (issue #162) ────────────────
                 Expr::CommandMethod(method, args) => {
                     let mut arg_vals = Vec::new();

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -104,6 +104,24 @@ fn accept_uncertain_error() {
 }
 
 #[test]
+fn accept_session_uncertain_error() {
+    let source = "task review\n  gives Text\n  do\n    result = session \"code-review\" prompt \"check\"\n    give result\n";
+    let program = forge::parser::parse(source).unwrap();
+    let mut diags = checker::check_all(&program, "session_uncertain.forge");
+    diags.extend(boundary_checker::check(&[(
+        &program,
+        "session_uncertain.forge",
+    )]));
+    let errs = errors(&diags);
+    assert!(
+        errs.iter()
+            .any(|d| d.message.contains("unhandled uncertain")),
+        "session should be treated as uncertain/oracle output: {:?}",
+        errs.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn accept_pure_error() {
     let diags = check_file("examples/pure_error.forge");
     let errs = errors(&diags);

--- a/tests/boundary_tests.rs
+++ b/tests/boundary_tests.rs
@@ -211,6 +211,40 @@ agent MyAgent
 }
 
 #[test]
+fn session_expression_recurses_into_nested_references() {
+    let server = "\
+#! boundary: server
+
+pure server_only
+  needs input: Text
+  gives Text
+  do
+    give input
+";
+    let client = "\
+#! boundary: client
+
+event ReviewUpdate
+  payload: Text
+
+task review
+  needs input: Text
+  gives Text
+  do
+    prompt_text = \"review {input}\"
+    result = session \"code-review\" prompt prompt_text tools [server_only(input)] budget 2.0 on progress -> emit ReviewUpdate(server_only(input))
+    give result
+";
+    let diags = check_boundary(&[(server, "server.forge"), (client, "client.forge")]);
+    let errs = errors(&diags);
+    assert!(
+        errs.iter().any(|d| d.message.contains("server_only")),
+        "expected boundary checker to recurse into session subexpressions: {:?}",
+        errs.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn shared_type_with_pool_field_is_error() {
     let shared = "\
 #! boundary: shared

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -440,6 +440,112 @@ fn parse_command_all_modifiers_with_env() {
 }
 
 #[test]
+fn parse_session_basic() {
+    let prog = parse_task_with("x = session \"code-review\"");
+    match bind_expr(first_stmt(&prog)) {
+        Expr::Session(session) => {
+            assert!(matches!(&session.name.node, Expr::Template(_)));
+            assert!(session.agent.is_none());
+            assert!(session.prompt.is_none());
+            assert!(session.tools.is_none());
+            assert!(session.timeout.is_none());
+            assert!(session.budget.is_none());
+            assert!(session.gives.is_none());
+            assert!(session.on_progress.is_none());
+            assert!(session.on_complete.is_none());
+        }
+        other => panic!("expected Session, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_session_all_modifiers() {
+    let prog = parse_task_with(
+        "x = session \"code-review\" prompt review_prompt agent \"claude\" tools [\"Read\", tool_name] timeout 30m budget 2.0 gives AgentResult on progress -> emit ReviewUpdate(it) on complete -> emit ReviewDone(it)",
+    );
+    match bind_expr(first_stmt(&prog)) {
+        Expr::Session(session) => {
+            assert!(matches!(&session.name.node, Expr::Template(_)));
+            assert!(
+                matches!(&session.prompt.as_ref().unwrap().node, Expr::Ident(name) if name == "review_prompt")
+            );
+            assert!(matches!(
+                &session.agent.as_ref().unwrap().node,
+                Expr::Template(_)
+            ));
+            match &session.tools.as_ref().unwrap().node {
+                Expr::ArrayLit(elems) => {
+                    assert_eq!(elems.len(), 2);
+                    assert!(matches!(&elems[1].node, Expr::Ident(name) if name == "tool_name"));
+                }
+                other => panic!("expected ArrayLit, got {:?}", other),
+            }
+            let dur = session.timeout.as_ref().unwrap();
+            assert_eq!(dur.node.value, 30);
+            assert!(matches!(dur.node.unit, DurationUnit::Minutes));
+            assert!(
+                matches!(&session.budget.as_ref().unwrap().node, Expr::NumberLit(n) if (*n - 2.0).abs() < f64::EPSILON)
+            );
+            assert!(matches!(
+                &session.gives.as_ref().unwrap().node,
+                TypeName::AgentResult
+            ));
+            assert_eq!(
+                session.on_progress.as_ref().unwrap().node.event.node,
+                "ReviewUpdate"
+            );
+            assert_eq!(
+                session.on_complete.as_ref().unwrap().node.event.node,
+                "ReviewDone"
+            );
+            assert!(matches!(
+                &session.on_progress.as_ref().unwrap().node.args[0].node.value.node,
+                Expr::Ident(name) if name == "it"
+            ));
+        }
+        other => panic!("expected Session, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_session_reordered_modifiers() {
+    let prog = parse_task_with(
+        "x = session label on complete -> emit Done(it) budget 1.5 timeout 5m prompt prompt_text agent agent_name tools [\"Read\"]",
+    );
+    match bind_expr(first_stmt(&prog)) {
+        Expr::Session(session) => {
+            assert!(matches!(&session.name.node, Expr::Ident(name) if name == "label"));
+            assert!(
+                matches!(&session.prompt.as_ref().unwrap().node, Expr::Ident(name) if name == "prompt_text")
+            );
+            assert!(
+                matches!(&session.agent.as_ref().unwrap().node, Expr::Ident(name) if name == "agent_name")
+            );
+            assert!(session.tools.is_some());
+            assert!(session.timeout.is_some());
+            assert!(session.budget.is_some());
+            assert!(session.on_complete.is_some());
+        }
+        other => panic!("expected Session, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_session_progress_hook_only() {
+    let prog =
+        parse_task_with("x = session work on progress -> emit ProgressUpdate(it, state: status)");
+    match bind_expr(first_stmt(&prog)) {
+        Expr::Session(session) => {
+            let hook = session.on_progress.as_ref().unwrap();
+            assert_eq!(hook.node.event.node, "ProgressUpdate");
+            assert_eq!(hook.node.args.len(), 2);
+            assert_eq!(hook.node.args[1].node.label.as_ref().unwrap().node, "state");
+        }
+        other => panic!("expected Session, got {:?}", other),
+    }
+}
+
+#[test]
 fn parse_try_or_expression() {
     let prog = parse_task_with("x = try search \"query\" or \"default\"");
     match bind_expr(first_stmt(&prog)) {

--- a/tests/pure_checker_tests.rs
+++ b/tests/pure_checker_tests.rs
@@ -138,6 +138,17 @@ fn pure_rejects_exec() {
 }
 
 #[test]
+fn pure_rejects_session() {
+    let source = "pure bad\n  gives Text\n  do\n    result = session \"code-review\" prompt \"review this\"\n    give result\n";
+    let program = parse(source).unwrap();
+    let errors = check(&program);
+    assert_eq!(errors.len(), 1);
+    assert!(
+        matches!(&errors[0], CheckError::PureUsesLlm { name, op, .. } if name == "bad" && *op == "session")
+    );
+}
+
+#[test]
 fn multiple_pure_fns_all_checked() {
     let source = "\
 pure bad1\n  needs x: Text\n  gives Text\n  do\n    give reason x\n\

--- a/tests/requires_checker_tests.rs
+++ b/tests/requires_checker_tests.rs
@@ -184,3 +184,18 @@ agent room
     assert!(warns[0].message.contains("reason"));
     assert!(warns[0].message.contains("LLM"));
 }
+
+#[test]
+fn session_in_requires_is_warning() {
+    let source = "\
+agent room
+  on review()
+    requires session \"code-review\" prompt \"check this\"
+    say \"ok\"
+";
+    let diags = check(source);
+    let warns = warnings(&diags);
+    assert_eq!(warns.len(), 1);
+    assert!(warns[0].message.contains("session"));
+    assert!(warns[0].message.contains("external agent"));
+}


### PR DESCRIPTION
## Summary
- add the `session` expression front-end with order-independent modifiers for `agent`, `prompt`, `tools`, `timeout`, `budget`, `gives AgentResult`, and `on progress` / `on complete` emit hooks
- wire `session` through parser, AST, checkers, resolver, cost estimator, and runtime placeholder behavior
- add parser/semantic/conformance coverage and a real `.forge` example for runtime-placeholder validation
- add repo-local workflow guardrails in `AGENTS.md` for self-healing worktrees and PR verification requirements

## Acceptance Criteria
- [x] `grammar/forge.pest`: `session_expr` rule with `session_modifier` (agent, prompt, tools, timeout, budget, gives, on progress, on complete)
- [x] `src/ast.rs`: `SessionExpr` struct with all modifier fields, `Expr::Session` variant
- [x] `src/parser.rs`: parse session expression with all modifier combinations
- [x] `src/checker/pure_checker.rs`: session is impure
- [x] `src/checker/uncertain_checker.rs`: session is an oracle
- [x] `src/checker/requires_checker.rs`: warn about session in requires guards
- [x] `src/checker/boundary_checker.rs`: recurse into sub-expressions
- [x] `src/resolver.rs`: return type is `AgentResult` (or `Text` if no `gives`)
- [x] `src/cost_estimator.rs`: budget-aware cost estimation
- [x] `src/runtime/executor.rs`: placeholder bail (runtime in separate issue)
- [x] Parser roundtrip tests for all modifier combinations
- [x] Conformance test: `conformance/parser/session_expression.json`

## Verification
- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Real validation: `cargo run -- run examples/session_placeholder.forge`
  - parse/check succeeded
  - runtime reached the explicit placeholder and failed with: `session runtime is not implemented yet; see issue #190`
- [x] Targeted tests added for parser, purity, requires, boundary recursion, uncertainty handling, resolver typing, and cost estimation

## Deferred / Known Gaps
- runtime execution is intentionally not implemented here; `#190` remains the follow-up for lifecycle management
- this PR keeps the planned single-line `session` expression surface rather than introducing multiline block-expression syntax
