### PR TITLE
feat: add session runtime lifecycle manager (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- `SessionManager` runtime for long-running external agent sessions with UUID-backed session IDs, persisted JSON state under `.forge-data/sessions/`, startup `resume_all()`, progress listeners, budget enforcement, and graceful cancel escalation (#190)
+- `session` runtime execution in `TaskExecutor` with `on progress` / `on complete` hook emission, `Text`/`AgentResult` output coercion, and lifecycle tracing for Principle VIII (#190)
 - `session` expression front-end: grammar, AST, parser, checker, resolver, cost estimation, and runtime placeholder support with `agent`, `prompt`, `tools`, `timeout`, `budget`, `gives AgentResult`, and `on progress`/`on complete` emit hooks (#189)
 - `AgentResult` built-in type — standard typed result contract for agent/session runs with 9 fields: `plan`, `patch_summary`, `files_changed`, `tests_run`, `tests_passed`, `cost_usd`, `confidence`, `approval_needed`, `metadata` (#193)
 - `AgentResult` constructor with default fields: `AgentResult()` or `AgentResult(plan: "fix bug", confidence: 0.9)` — unspecified fields get zero/empty defaults (#193)

--- a/roadmap.md
+++ b/roadmap.md
@@ -71,7 +71,7 @@ Everything in this document exists to reach that moment.
 | Milestone | Description | Issues | Status |
 |-----------|-------------|--------|--------|
 | P2.M1 — Command | `command` primitive: grammar, sync execution, background mode | #160 ✅ #161 ✅ #162 ✅ | Done |
-| P2.M2 — Session Core | `session` primitive: grammar and lifecycle manager | #189 ✅, #190 | In Progress |
+| P2.M2 — Session Core | `session` primitive: grammar and lifecycle manager | #189 ✅, #190 ✅ | Done |
 | P2.M3 — AgentResult + Contract | Typed result contract plus claims/evidence/verification model | #193, #203 | Open |
 | P2.M4 — Session Adapters + Events | Agent adapters, polling, and event integration | #191, #192 | Open |
 | P2.M5 — Verification + Contradictions | Verification engine and contradiction/warden integration | #204, #205 | Open |
@@ -658,7 +658,7 @@ Worktree isolation for safe agent execution:
 | Issue | Title | Status |
 |-------|-------|--------|
 | #189 | session primitive — grammar, AST, and parser | Done |
-| #190 | session runtime — lifecycle manager | Open |
+| #190 | session runtime — lifecycle manager | Done |
 
 ### P2.M3: AgentResult + Reliability Contract
 
@@ -933,7 +933,7 @@ command (#160-162) ✅
 
 ```
 P2.M1  Command         ████████████████████  3/3  (100%)  DONE
-P2.M2  Session Core    ██████████░░░░░░░░░░  1/2  ( 50%)
+P2.M2  Session Core    ████████████████████  2/2  (100%)  DONE
 P2.M3  Result+Contract ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M4  Adapters+Events ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M5  Verify+Contra   ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
@@ -946,7 +946,7 @@ P2.M11 Knowledge       ░░░░░░░░░░░░░░░░░░░
 P2.M12 Toolkit         ░░░░░░░░░░░░░░░░░░░░  0/8  (  0%)
 P2.M13 Polish          ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 ─────────────────────────────────────────────────────────
-Phase 2 Overall         ████░░░░░░░░░░░░░░░░  7/37 ( 19%)
+Phase 2 Overall         ████░░░░░░░░░░░░░░░░  8/37 ( 22%)
 ```
 
 ---
@@ -1318,9 +1318,9 @@ Phase 1 (Layer 1): Build FORGE — **SHIPPED v0.1.0 on 2026-04-09**
   ⬜ WASM compilation (Cranelift backend) — deferred, not blocking Phase 2
   Goal: tic-tac-toe system runs end-to-end ✅
 
-Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (7/37 issues done)**
+Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (8/37 issues done)**
   ✅ P2.M1: `command` primitive — grammar, sync, background (#160-#162)
-  🚧 P2.M2: `session` core — grammar done, runtime pending (#189 ✅, #190)
+  ✅ P2.M2: `session` core — grammar and lifecycle manager done (#189 ✅, #190 ✅)
   ⬜ P2.M3: `AgentResult` + reliability contract — claims, evidence, verification (#193, #203)
   ⬜ P2.M4: session adapters + events — Claude/Codex/generic and event hooks (#191-#192)
   ⬜ P2.M5: verification + contradictions — trusted gating before repo mutations (#204-#205)
@@ -1371,5 +1371,5 @@ Everything in this document exists to reach that moment.
 
 *FORGE — Making It Real · Master Roadmap v3.0*
 *Layers: Substrate → Toolkit → Factory → Self-improvement*
-*Layer 1: v0.1.0 shipped (32/36 tracks, 89%) · Phase 2: 7/37 issues (19%) · Next: session runtime → AgentResult/reliability contract → verification*
+*Layer 1: v0.1.0 shipped (32/36 tracks, 89%) · Phase 2: 8/37 issues (22%) · Next: session adapters/events → AgentResult/reliability contract → verification*
 *Last updated: 2026-04-10*

--- a/src/build.rs
+++ b/src/build.rs
@@ -469,9 +469,11 @@ async fn main() -> anyhow::Result<()> {{
     let registry = forge::llm::registry::ProviderRegistry::from_config(config)
         .map_err(|e| anyhow::anyhow!("provider setup failed: {{}}", e))?;
     let cmd_mgr = Arc::new(std::sync::Mutex::new(forge::runtime::command_manager::CommandManager::new()));
+    let session_mgr = forge::runtime::session_manager::new_shared_default_session_manager(None);
+    let _ = session_mgr.resume_all().await;
     let executor = forge::runtime::executor::TaskExecutor::new(
         program, Arc::new(registry), None,
-    ).with_command_manager(cmd_mgr);
+    ).with_command_manager(cmd_mgr).with_session_manager(session_mgr);
     match executor.run().await {{
         Ok(_) => Ok(()),
         Err(e) => {{
@@ -804,9 +806,11 @@ async fn main() -> anyhow::Result<()> {{
     let registry = forge::llm::registry::ProviderRegistry::from_config(config.clone())
         .map_err(|e| anyhow::anyhow!("provider setup failed: {{}}", e))?;
     let cmd_mgr = Arc::new(std::sync::Mutex::new(forge::runtime::command_manager::CommandManager::new()));
+    let session_mgr = forge::runtime::session_manager::new_shared_default_session_manager(None);
+    let _ = session_mgr.resume_all().await;
     let executor = forge::runtime::executor::TaskExecutor::new(
         program, Arc::new(registry), None,
-    ).with_command_manager(cmd_mgr);
+    ).with_command_manager(cmd_mgr).with_session_manager(session_mgr);
     let event_bus = forge::runtime::event_bus::EventBus::new_shared(None);
     let mut server = forge::runtime::http_server::ForgeServer::new(executor, config.server.as_ref())
         .with_event_bus(event_bus);

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,10 +672,14 @@ async fn run_program(file: &Path, trace: bool) -> anyhow::Result<()> {
     }
 
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
+    let session_mgr =
+        forge::runtime::session_manager::new_shared_default_session_manager(tracer.clone());
+    let _ = session_mgr.resume_all().await;
     let mut executor =
         forge::runtime::executor::TaskExecutor::new(program, Arc::clone(&providers), tracer)
             .with_config(config_clone)
-            .with_command_manager(cmd_mgr);
+            .with_command_manager(cmd_mgr)
+            .with_session_manager(session_mgr);
     if let Some(se) = skill_exec {
         executor = executor.with_skill_executor(se);
     }
@@ -786,13 +790,17 @@ async fn run_manifest(manifest_path: &Path, trace: bool) -> anyhow::Result<()> {
     })?;
 
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
+    let session_mgr =
+        forge::runtime::session_manager::new_shared_default_session_manager(tracer.clone());
+    let _ = session_mgr.resume_all().await;
     let mut executor = forge::runtime::executor::TaskExecutor::new(
         composed.program,
         Arc::clone(&providers),
         tracer,
     )
     .with_config(config_clone)
-    .with_command_manager(cmd_mgr);
+    .with_command_manager(cmd_mgr)
+    .with_session_manager(session_mgr);
     if let Some(se) = skill_exec {
         executor = executor.with_skill_executor(se);
     }
@@ -984,13 +992,16 @@ fn try_build_executor_multi(
     let (skill_exec, _skill_sigs) =
         build_skill_executor(&config, &providers, tracer.as_ref(), None, None);
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
+    let session_mgr =
+        forge::runtime::session_manager::new_shared_default_session_manager(tracer.clone());
     let mut executor = forge::runtime::executor::TaskExecutor::new(
         composed.program,
         Arc::clone(&providers),
         tracer,
     )
     .with_config(config.clone())
-    .with_command_manager(cmd_mgr);
+    .with_command_manager(cmd_mgr)
+    .with_session_manager(session_mgr);
     if let Some(se) = skill_exec {
         executor = executor.with_skill_executor(se);
     }
@@ -1057,10 +1068,13 @@ fn try_build_executor(
     let (skill_exec, _skill_sigs) =
         build_skill_executor(&config, &providers, tracer.as_ref(), None, None);
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
+    let session_mgr =
+        forge::runtime::session_manager::new_shared_default_session_manager(tracer.clone());
     let mut executor =
         forge::runtime::executor::TaskExecutor::new(program, Arc::clone(&providers), tracer)
             .with_config(config.clone())
-            .with_command_manager(cmd_mgr);
+            .with_command_manager(cmd_mgr)
+            .with_session_manager(session_mgr);
     if let Some(se) = skill_exec {
         executor = executor.with_skill_executor(se);
     }

--- a/src/runtime/agent.rs
+++ b/src/runtime/agent.rs
@@ -363,10 +363,13 @@ impl AgentProcess {
         let cmd_mgr = Arc::new(Mutex::new(
             crate::runtime::command_manager::CommandManager::new(),
         ));
+        let session_mgr =
+            crate::runtime::session_manager::new_shared_default_session_manager(tracer.clone());
         let mut executor = TaskExecutor::new(program, registry, tracer)
             .with_agent_context(context.clone())
             .with_timer_engine(timer_engine.clone())
-            .with_command_manager(cmd_mgr);
+            .with_command_manager(cmd_mgr)
+            .with_session_manager(session_mgr);
 
         // Wire instance registry into executor (issue #82)
         if let Some(ir) = instance_registry {

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -13,6 +13,9 @@ use crate::runtime::agent::{AgentContext, EmittedEvent};
 use crate::runtime::command_manager::SharedCommandManager;
 use crate::runtime::confidence::{ConfidentValue, Value};
 use crate::runtime::instance_registry::{InstanceInfo, InstanceStatus};
+use crate::runtime::session_manager::{
+    SessionConfig, SessionEvent, SessionListener, SharedSessionManager,
+};
 use crate::runtime::timer_engine::TimerEngine;
 use crate::tracer::{LLMResponseInfo, Tracer};
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -70,6 +73,7 @@ pub struct EndpointResult {
 
 // ── Environment (scope stack) ─────────────────────────────────────────────────
 
+#[derive(Clone)]
 pub(crate) struct Env {
     scopes: Vec<HashMap<String, ConfidentValue>>,
 }
@@ -151,6 +155,8 @@ pub struct TaskExecutor {
     vector_index: Option<crate::runtime::vector_index::SharedVectorIndex>,
     /// Command manager for background process lifecycle (issue #162).
     command_manager: Option<SharedCommandManager>,
+    /// Session manager for long-running external agent sessions (issue #190).
+    session_manager: Option<SharedSessionManager>,
 }
 
 impl Clone for TaskExecutor {
@@ -179,6 +185,7 @@ impl Clone for TaskExecutor {
             embedding_provider: self.embedding_provider.clone(),
             vector_index: self.vector_index.clone(),
             command_manager: self.command_manager.clone(),
+            session_manager: self.session_manager.clone(),
         }
     }
 }
@@ -215,7 +222,7 @@ impl TaskExecutor {
         Self {
             program,
             providers,
-            tracer,
+            tracer: tracer.clone(),
             task_map,
             pure_map,
             flow_map,
@@ -236,6 +243,9 @@ impl TaskExecutor {
             embedding_provider: None,
             vector_index: None,
             command_manager: None,
+            session_manager: Some(
+                crate::runtime::session_manager::new_shared_default_session_manager(tracer.clone()),
+            ),
         }
     }
 
@@ -314,6 +324,17 @@ impl TaskExecutor {
         self.command_manager.as_ref()
     }
 
+    /// Attach a session manager for long-running external agent sessions (issue #190).
+    pub fn with_session_manager(mut self, mgr: SharedSessionManager) -> Self {
+        self.session_manager = Some(mgr);
+        self
+    }
+
+    /// Get a reference to the session manager.
+    pub fn session_manager(&self) -> Option<&SharedSessionManager> {
+        self.session_manager.as_ref()
+    }
+
     /// Configure persistent memory storage (issue #57).
     pub fn with_persistent_memory(
         mut self,
@@ -359,6 +380,286 @@ impl TaskExecutor {
     ) -> Self {
         self.knowledge_store = Some(Arc::new(Mutex::new(ks)));
         self
+    }
+
+    async fn emit_named_args(
+        &self,
+        event_name: &str,
+        args: &[Spanned<CallArg>],
+        env: &mut Env,
+    ) -> Result<(), RuntimeError> {
+        let mut arg_vals = Vec::new();
+        let mut fields = std::collections::HashMap::new();
+        for arg in args {
+            let val = self.eval_expr(&arg.node.value, env).await?;
+            if let Some(ref label) = arg.node.label {
+                fields.insert(label.node.clone(), val.clone());
+            }
+            arg_vals.push(val);
+        }
+        self.emit_precomputed(event_name, arg_vals, fields).await
+    }
+
+    async fn emit_precomputed(
+        &self,
+        event_name: &str,
+        arg_vals: Vec<ConfidentValue>,
+        fields: HashMap<String, ConfidentValue>,
+    ) -> Result<(), RuntimeError> {
+        if let Some(ref ctx_arc) = self.agent_context {
+            ctx_arc
+                .lock()
+                .unwrap()
+                .event_sink
+                .emitted
+                .push(EmittedEvent {
+                    name: event_name.to_string(),
+                    args: arg_vals,
+                    fields,
+                });
+        } else if let Some(ref bus) = self.event_bus {
+            let source = self
+                .agent_name
+                .clone()
+                .unwrap_or_else(|| "endpoint".to_string());
+            let payload = crate::runtime::event_bus::EventPayload {
+                event_name: event_name.to_string(),
+                args: arg_vals,
+                source_agent: source.clone(),
+                fields,
+            };
+            let delivered = bus.read().await.publish(&payload);
+            if let Some(ref t) = self.tracer {
+                t.event_emit(&source, event_name, delivered);
+            }
+        } else {
+            return Err(RuntimeError::Unsupported("emit outside agent".into()));
+        }
+        Ok(())
+    }
+
+    async fn emit_session_hook(
+        &self,
+        hook: &SessionHook,
+        payload: ConfidentValue,
+        env: &Env,
+    ) -> Result<(), RuntimeError> {
+        let mut hook_env = env.clone();
+        hook_env.push_scope();
+        hook_env.bind("it", payload);
+        self.emit_named_args(&hook.event.node, &hook.args, &mut hook_env)
+            .await
+    }
+
+    fn type_name_to_string(type_name: &TypeName) -> String {
+        match type_name {
+            TypeName::Text => "Text".to_string(),
+            TypeName::Number => "Number".to_string(),
+            TypeName::Bool => "Bool".to_string(),
+            TypeName::Results => "Results".to_string(),
+            TypeName::Report => "Report".to_string(),
+            TypeName::Intent => "Intent".to_string(),
+            TypeName::Summary => "Summary".to_string(),
+            TypeName::Failure => "Failure".to_string(),
+            TypeName::Classification => "Classification".to_string(),
+            TypeName::Conversation => "Conversation".to_string(),
+            TypeName::Profile => "Profile".to_string(),
+            TypeName::SearchResults => "SearchResults".to_string(),
+            TypeName::Request => "Request".to_string(),
+            TypeName::Response => "Response".to_string(),
+            TypeName::Headers => "Headers".to_string(),
+            TypeName::Html => "Html".to_string(),
+            TypeName::AgentResult => "AgentResult".to_string(),
+            TypeName::Custom(name) => name.clone(),
+            TypeName::Array(inner, Some(size)) => {
+                format!("{}[{}]", Self::type_name_to_string(inner), size)
+            }
+            TypeName::Array(inner, None) => format!("{}[]", Self::type_name_to_string(inner)),
+        }
+    }
+
+    async fn eval_session_expr(
+        &self,
+        session: &SessionExpr,
+        env: &mut Env,
+    ) -> Result<ConfidentValue, RuntimeError> {
+        let Some(manager) = self.session_manager.as_ref() else {
+            return Err(RuntimeError::Unsupported(
+                "session requires a session manager".to_string(),
+            ));
+        };
+
+        let name = format!("{}", self.eval_expr(&session.name, env).await?.value);
+        let agent = match &session.agent {
+            Some(agent_expr) => format!("{}", self.eval_expr(agent_expr, env).await?.value),
+            None => "default".to_string(),
+        };
+        let prompt = match &session.prompt {
+            Some(prompt_expr) => Some(format!("{}", self.eval_expr(prompt_expr, env).await?.value)),
+            None => None,
+        };
+        let tools = match &session.tools {
+            Some(tools_expr) => match self.eval_expr(tools_expr, env).await?.value {
+                Value::Array(items) | Value::List(items) => items
+                    .into_iter()
+                    .map(|item| format!("{}", item.value))
+                    .collect(),
+                other => {
+                    return Err(RuntimeError::TypeError {
+                        expected: "Array".to_string(),
+                        got: format!("{}", other),
+                    })
+                }
+            },
+            None => Vec::new(),
+        };
+        let budget_usd = match &session.budget {
+            Some(budget_expr) => {
+                let budget = self.eval_expr(budget_expr, env).await?;
+                match budget.value {
+                    Value::Number(n) => Some(n as f32),
+                    other => {
+                        return Err(RuntimeError::TypeError {
+                            expected: "Number".to_string(),
+                            got: format!("{}", other),
+                        })
+                    }
+                }
+            }
+            None => None,
+        };
+
+        let mut config = SessionConfig::new(name, agent);
+        config.prompt = prompt;
+        config.tools = tools;
+        config.timeout_secs = session
+            .timeout
+            .as_ref()
+            .map(|dur| dur.node.to_std().as_secs());
+        config.budget_usd = budget_usd;
+        config.gives = session
+            .gives
+            .as_ref()
+            .map(|gives| Self::type_name_to_string(&gives.node));
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SessionEvent>();
+        let listener: SessionListener = Arc::new(move |event| {
+            let _ = tx.send(event);
+        });
+
+        let run_fut = manager.run_to_completion(config, vec![listener]);
+        tokio::pin!(run_fut);
+
+        loop {
+            tokio::select! {
+                state = &mut run_fut => {
+                    let state = state.map_err(RuntimeError::FlowError)?;
+                    let output = state.output.unwrap_or_else(ConfidentValue::default_agent_result);
+                    while let Ok(event) = rx.try_recv() {
+                        if let SessionEvent::Progress { payload, .. } = event {
+                            if let Some(ref hook) = session.on_progress {
+                                self.emit_session_hook(&hook.node, payload, env).await?;
+                            }
+                        }
+                    }
+                    if let Some(ref hook) = session.on_complete {
+                        self.emit_session_hook(&hook.node, output.clone(), env).await?;
+                    }
+                    return if matches!(session.gives.as_ref().map(|g| &g.node), Some(TypeName::AgentResult)) {
+                        Ok(self.coerce_session_result_to_agent_result(output, state.cost_usd))
+                    } else {
+                        Ok(self.coerce_session_result_to_text(output))
+                    };
+                }
+                event = rx.recv() => {
+                    let Some(event) = event else {
+                        continue;
+                    };
+                    if let SessionEvent::Progress { payload, .. } = event {
+                        if let Some(ref hook) = session.on_progress {
+                            self.emit_session_hook(&hook.node, payload, env).await?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn coerce_session_result_to_text(&self, result: ConfidentValue) -> ConfidentValue {
+        match result.value {
+            Value::Text(_) | Value::Html(_) => result,
+            other => {
+                ConfidentValue::from_skill(Value::Text(format!("{}", other)), result.confidence)
+            }
+        }
+    }
+
+    fn coerce_session_result_to_agent_result(
+        &self,
+        result: ConfidentValue,
+        total_cost_usd: f32,
+    ) -> ConfidentValue {
+        match result.value {
+            Value::Record(mut fields) => {
+                if fields.contains_key("cost_usd") {
+                    fields.insert(
+                        "cost_usd".to_string(),
+                        ConfidentValue::deterministic(Value::Number(total_cost_usd as f64)),
+                    );
+                    if !fields.contains_key("confidence") {
+                        fields.insert(
+                            "confidence".to_string(),
+                            ConfidentValue::deterministic(Value::Number(result.confidence as f64)),
+                        );
+                    }
+                    ConfidentValue::from_agent_result(fields)
+                } else {
+                    let record_text = format!("{}", Value::Record(fields));
+                    let mut defaults = ConfidentValue::default_agent_result_fields();
+                    defaults.insert(
+                        "plan".to_string(),
+                        ConfidentValue::from_skill(
+                            Value::Text(record_text.clone()),
+                            result.confidence,
+                        ),
+                    );
+                    defaults.insert(
+                        "patch_summary".to_string(),
+                        ConfidentValue::from_skill(Value::Text(record_text), result.confidence),
+                    );
+                    defaults.insert(
+                        "cost_usd".to_string(),
+                        ConfidentValue::deterministic(Value::Number(total_cost_usd as f64)),
+                    );
+                    defaults.insert(
+                        "confidence".to_string(),
+                        ConfidentValue::deterministic(Value::Number(result.confidence as f64)),
+                    );
+                    ConfidentValue::from_agent_result(defaults)
+                }
+            }
+            other => {
+                let text = format!("{}", other);
+                let mut fields = ConfidentValue::default_agent_result_fields();
+                fields.insert(
+                    "plan".to_string(),
+                    ConfidentValue::from_skill(Value::Text(text.clone()), result.confidence),
+                );
+                fields.insert(
+                    "patch_summary".to_string(),
+                    ConfidentValue::from_skill(Value::Text(text), result.confidence),
+                );
+                fields.insert(
+                    "cost_usd".to_string(),
+                    ConfidentValue::deterministic(Value::Number(total_cost_usd as f64)),
+                );
+                fields.insert(
+                    "confidence".to_string(),
+                    ConfidentValue::deterministic(Value::Number(result.confidence as f64)),
+                );
+                ConfidentValue::from_agent_result(fields)
+            }
+        }
     }
 
     /// Check if an OutputType includes Html.
@@ -672,47 +973,7 @@ impl TaskExecutor {
 
                 // ── Agent features (issue #11) ─────────────────────────────
                 Stmt::Emit(name, args) => {
-                    let mut arg_vals = Vec::new();
-                    let mut fields = std::collections::HashMap::new();
-                    for arg in args {
-                        let val = self.eval_expr(&arg.node.value, env).await?;
-                        if let Some(ref label) = arg.node.label {
-                            fields.insert(label.node.clone(), val.clone());
-                        }
-                        arg_vals.push(val);
-                    }
-
-                    if let Some(ref ctx_arc) = self.agent_context {
-                        // Inside agent: collect in sink for batch publish
-                        ctx_arc
-                            .lock()
-                            .unwrap()
-                            .event_sink
-                            .emitted
-                            .push(EmittedEvent {
-                                name: name.node.clone(),
-                                args: arg_vals,
-                                fields,
-                            });
-                    } else if let Some(ref bus) = self.event_bus {
-                        // Outside agent (e.g. endpoint/webhook): publish directly
-                        let source = self
-                            .agent_name
-                            .clone()
-                            .unwrap_or_else(|| "endpoint".to_string());
-                        let payload = crate::runtime::event_bus::EventPayload {
-                            event_name: name.node.clone(),
-                            args: arg_vals,
-                            source_agent: source.clone(),
-                            fields,
-                        };
-                        let delivered = bus.read().await.publish(&payload);
-                        if let Some(ref t) = self.tracer {
-                            t.event_emit(&source, &name.node, delivered);
-                        }
-                    } else {
-                        return Err(RuntimeError::Unsupported("emit outside agent".into()));
-                    }
+                    self.emit_named_args(&name.node, args, env).await?;
                 }
                 Stmt::TransitionTo(state) => {
                     if let Some(ref ctx_arc) = self.agent_context {
@@ -2414,9 +2675,7 @@ impl TaskExecutor {
                     }
                 }
 
-                Expr::Session(_) => Err(RuntimeError::Unsupported(
-                    "session runtime is not implemented yet; see issue #190".to_string(),
-                )),
+                Expr::Session(session) => self.eval_session_expr(session, env).await,
 
                 // ── command.method() expressions (issue #162) ────────────────
                 Expr::CommandMethod(method, args) => {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -15,6 +15,7 @@ pub mod knowledge_store;
 pub mod markdown;
 pub mod memory;
 pub mod pool;
+pub mod session_manager;
 pub mod skill;
 pub mod skill_executor;
 pub mod skill_loader;

--- a/src/runtime/pool.rs
+++ b/src/runtime/pool.rs
@@ -155,12 +155,17 @@ impl PoolExecutor {
                     let cmd_mgr = std::sync::Arc::new(std::sync::Mutex::new(
                         crate::runtime::command_manager::CommandManager::new(),
                     ));
+                    let session_mgr =
+                        crate::runtime::session_manager::new_shared_default_session_manager(
+                            self.tracer.clone(),
+                        );
                     let executor = TaskExecutor::new(
                         self.program.clone(),
                         self.providers.clone(),
                         self.tracer.clone(),
                     )
-                    .with_command_manager(cmd_mgr);
+                    .with_command_manager(cmd_mgr)
+                    .with_session_manager(session_mgr);
                     let decl = task_decl.clone();
                     let args = args.to_vec();
                     join_set.spawn(async move { executor.call_task(&decl, args).await });
@@ -378,12 +383,16 @@ impl PoolExecutor {
         let cmd_mgr = std::sync::Arc::new(std::sync::Mutex::new(
             crate::runtime::command_manager::CommandManager::new(),
         ));
+        let session_mgr = crate::runtime::session_manager::new_shared_default_session_manager(
+            self.tracer.clone(),
+        );
         let executor = TaskExecutor::new(
             self.program.clone(),
             self.providers.clone(),
             self.tracer.clone(),
         )
-        .with_command_manager(cmd_mgr);
+        .with_command_manager(cmd_mgr)
+        .with_session_manager(session_mgr);
 
         // Look up the fallback as a task
         let task = self

--- a/src/runtime/session_manager.rs
+++ b/src/runtime/session_manager.rs
@@ -1,0 +1,1328 @@
+// FORGE session manager — session runtime lifecycle (issue #190)
+//
+// Manages long-running external agent sessions with stable UUIDs,
+// persisted state, resumable startup recovery, budget tracking,
+// progress listeners, and graceful cancellation escalation.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, Notify};
+use uuid::Uuid;
+
+use crate::runtime::confidence::{ConfidentValue, Value};
+use crate::tracer::Tracer;
+
+pub type SessionId = String;
+pub type ListenerId = String;
+pub type SharedSessionManager = Arc<SessionManager>;
+pub type SessionListener = Arc<dyn Fn(SessionEvent) + Send + Sync>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SessionStatus {
+    Starting,
+    Running,
+    Completing,
+    Done,
+    Failed,
+    Cancelled,
+}
+
+impl SessionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SessionStatus::Starting => "starting",
+            SessionStatus::Running => "running",
+            SessionStatus::Completing => "completing",
+            SessionStatus::Done => "done",
+            SessionStatus::Failed => "failed",
+            SessionStatus::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            SessionStatus::Done | SessionStatus::Failed | SessionStatus::Cancelled
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionConfig {
+    pub name: String,
+    pub agent: String,
+    pub prompt: Option<String>,
+    pub tools: Vec<String>,
+    pub timeout_secs: Option<u64>,
+    pub budget_usd: Option<f32>,
+    pub gives: Option<String>,
+    pub cancel_timeout_secs: u64,
+}
+
+impl SessionConfig {
+    pub fn new(name: impl Into<String>, agent: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            agent: agent.into(),
+            prompt: None,
+            tools: Vec::new(),
+            timeout_secs: None,
+            budget_usd: None,
+            gives: None,
+            cancel_timeout_secs: 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionProgress {
+    pub ts: DateTime<Utc>,
+    pub payload: ConfidentValue,
+    pub cost_delta_usd: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionState {
+    pub id: SessionId,
+    pub config: SessionConfig,
+    pub status: SessionStatus,
+    pub external_session_id: Option<String>,
+    pub process_id: Option<u32>,
+    pub started_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub cost_usd: f32,
+    pub budget_exceeded: bool,
+    pub latest_progress: Option<ConfidentValue>,
+    pub progress_events: Vec<SessionProgress>,
+    pub output: Option<ConfidentValue>,
+    pub error: Option<String>,
+}
+
+impl SessionState {
+    fn new(id: SessionId, config: SessionConfig) -> Self {
+        let now = Utc::now();
+        Self {
+            id,
+            config,
+            status: SessionStatus::Starting,
+            external_session_id: None,
+            process_id: None,
+            started_at: now,
+            updated_at: now,
+            cost_usd: 0.0,
+            budget_exceeded: false,
+            latest_progress: None,
+            progress_events: Vec::new(),
+            output: None,
+            error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SessionEvent {
+    Spawned {
+        session_id: SessionId,
+    },
+    StateChanged {
+        session_id: SessionId,
+        status: SessionStatus,
+    },
+    Progress {
+        session_id: SessionId,
+        payload: ConfidentValue,
+    },
+    BudgetUpdated {
+        session_id: SessionId,
+        total_cost_usd: f32,
+    },
+    Completed {
+        session_id: SessionId,
+        result: ConfidentValue,
+    },
+    Failed {
+        session_id: SessionId,
+        error: String,
+    },
+    Cancelled {
+        session_id: SessionId,
+    },
+    ResumeAttempted {
+        session_id: SessionId,
+    },
+    ResumeFailed {
+        session_id: SessionId,
+        error: String,
+    },
+}
+
+#[derive(Clone)]
+pub enum SessionDriverEvent {
+    Progress {
+        payload: ConfidentValue,
+        cost_delta_usd: f32,
+    },
+    Cost {
+        delta_usd: f32,
+    },
+    Completing,
+    Completed {
+        result: ConfidentValue,
+    },
+    Failed {
+        error: String,
+    },
+    Cancelled,
+}
+
+pub struct SessionRuntimeHandle {
+    pub external_session_id: Option<String>,
+    pub process_id: Option<u32>,
+    pub events: mpsc::UnboundedReceiver<SessionDriverEvent>,
+    pub controller: Arc<dyn SessionController>,
+}
+
+#[async_trait]
+pub trait SessionController: Send + Sync {
+    async fn request_cancel(&self) -> Result<(), String>;
+    async fn force_kill(&self) -> Result<(), String>;
+}
+
+pub struct NoopSessionController;
+
+#[async_trait]
+impl SessionController for NoopSessionController {
+    async fn request_cancel(&self) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn force_kill(&self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+pub trait SessionDriver: Send + Sync {
+    async fn start(
+        &self,
+        session_id: &str,
+        config: &SessionConfig,
+    ) -> Result<SessionRuntimeHandle, String>;
+
+    async fn resume(&self, state: &SessionState) -> Result<Option<SessionRuntimeHandle>, String>;
+}
+
+struct LiveSession {
+    controller: Arc<dyn SessionController>,
+    notify: Arc<Notify>,
+}
+
+struct SessionEntry {
+    state: SessionState,
+    local_listeners: Vec<SessionListener>,
+    live: Option<LiveSession>,
+}
+
+struct SessionManagerInner {
+    sessions: HashMap<SessionId, SessionEntry>,
+    listeners: HashMap<ListenerId, SessionListener>,
+    drivers: HashMap<String, Arc<dyn SessionDriver>>,
+}
+
+#[derive(Clone)]
+pub struct SessionManager {
+    base_dir: PathBuf,
+    tracer: Option<Tracer>,
+    inner: Arc<Mutex<SessionManagerInner>>,
+}
+
+impl SessionManager {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        let base_dir = base_dir.into();
+        let _ = fs::create_dir_all(&base_dir);
+        Self {
+            base_dir,
+            tracer: None,
+            inner: Arc::new(Mutex::new(SessionManagerInner {
+                sessions: HashMap::new(),
+                listeners: HashMap::new(),
+                drivers: HashMap::new(),
+            })),
+        }
+    }
+
+    pub fn with_tracer(mut self, tracer: Option<Tracer>) -> Self {
+        self.tracer = tracer;
+        self
+    }
+
+    pub fn register_driver(&self, name: impl Into<String>, driver: Arc<dyn SessionDriver>) {
+        self.inner
+            .lock()
+            .unwrap()
+            .drivers
+            .insert(name.into(), driver);
+    }
+
+    pub fn add_listener(&self, listener: SessionListener) -> ListenerId {
+        let id = Uuid::new_v4().to_string();
+        self.inner
+            .lock()
+            .unwrap()
+            .listeners
+            .insert(id.clone(), listener);
+        id
+    }
+
+    pub fn remove_listener(&self, id: &str) {
+        self.inner.lock().unwrap().listeners.remove(id);
+    }
+
+    pub async fn spawn(&self, config: SessionConfig) -> Result<SessionId, String> {
+        self.spawn_with_listeners(config, Vec::new()).await
+    }
+
+    pub async fn run_to_completion(
+        &self,
+        config: SessionConfig,
+        local_listeners: Vec<SessionListener>,
+    ) -> Result<SessionState, String> {
+        let id = self.spawn_with_listeners(config, local_listeners).await?;
+        self.wait(&id).await
+    }
+
+    async fn spawn_with_listeners(
+        &self,
+        config: SessionConfig,
+        local_listeners: Vec<SessionListener>,
+    ) -> Result<SessionId, String> {
+        let session_id = Uuid::new_v4().to_string();
+        let state = SessionState::new(session_id.clone(), config.clone());
+        let driver = {
+            let mut inner = self.inner.lock().unwrap();
+            let driver = inner
+                .drivers
+                .get(&config.agent)
+                .cloned()
+                .ok_or_else(|| format!("unknown session driver: {}", config.agent))?;
+            inner.sessions.insert(
+                session_id.clone(),
+                SessionEntry {
+                    state: state.clone(),
+                    local_listeners,
+                    live: None,
+                },
+            );
+            driver
+        };
+
+        self.persist_state(&state)?;
+        self.trace_spawned(&session_id);
+        self.dispatch_event(SessionEvent::Spawned {
+            session_id: session_id.clone(),
+        });
+        self.dispatch_event(SessionEvent::StateChanged {
+            session_id: session_id.clone(),
+            status: SessionStatus::Starting,
+        });
+
+        match driver.start(&session_id, &config).await {
+            Ok(handle) => {
+                self.attach_runtime(session_id.clone(), handle, false)
+                    .await?;
+                Ok(session_id)
+            }
+            Err(err) => {
+                self.mark_failed(&session_id, err.clone()).await;
+                Err(err)
+            }
+        }
+    }
+
+    pub fn status(&self, id: &str) -> Option<SessionStatus> {
+        self.inner
+            .lock()
+            .unwrap()
+            .sessions
+            .get(id)
+            .map(|entry| entry.state.status.clone())
+    }
+
+    pub fn output(&self, id: &str) -> Option<ConfidentValue> {
+        self.inner
+            .lock()
+            .unwrap()
+            .sessions
+            .get(id)
+            .and_then(|entry| entry.state.output.clone())
+    }
+
+    pub fn session_state(&self, id: &str) -> Option<SessionState> {
+        self.inner
+            .lock()
+            .unwrap()
+            .sessions
+            .get(id)
+            .map(|entry| entry.state.clone())
+    }
+
+    pub fn cancel(&self, id: &str) -> Result<(), String> {
+        let session_id = id.to_string();
+        let exists = self
+            .inner
+            .lock()
+            .unwrap()
+            .sessions
+            .contains_key(&session_id);
+        if !exists {
+            return Err(format!("unknown session id: {}", id));
+        }
+        let manager = self.clone();
+        tokio::spawn(async move {
+            manager.cancel_impl(session_id).await;
+        });
+        Ok(())
+    }
+
+    async fn cancel_impl(&self, session_id: SessionId) {
+        let (controller, cancel_timeout, notify, terminal) = {
+            let inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get(&session_id) else {
+                return;
+            };
+            let terminal = entry.state.status.is_terminal();
+            let live = entry.live.as_ref().map(|live| {
+                (
+                    live.controller.clone(),
+                    Duration::from_secs(entry.state.config.cancel_timeout_secs),
+                    live.notify.clone(),
+                )
+            });
+            match live {
+                Some((controller, timeout, notify)) => {
+                    (Some(controller), timeout, Some(notify), terminal)
+                }
+                None => (None, Duration::from_secs(0), None, terminal),
+            }
+        };
+
+        if terminal {
+            return;
+        }
+
+        let Some(controller) = controller else {
+            self.mark_cancelled(&session_id).await;
+            return;
+        };
+
+        if let Err(err) = controller.request_cancel().await {
+            self.mark_failed(&session_id, format!("cancel request failed: {}", err))
+                .await;
+            return;
+        }
+
+        let Some(notify) = notify else {
+            self.mark_cancelled(&session_id).await;
+            return;
+        };
+
+        if cancel_timeout.is_zero() {
+            let _ = controller.force_kill().await;
+            self.mark_cancelled(&session_id).await;
+            return;
+        }
+
+        tokio::select! {
+            _ = notify.notified() => {}
+            _ = tokio::time::sleep(cancel_timeout) => {
+                let _ = controller.force_kill().await;
+                self.mark_cancelled(&session_id).await;
+            }
+        }
+    }
+
+    pub async fn wait(&self, id: &str) -> Result<SessionState, String> {
+        loop {
+            let notify = {
+                let inner = self.inner.lock().unwrap();
+                let entry = inner
+                    .sessions
+                    .get(id)
+                    .ok_or_else(|| format!("unknown session id: {}", id))?;
+                if entry.state.status.is_terminal() {
+                    return Ok(entry.state.clone());
+                }
+                entry.live.as_ref().map(|live| live.notify.clone())
+            };
+
+            match notify {
+                Some(notify) => notify.notified().await,
+                None => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+        }
+    }
+
+    pub async fn resume_all(&self) -> Vec<SessionId> {
+        let mut resumed = Vec::new();
+        let Ok(entries) = fs::read_dir(&self.base_dir) else {
+            return resumed;
+        };
+
+        for dir_entry in entries.flatten() {
+            let path = dir_entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+
+            let Ok(contents) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(state) = serde_json::from_str::<SessionState>(&contents) else {
+                continue;
+            };
+            let session_id = state.id.clone();
+
+            self.insert_persisted_state(state.clone());
+            if state.status.is_terminal() {
+                continue;
+            }
+
+            self.trace_resume_attempted(&session_id);
+            self.dispatch_event(SessionEvent::ResumeAttempted {
+                session_id: session_id.clone(),
+            });
+
+            let driver = {
+                self.inner
+                    .lock()
+                    .unwrap()
+                    .drivers
+                    .get(&state.config.agent)
+                    .cloned()
+            };
+
+            let Some(driver) = driver else {
+                let err = format!("unknown session driver: {}", state.config.agent);
+                self.trace_resume_failed(&session_id, &err);
+                self.dispatch_event(SessionEvent::ResumeFailed {
+                    session_id: session_id.clone(),
+                    error: err.clone(),
+                });
+                self.mark_failed(&session_id, err).await;
+                continue;
+            };
+
+            match driver.resume(&state).await {
+                Ok(Some(handle)) => {
+                    if self
+                        .attach_runtime(session_id.clone(), handle, true)
+                        .await
+                        .is_ok()
+                    {
+                        resumed.push(session_id);
+                    }
+                }
+                Ok(None) => {
+                    let err = "driver could not resume session".to_string();
+                    self.trace_resume_failed(&session_id, &err);
+                    self.dispatch_event(SessionEvent::ResumeFailed {
+                        session_id: session_id.clone(),
+                        error: err.clone(),
+                    });
+                    self.mark_failed(&session_id, err).await;
+                }
+                Err(err) => {
+                    self.trace_resume_failed(&session_id, &err);
+                    self.dispatch_event(SessionEvent::ResumeFailed {
+                        session_id: session_id.clone(),
+                        error: err.clone(),
+                    });
+                    self.mark_failed(&session_id, err).await;
+                }
+            }
+        }
+
+        resumed
+    }
+
+    fn insert_persisted_state(&self, state: SessionState) {
+        self.inner
+            .lock()
+            .unwrap()
+            .sessions
+            .entry(state.id.clone())
+            .or_insert(SessionEntry {
+                state,
+                local_listeners: Vec::new(),
+                live: None,
+            });
+    }
+
+    async fn attach_runtime(
+        &self,
+        session_id: SessionId,
+        handle: SessionRuntimeHandle,
+        _resumed: bool,
+    ) -> Result<(), String> {
+        let notify = Arc::new(Notify::new());
+        let SessionRuntimeHandle {
+            external_session_id,
+            process_id,
+            mut events,
+            controller,
+        } = handle;
+
+        let snapshot = {
+            let mut inner = self.inner.lock().unwrap();
+            let entry = inner
+                .sessions
+                .get_mut(&session_id)
+                .ok_or_else(|| format!("unknown session id: {}", session_id))?;
+            entry.state.external_session_id = external_session_id;
+            entry.state.process_id = process_id;
+            entry.state.updated_at = Utc::now();
+            if !entry.state.status.is_terminal() {
+                entry.state.status = SessionStatus::Running;
+            }
+            entry.live = Some(LiveSession {
+                controller,
+                notify: notify.clone(),
+            });
+            entry.state.clone()
+        };
+
+        self.persist_state(&snapshot)?;
+        self.trace_state_changed(&session_id, &SessionStatus::Running);
+        self.dispatch_event(SessionEvent::StateChanged {
+            session_id: session_id.clone(),
+            status: SessionStatus::Running,
+        });
+
+        let manager = self.clone();
+        let session_id_for_events = session_id.clone();
+        tokio::spawn(async move {
+            while let Some(event) = events.recv().await {
+                match event {
+                    SessionDriverEvent::Progress {
+                        payload,
+                        cost_delta_usd,
+                    } => {
+                        manager
+                            .handle_progress(&session_id_for_events, payload, cost_delta_usd)
+                            .await
+                    }
+                    SessionDriverEvent::Cost { delta_usd } => {
+                        manager
+                            .handle_cost_delta(&session_id_for_events, delta_usd)
+                            .await
+                    }
+                    SessionDriverEvent::Completing => {
+                        manager
+                            .transition_status(&session_id_for_events, SessionStatus::Completing);
+                    }
+                    SessionDriverEvent::Completed { result } => {
+                        manager.mark_completed(&session_id_for_events, result).await;
+                        return;
+                    }
+                    SessionDriverEvent::Failed { error } => {
+                        manager.mark_failed(&session_id_for_events, error).await;
+                        return;
+                    }
+                    SessionDriverEvent::Cancelled => {
+                        manager.mark_cancelled(&session_id_for_events).await;
+                        return;
+                    }
+                }
+            }
+
+            if let Some(status) = manager.status(&session_id_for_events) {
+                if !status.is_terminal() {
+                    manager
+                        .mark_failed(
+                            &session_id_for_events,
+                            "session driver event stream closed".to_string(),
+                        )
+                        .await;
+                }
+            }
+        });
+
+        if let Some(timeout_secs) = snapshot.config.timeout_secs {
+            let manager = self.clone();
+            let session_id_for_timeout = session_id.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(timeout_secs)).await;
+                manager
+                    .mark_timeout_if_still_running(&session_id_for_timeout, timeout_secs)
+                    .await;
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn mark_timeout_if_still_running(&self, session_id: &str, timeout_secs: u64) {
+        let should_cancel = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get_mut(session_id) else {
+                return;
+            };
+            if entry.state.status.is_terminal() {
+                return;
+            }
+            entry.state.error = Some(format!("session timed out after {}s", timeout_secs));
+            entry.state.updated_at = Utc::now();
+            true
+        };
+
+        if should_cancel {
+            if let Some(state) = self.session_state(session_id) {
+                let _ = self.persist_state(&state);
+            }
+            let _ = self.cancel(session_id);
+        }
+    }
+
+    async fn handle_progress(
+        &self,
+        session_id: &str,
+        payload: ConfidentValue,
+        cost_delta_usd: f32,
+    ) {
+        let maybe_snapshot = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get_mut(session_id) else {
+                return;
+            };
+            if entry.state.status == SessionStatus::Starting {
+                entry.state.status = SessionStatus::Running;
+            }
+            entry.state.updated_at = Utc::now();
+            entry.state.cost_usd += cost_delta_usd.max(0.0);
+            entry.state.latest_progress = Some(payload.clone());
+            entry.state.progress_events.push(SessionProgress {
+                ts: Utc::now(),
+                payload: payload.clone(),
+                cost_delta_usd,
+            });
+            Some(entry.state.clone())
+        };
+
+        let Some(snapshot) = maybe_snapshot else {
+            return;
+        };
+
+        let _ = self.persist_state(&snapshot);
+        self.trace_progress(session_id, snapshot.cost_usd);
+        self.dispatch_event(SessionEvent::Progress {
+            session_id: session_id.to_string(),
+            payload,
+        });
+        self.dispatch_event(SessionEvent::BudgetUpdated {
+            session_id: session_id.to_string(),
+            total_cost_usd: snapshot.cost_usd,
+        });
+        self.trace_budget_updated(session_id, snapshot.cost_usd);
+        self.enforce_budget_if_needed(session_id).await;
+    }
+
+    async fn handle_cost_delta(&self, session_id: &str, delta_usd: f32) {
+        let maybe_snapshot = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get_mut(session_id) else {
+                return;
+            };
+            entry.state.updated_at = Utc::now();
+            entry.state.cost_usd += delta_usd.max(0.0);
+            Some(entry.state.clone())
+        };
+
+        if let Some(snapshot) = maybe_snapshot {
+            let _ = self.persist_state(&snapshot);
+            self.dispatch_event(SessionEvent::BudgetUpdated {
+                session_id: session_id.to_string(),
+                total_cost_usd: snapshot.cost_usd,
+            });
+            self.trace_budget_updated(session_id, snapshot.cost_usd);
+            self.enforce_budget_if_needed(session_id).await;
+        }
+    }
+
+    async fn enforce_budget_if_needed(&self, session_id: &str) {
+        let should_cancel = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get_mut(session_id) else {
+                return;
+            };
+            let Some(budget) = entry.state.config.budget_usd else {
+                return;
+            };
+            if entry.state.budget_exceeded || entry.state.cost_usd <= budget {
+                return;
+            }
+            entry.state.budget_exceeded = true;
+            entry.state.error = Some(format!(
+                "session budget exceeded: spent ${:.4} of ${:.4}",
+                entry.state.cost_usd, budget
+            ));
+            true
+        };
+
+        if should_cancel {
+            let _ = self.cancel(session_id);
+        }
+    }
+
+    fn transition_status(&self, session_id: &str, status: SessionStatus) {
+        let maybe_snapshot = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get_mut(session_id) else {
+                return;
+            };
+            if entry.state.status == status {
+                return;
+            }
+            if entry.state.status.is_terminal() {
+                return;
+            }
+            entry.state.status = status.clone();
+            entry.state.updated_at = Utc::now();
+            Some(entry.state.clone())
+        };
+
+        if let Some(snapshot) = maybe_snapshot {
+            let _ = self.persist_state(&snapshot);
+            self.trace_state_changed(session_id, &status);
+            self.dispatch_event(SessionEvent::StateChanged {
+                session_id: session_id.to_string(),
+                status,
+            });
+        }
+    }
+
+    async fn mark_completed(&self, session_id: &str, result: ConfidentValue) {
+        self.transition_status(session_id, SessionStatus::Completing);
+        let result = self.inject_cost(result, session_id);
+        let (snapshot, notify) = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get_mut(session_id) else {
+                return;
+            };
+            entry.state.status = SessionStatus::Done;
+            entry.state.output = Some(result.clone());
+            entry.state.updated_at = Utc::now();
+            let notify = entry.live.as_ref().map(|live| live.notify.clone());
+            entry.live = None;
+            (entry.state.clone(), notify)
+        };
+
+        let _ = self.persist_state(&snapshot);
+        self.trace_completed(session_id, snapshot.cost_usd);
+        self.dispatch_event(SessionEvent::Completed {
+            session_id: session_id.to_string(),
+            result,
+        });
+        self.dispatch_event(SessionEvent::StateChanged {
+            session_id: session_id.to_string(),
+            status: SessionStatus::Done,
+        });
+        if let Some(notify) = notify {
+            notify.notify_waiters();
+        }
+    }
+
+    async fn mark_failed(&self, session_id: &str, error: String) {
+        let (snapshot, notify) = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get_mut(session_id) else {
+                return;
+            };
+            entry.state.status = SessionStatus::Failed;
+            entry.state.error = Some(error.clone());
+            entry.state.updated_at = Utc::now();
+            let notify = entry.live.as_ref().map(|live| live.notify.clone());
+            entry.live = None;
+            (entry.state.clone(), notify)
+        };
+
+        let _ = self.persist_state(&snapshot);
+        self.trace_failed(session_id, &error);
+        self.dispatch_event(SessionEvent::Failed {
+            session_id: session_id.to_string(),
+            error: error.clone(),
+        });
+        self.dispatch_event(SessionEvent::StateChanged {
+            session_id: session_id.to_string(),
+            status: SessionStatus::Failed,
+        });
+        if let Some(notify) = notify {
+            notify.notify_waiters();
+        }
+    }
+
+    async fn mark_cancelled(&self, session_id: &str) {
+        let (snapshot, notify, changed) = {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.sessions.get_mut(session_id) else {
+                return;
+            };
+            let changed = entry.state.status != SessionStatus::Cancelled;
+            entry.state.status = SessionStatus::Cancelled;
+            entry.state.updated_at = Utc::now();
+            let notify = entry.live.as_ref().map(|live| live.notify.clone());
+            entry.live = None;
+            (entry.state.clone(), notify, changed)
+        };
+
+        let _ = self.persist_state(&snapshot);
+        if changed {
+            self.trace_cancelled(session_id);
+            self.dispatch_event(SessionEvent::Cancelled {
+                session_id: session_id.to_string(),
+            });
+            self.dispatch_event(SessionEvent::StateChanged {
+                session_id: session_id.to_string(),
+                status: SessionStatus::Cancelled,
+            });
+        }
+        if let Some(notify) = notify {
+            notify.notify_waiters();
+        }
+    }
+
+    fn inject_cost(&self, result: ConfidentValue, session_id: &str) -> ConfidentValue {
+        let cost_usd = self
+            .session_state(session_id)
+            .map(|state| state.cost_usd)
+            .unwrap_or(0.0);
+
+        match result.value {
+            Value::Record(mut fields) => {
+                if fields.contains_key("cost_usd") {
+                    fields.insert(
+                        "cost_usd".to_string(),
+                        ConfidentValue::deterministic(Value::Number(cost_usd as f64)),
+                    );
+                    ConfidentValue::from_agent_result(fields)
+                } else {
+                    ConfidentValue {
+                        value: Value::Record(fields),
+                        confidence: result.confidence,
+                        source: result.source,
+                    }
+                }
+            }
+            other => ConfidentValue {
+                value: other,
+                confidence: result.confidence,
+                source: result.source,
+            },
+        }
+    }
+
+    fn state_path(&self, session_id: &str) -> PathBuf {
+        self.base_dir.join(format!("{}.json", session_id))
+    }
+
+    fn persist_state(&self, state: &SessionState) -> Result<(), String> {
+        fs::create_dir_all(&self.base_dir).map_err(|e| e.to_string())?;
+        let json = serde_json::to_string_pretty(state).map_err(|e| e.to_string())?;
+        fs::write(self.state_path(&state.id), json).map_err(|e| e.to_string())
+    }
+
+    fn dispatch_event(&self, event: SessionEvent) {
+        let listeners = {
+            let inner = self.inner.lock().unwrap();
+            let session_id = session_id_of(&event);
+            let mut listeners: Vec<SessionListener> = inner.listeners.values().cloned().collect();
+            if let Some(session_id) = session_id {
+                if let Some(entry) = inner.sessions.get(session_id) {
+                    listeners.extend(entry.local_listeners.iter().cloned());
+                }
+            }
+            listeners
+        };
+
+        for listener in listeners {
+            listener(event.clone());
+        }
+    }
+
+    fn trace_spawned(&self, session_id: &str) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_spawned(session_id);
+        }
+    }
+
+    fn trace_state_changed(&self, session_id: &str, status: &SessionStatus) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_state_changed(session_id, status.as_str());
+        }
+    }
+
+    fn trace_progress(&self, session_id: &str, total_cost_usd: f32) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_progress(session_id, total_cost_usd);
+        }
+    }
+
+    fn trace_budget_updated(&self, session_id: &str, total_cost_usd: f32) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_budget_updated(session_id, total_cost_usd);
+        }
+    }
+
+    fn trace_completed(&self, session_id: &str, total_cost_usd: f32) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_completed(session_id, total_cost_usd);
+        }
+    }
+
+    fn trace_failed(&self, session_id: &str, error: &str) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_failed(session_id, error);
+        }
+    }
+
+    fn trace_cancelled(&self, session_id: &str) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_cancelled(session_id);
+        }
+    }
+
+    fn trace_resume_attempted(&self, session_id: &str) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_resume_attempted(session_id);
+        }
+    }
+
+    fn trace_resume_failed(&self, session_id: &str, error: &str) {
+        if let Some(ref tracer) = self.tracer {
+            tracer.session_resume_failed(session_id, error);
+        }
+    }
+}
+
+fn session_id_of(event: &SessionEvent) -> Option<&str> {
+    match event {
+        SessionEvent::Spawned { session_id }
+        | SessionEvent::StateChanged { session_id, .. }
+        | SessionEvent::Progress { session_id, .. }
+        | SessionEvent::BudgetUpdated { session_id, .. }
+        | SessionEvent::Completed { session_id, .. }
+        | SessionEvent::Failed { session_id, .. }
+        | SessionEvent::Cancelled { session_id }
+        | SessionEvent::ResumeAttempted { session_id }
+        | SessionEvent::ResumeFailed { session_id, .. } => Some(session_id.as_str()),
+    }
+}
+
+pub fn default_session_dir(root: impl AsRef<Path>) -> PathBuf {
+    root.as_ref().join(".forge-data").join("sessions")
+}
+
+pub fn new_shared_default_session_manager(tracer: Option<Tracer>) -> SharedSessionManager {
+    let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    Arc::new(SessionManager::new(default_session_dir(root)).with_tracer(tracer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::TempDir;
+
+    fn text(s: &str) -> ConfidentValue {
+        ConfidentValue::from_skill(Value::Text(s.to_string()), 0.8)
+    }
+
+    fn temp_manager() -> (TempDir, SessionManager) {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = SessionManager::new(default_session_dir(dir.path()));
+        (dir, manager)
+    }
+
+    #[derive(Default)]
+    struct TestController {
+        cancel_requests: AtomicUsize,
+        kill_requests: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl SessionController for TestController {
+        async fn request_cancel(&self) -> Result<(), String> {
+            self.cancel_requests.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn force_kill(&self) -> Result<(), String> {
+            self.kill_requests.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct ScriptedDriver {
+        factory: Arc<dyn Fn() -> SessionRuntimeHandle + Send + Sync>,
+        resume_factory: Option<Arc<dyn Fn() -> Option<SessionRuntimeHandle> + Send + Sync>>,
+    }
+
+    #[async_trait]
+    impl SessionDriver for ScriptedDriver {
+        async fn start(
+            &self,
+            _session_id: &str,
+            _config: &SessionConfig,
+        ) -> Result<SessionRuntimeHandle, String> {
+            Ok((self.factory)())
+        }
+
+        async fn resume(
+            &self,
+            _state: &SessionState,
+        ) -> Result<Option<SessionRuntimeHandle>, String> {
+            match &self.resume_factory {
+                Some(factory) => Ok(factory()),
+                None => Ok(None),
+            }
+        }
+    }
+
+    fn runtime_with_events(
+        controller: Arc<TestController>,
+        events: Vec<SessionDriverEvent>,
+    ) -> SessionRuntimeHandle {
+        let (tx, rx) = mpsc::unbounded_channel();
+        for event in events {
+            tx.send(event).unwrap();
+        }
+        drop(tx);
+        SessionRuntimeHandle {
+            external_session_id: Some("driver-123".to_string()),
+            process_id: Some(4321),
+            events: rx,
+            controller,
+        }
+    }
+
+    fn runtime_keepalive(controller: Arc<TestController>) -> SessionRuntimeHandle {
+        let (tx, rx) = mpsc::unbounded_channel::<SessionDriverEvent>();
+        tokio::spawn(async move {
+            let _tx = tx;
+            std::future::pending::<()>().await;
+        });
+        SessionRuntimeHandle {
+            external_session_id: None,
+            process_id: None,
+            events: rx,
+            controller,
+        }
+    }
+
+    fn runtime_keepalive_with_events(
+        controller: Arc<TestController>,
+        events: Vec<SessionDriverEvent>,
+    ) -> SessionRuntimeHandle {
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            for event in events {
+                let _ = tx.send(event);
+            }
+            std::future::pending::<()>().await;
+        });
+        SessionRuntimeHandle {
+            external_session_id: None,
+            process_id: None,
+            events: rx,
+            controller,
+        }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_runs_start_to_complete() {
+        let (_dir, manager) = temp_manager();
+        manager.register_driver(
+            "fake",
+            Arc::new(ScriptedDriver {
+                factory: Arc::new(|| {
+                    runtime_with_events(
+                        Arc::new(TestController::default()),
+                        vec![
+                            SessionDriverEvent::Progress {
+                                payload: text("working"),
+                                cost_delta_usd: 0.2,
+                            },
+                            SessionDriverEvent::Completing,
+                            SessionDriverEvent::Completed {
+                                result: text("done"),
+                            },
+                        ],
+                    )
+                }),
+                resume_factory: None,
+            }),
+        );
+
+        let state = manager
+            .run_to_completion(SessionConfig::new("review", "fake"), Vec::new())
+            .await
+            .unwrap();
+
+        assert_eq!(state.status, SessionStatus::Done);
+        assert!((state.cost_usd - 0.2).abs() < f32::EPSILON);
+        assert_eq!(
+            manager.output(&state.id).unwrap().value.to_string(),
+            "done".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_escalates_to_force_kill_after_timeout() {
+        let (_dir, manager) = temp_manager();
+        let controller = Arc::new(TestController::default());
+        let controller_for_driver = controller.clone();
+        manager.register_driver(
+            "fake",
+            Arc::new(ScriptedDriver {
+                factory: Arc::new(move || runtime_keepalive(controller_for_driver.clone())),
+                resume_factory: None,
+            }),
+        );
+
+        let mut config = SessionConfig::new("review", "fake");
+        config.cancel_timeout_secs = 0;
+        let session_id = manager.spawn(config).await.unwrap();
+        manager.cancel(&session_id).unwrap();
+        let state = manager.wait(&session_id).await.unwrap();
+
+        assert_eq!(state.status, SessionStatus::Cancelled);
+        assert_eq!(controller.cancel_requests.load(Ordering::SeqCst), 1);
+        assert_eq!(controller.kill_requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn resume_all_reattaches_running_sessions() {
+        let (dir, manager) = temp_manager();
+        let mut persisted = SessionState::new(
+            "resume-me".to_string(),
+            SessionConfig::new("review", "fake"),
+        );
+        persisted.status = SessionStatus::Running;
+        persisted.updated_at = Utc::now();
+        manager.persist_state(&persisted).unwrap();
+
+        manager.register_driver(
+            "fake",
+            Arc::new(ScriptedDriver {
+                factory: Arc::new(|| {
+                    runtime_with_events(
+                        Arc::new(TestController::default()),
+                        vec![SessionDriverEvent::Completed {
+                            result: text("resumed"),
+                        }],
+                    )
+                }),
+                resume_factory: Some(Arc::new(|| {
+                    Some(runtime_with_events(
+                        Arc::new(TestController::default()),
+                        vec![SessionDriverEvent::Completed {
+                            result: text("resumed"),
+                        }],
+                    ))
+                })),
+            }),
+        );
+
+        let reloaded = SessionManager::new(default_session_dir(dir.path()));
+        reloaded.register_driver(
+            "fake",
+            Arc::new(ScriptedDriver {
+                factory: Arc::new(|| {
+                    runtime_with_events(
+                        Arc::new(TestController::default()),
+                        vec![SessionDriverEvent::Completed {
+                            result: text("resumed"),
+                        }],
+                    )
+                }),
+                resume_factory: Some(Arc::new(|| {
+                    Some(runtime_with_events(
+                        Arc::new(TestController::default()),
+                        vec![SessionDriverEvent::Completed {
+                            result: text("resumed"),
+                        }],
+                    ))
+                })),
+            }),
+        );
+
+        let resumed = reloaded.resume_all().await;
+        assert_eq!(resumed, vec!["resume-me".to_string()]);
+        let state = reloaded.wait("resume-me").await.unwrap();
+        assert_eq!(state.status, SessionStatus::Done);
+    }
+
+    #[tokio::test]
+    async fn budget_exceeded_triggers_cancel() {
+        let (_dir, manager) = temp_manager();
+        let controller = Arc::new(TestController::default());
+        let controller_for_driver = controller.clone();
+        manager.register_driver(
+            "fake",
+            Arc::new(ScriptedDriver {
+                factory: Arc::new(move || {
+                    runtime_keepalive_with_events(
+                        controller_for_driver.clone(),
+                        vec![SessionDriverEvent::Progress {
+                            payload: text("expensive"),
+                            cost_delta_usd: 2.5,
+                        }],
+                    )
+                }),
+                resume_factory: None,
+            }),
+        );
+
+        let mut config = SessionConfig::new("review", "fake");
+        config.budget_usd = Some(1.0);
+        config.cancel_timeout_secs = 0;
+        let session_id = manager.spawn(config).await.unwrap();
+        let state = manager.wait(&session_id).await.unwrap();
+
+        assert_eq!(state.status, SessionStatus::Cancelled);
+        assert!(state.budget_exceeded);
+        assert_eq!(controller.cancel_requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn timeout_triggers_cancel() {
+        let (_dir, manager) = temp_manager();
+        let controller = Arc::new(TestController::default());
+        let controller_for_driver = controller.clone();
+        manager.register_driver(
+            "fake",
+            Arc::new(ScriptedDriver {
+                factory: Arc::new(move || runtime_keepalive(controller_for_driver.clone())),
+                resume_factory: None,
+            }),
+        );
+
+        let mut config = SessionConfig::new("review", "fake");
+        config.timeout_secs = Some(0);
+        config.cancel_timeout_secs = 0;
+        let session_id = manager.spawn(config).await.unwrap();
+        let state = manager.wait(&session_id).await.unwrap();
+
+        assert_eq!(state.status, SessionStatus::Cancelled);
+        assert_eq!(state.error.as_deref(), Some("session timed out after 0s"));
+        assert_eq!(controller.cancel_requests.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/runtime/watcher.rs
+++ b/src/runtime/watcher.rs
@@ -209,16 +209,22 @@ fn attempt_reload(
     let cmd_mgr = std::sync::Arc::new(std::sync::Mutex::new(
         crate::runtime::command_manager::CommandManager::new(),
     ));
+    let session_mgr =
+        crate::runtime::session_manager::new_shared_default_session_manager(tracer.clone());
     let mut new_executor =
         crate::runtime::executor::TaskExecutor::new(program, std::sync::Arc::new(registry), tracer)
             .with_config(config)
-            .with_command_manager(cmd_mgr);
+            .with_command_manager(cmd_mgr)
+            .with_session_manager(session_mgr);
 
     // Preserve storage handle from the old executor (#140)
     {
         let old_guard = swappable.read().unwrap();
         if let Some(storage) = old_guard.storage_handle() {
             new_executor = new_executor.with_storage(storage);
+        }
+        if let Some(session_mgr) = old_guard.session_manager() {
+            new_executor = new_executor.with_session_manager(session_mgr.clone());
         }
     }
 

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -402,6 +402,95 @@ impl Tracer {
         );
     }
 
+    // ── Session tracing (issue #190) ───────────────────────────────────────
+
+    pub fn session_spawned(&self, session_id: &str) {
+        self.emit(
+            "session_spawned",
+            serde_json::json!({
+                "session_id": session_id,
+            }),
+        );
+    }
+
+    pub fn session_state_changed(&self, session_id: &str, status: &str) {
+        self.emit(
+            "session_state_changed",
+            serde_json::json!({
+                "session_id": session_id,
+                "status": status,
+            }),
+        );
+    }
+
+    pub fn session_progress(&self, session_id: &str, total_cost_usd: f32) {
+        self.emit(
+            "session_progress",
+            serde_json::json!({
+                "session_id": session_id,
+                "total_cost_usd": total_cost_usd,
+            }),
+        );
+    }
+
+    pub fn session_budget_updated(&self, session_id: &str, total_cost_usd: f32) {
+        self.emit(
+            "session_budget_updated",
+            serde_json::json!({
+                "session_id": session_id,
+                "total_cost_usd": total_cost_usd,
+            }),
+        );
+    }
+
+    pub fn session_completed(&self, session_id: &str, total_cost_usd: f32) {
+        self.emit(
+            "session_completed",
+            serde_json::json!({
+                "session_id": session_id,
+                "total_cost_usd": total_cost_usd,
+            }),
+        );
+    }
+
+    pub fn session_failed(&self, session_id: &str, error: &str) {
+        self.emit(
+            "session_failed",
+            serde_json::json!({
+                "session_id": session_id,
+                "error": error,
+            }),
+        );
+    }
+
+    pub fn session_cancelled(&self, session_id: &str) {
+        self.emit(
+            "session_cancelled",
+            serde_json::json!({
+                "session_id": session_id,
+            }),
+        );
+    }
+
+    pub fn session_resume_attempted(&self, session_id: &str) {
+        self.emit(
+            "session_resume_attempted",
+            serde_json::json!({
+                "session_id": session_id,
+            }),
+        );
+    }
+
+    pub fn session_resume_failed(&self, session_id: &str, error: &str) {
+        self.emit(
+            "session_resume_failed",
+            serde_json::json!({
+                "session_id": session_id,
+                "error": error,
+            }),
+        );
+    }
+
     // ── Skill tracing (issue #40) ──────────────────────────────────────────
 
     pub fn skill_call(&self, skill_name: &str) {

--- a/tests/session_runtime_tests.rs
+++ b/tests/session_runtime_tests.rs
@@ -1,0 +1,193 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use forge::llm::providers::mock::MockProvider;
+use forge::llm::registry::ProviderRegistry;
+use forge::runtime::event_bus::EventBus;
+use forge::runtime::executor::TaskExecutor;
+use forge::runtime::session_manager::{
+    default_session_dir, NoopSessionController, SessionConfig, SessionDriver, SessionDriverEvent,
+    SessionManager, SessionRuntimeHandle, SessionState,
+};
+use forge::runtime::{confidence::ConfidentValue, confidence::Value};
+use forge::tracer::Tracer;
+
+fn mock_registry() -> Arc<ProviderRegistry> {
+    let mock = MockProvider::new("mock").with_default("mock");
+    let mut reg = ProviderRegistry::new("mock");
+    reg.register("mock", Arc::new(mock));
+    Arc::new(reg)
+}
+
+fn parse_source(src: &str) -> forge::ast::Program {
+    forge::parser::parse(src).unwrap_or_else(|e| panic!("parse failed: {:?}", e))
+}
+
+fn text_value(s: &str) -> ConfidentValue {
+    ConfidentValue::from_skill(Value::Text(s.to_string()), 0.84)
+}
+
+struct ScriptedDriver {
+    events: Vec<SessionDriverEvent>,
+}
+
+#[async_trait]
+impl SessionDriver for ScriptedDriver {
+    async fn start(
+        &self,
+        _session_id: &str,
+        _config: &SessionConfig,
+    ) -> Result<SessionRuntimeHandle, String> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        for event in self.events.clone() {
+            tx.send(event).unwrap();
+        }
+        drop(tx);
+        Ok(SessionRuntimeHandle {
+            external_session_id: Some("external-1".to_string()),
+            process_id: Some(42),
+            events: rx,
+            controller: Arc::new(NoopSessionController),
+        })
+    }
+
+    async fn resume(&self, _state: &SessionState) -> Result<Option<SessionRuntimeHandle>, String> {
+        Ok(None)
+    }
+}
+
+#[tokio::test]
+async fn session_expression_emits_progress_and_completion_hooks() {
+    let src = r#"
+task review
+  gives Text
+  do
+    result = session "code-review" agent "fake" prompt "check this" on progress -> emit ReviewUpdate(it) on complete -> emit ReviewDone(it)
+    give result
+
+fn main
+  say review()
+"#;
+    let program = parse_source(src);
+    let tracer = Tracer::with_capture();
+    let bus = EventBus::new_shared(None);
+    let mut review_update_rx = bus
+        .write()
+        .await
+        .subscribe("ReviewUpdate", "listener-a", None);
+    let mut review_done_rx = bus
+        .write()
+        .await
+        .subscribe("ReviewDone", "listener-b", None);
+
+    let temp = tempfile::tempdir().unwrap();
+    let session_mgr = Arc::new(
+        SessionManager::new(default_session_dir(temp.path())).with_tracer(Some(tracer.clone())),
+    );
+    session_mgr.register_driver(
+        "fake",
+        Arc::new(ScriptedDriver {
+            events: vec![
+                SessionDriverEvent::Progress {
+                    payload: text_value("working"),
+                    cost_delta_usd: 0.4,
+                },
+                SessionDriverEvent::Completed {
+                    result: text_value("final answer"),
+                },
+            ],
+        }),
+    );
+
+    let executor = TaskExecutor::new(program, mock_registry(), Some(tracer.clone()))
+        .with_event_bus(bus.clone())
+        .with_session_manager(session_mgr);
+    executor.run().await.unwrap();
+
+    let outputs = executor.outputs();
+    assert!(
+        outputs.iter().any(|line| line.contains("final answer")),
+        "expected final session text in output, got: {:?}",
+        outputs
+    );
+
+    let progress = tokio::time::timeout(std::time::Duration::from_secs(2), review_update_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(progress.args[0].value.to_string(), "working");
+
+    let done = tokio::time::timeout(std::time::Duration::from_secs(2), review_done_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(done.args[0].value.to_string(), "final answer");
+
+    let events = tracer.captured_events();
+    assert!(events.contains(&"session_spawned".to_string()));
+    assert!(events.contains(&"session_progress".to_string()));
+    assert!(events.contains(&"session_completed".to_string()));
+}
+
+#[tokio::test]
+async fn session_expression_coerces_to_agent_result() {
+    let src = r#"
+task review
+  gives AgentResult
+  do
+    result = session "code-review" agent "fake" prompt "check this" gives AgentResult
+    give result
+
+fn main
+  result = review()
+  say result.plan
+  say "{result.cost_usd}"
+"#;
+    let program = parse_source(src);
+    let temp = tempfile::tempdir().unwrap();
+    let session_mgr = Arc::new(SessionManager::new(default_session_dir(temp.path())));
+    session_mgr.register_driver(
+        "fake",
+        Arc::new(ScriptedDriver {
+            events: vec![SessionDriverEvent::Completed {
+                result: ConfidentValue::from_agent_result(
+                    [
+                        (
+                            "plan".to_string(),
+                            ConfidentValue::from_skill(
+                                Value::Text("review completed".to_string()),
+                                0.9,
+                            ),
+                        ),
+                        (
+                            "confidence".to_string(),
+                            ConfidentValue::deterministic(Value::Number(0.9)),
+                        ),
+                        (
+                            "cost_usd".to_string(),
+                            ConfidentValue::deterministic(Value::Number(0.0)),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            }],
+        }),
+    );
+
+    let executor =
+        TaskExecutor::new(program, mock_registry(), None).with_session_manager(session_mgr);
+    executor.run().await.unwrap();
+
+    let outputs = executor.outputs();
+    assert!(
+        outputs.iter().any(|line| line.contains("review completed")),
+        "expected AgentResult plan in output, got: {:?}",
+        outputs
+    );
+    assert!(
+        outputs.iter().any(|line| line.contains("0")),
+        "expected AgentResult cost output, got: {:?}",
+        outputs
+    );
+}


### PR DESCRIPTION
## Summary
- add `SessionManager` runtime support for long-running external agent sessions with persisted state, resume, graceful cancellation, budget enforcement, and lifecycle tracing
- execute `session` expressions through the runtime manager, including `on progress` / `on complete` hook emission and `Text` / `AgentResult` output coercion
- wire shared session-manager construction into runtime/bootstrap entrypoints and update roadmap/changelog for Phase 2 progress

## Acceptance Criteria
- [x] `src/runtime/session_manager.rs` (new): `SessionManager` struct with `HashMap<SessionId, SessionState>`
- [x] Stable session IDs (UUID, not PID)
- [x] State machine: starting -> running -> completing -> done / failed / cancelled
- [x] Persist session state to `.forge-data/sessions/` (JSON) for resume after restart
- [x] `resume_all()` on FORGE startup — reconnect to running processes
- [x] Graceful cancellation: SIGTERM -> configurable timeout -> SIGKILL
- [x] Progress callback: `SessionManager` emits progress events to registered listeners
- [x] Budget tracking: accumulate cost from adapter output, enforce budget cap
- [x] Tests: lifecycle (start->run->complete), cancel, timeout, resume, budget exceeded

## Verification
- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Real-world validation against a live external agent CLI

## Notes
- Live adapter validation is intentionally deferred to `#191`, which owns the actual Claude/Codex adapter wiring.
