### PR TITLE
feat: sandbox isolation — isolate worktree modifier (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- Sandbox isolation: `isolate worktree "branch"` modifier on `spawn` and `session` creates a git worktree at `.forge-data/worktrees/{branch-slug}/` for filesystem isolation, with automatic cleanup on agent retire or session completion (#194)
 - Session polling + event integration: `SessionManager` publishes typed events (`session.progress`, `session.complete`, `session.failed`, `session.cancelled`) directly to `EventBus`, enriched with timestamp, message, duration, and final status fields (#192)
 - Timer-based session polling with configurable interval (default 5s) — publishes `session.poll` events for active sessions to EventBus (#192)
 - `session.status(id)` imperative expression — query session state from FORGE code, returns Record with `status`, `cost_usd`, `started_at`, `updated_at`, `error` fields (#192)

--- a/examples/session/session_isolate.forge
+++ b/examples/session/session_isolate.forge
@@ -1,0 +1,9 @@
+# Session with sandbox isolation — issue #194
+# The isolate worktree modifier creates a git worktree so
+# the session agent operates on an isolated copy of the repo.
+
+task implement_feature
+  gives Text
+  do
+    result = session "implement" agent "claude" prompt "Fix the login bug" isolate worktree "feature/fix-login" timeout 30m gives AgentResult
+    say "Session completed with plan: {result.plan}"

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -375,8 +375,9 @@ spawn_stmt_i3 = {
     (nl ~ i4 ~ spawn_option)*
 }
 spawn_option = {
-    spawn_knowledge_option | spawn_confidence_cap_option | spawn_memory_option
+    spawn_isolate_option | spawn_knowledge_option | spawn_confidence_cap_option | spawn_memory_option
 }
+spawn_isolate_option        = { "isolate" ~ _s ~ "worktree" ~ _s ~ string_arg }
 spawn_knowledge_option      = { "with" ~ _s ~ "knowledge" ~ _s ~ "where" ~ _s ~ spawn_knowledge_pred }
 spawn_knowledge_pred        = { "category" ~ _s_opt ~ "==" ~ _s_opt ~ string_arg }
 spawn_confidence_cap_option = { "with" ~ _s ~ "confidence_cap" ~ _s_opt ~ ":" ~ _s_opt ~ expr }
@@ -607,14 +608,16 @@ session_modifier = _{
   | session_budget_modifier
   | session_gives_modifier
   | session_hook_modifier
+  | session_isolate_modifier
 }
-session_agent_modifier = { "agent" ~ _s ~ string_arg }
-session_prompt_modifier = { "prompt" ~ _s ~ string_arg }
-session_tools_modifier = { "tools" ~ _s ~ expr }
+session_agent_modifier   = { "agent" ~ _s ~ string_arg }
+session_prompt_modifier  = { "prompt" ~ _s ~ string_arg }
+session_tools_modifier   = { "tools" ~ _s ~ expr }
 session_timeout_modifier = { "timeout" ~ _s ~ duration }
-session_budget_modifier = { "budget" ~ _s ~ expr }
-session_gives_modifier = { "gives" ~ _s ~ "AgentResult" }
-session_hook_modifier = { "on" ~ _s ~ session_hook_kind ~ _s_opt ~ "->" ~ _s_opt ~ session_emit_hook }
+session_budget_modifier  = { "budget" ~ _s ~ expr }
+session_gives_modifier   = { "gives" ~ _s ~ "AgentResult" }
+session_hook_modifier    = { "on" ~ _s ~ session_hook_kind ~ _s_opt ~ "->" ~ _s_opt ~ session_emit_hook }
+session_isolate_modifier = { "isolate" ~ _s ~ "worktree" ~ _s ~ string_arg }
 session_hook_kind = { "progress" | "complete" }
 session_emit_hook = { "emit" ~ _s ~ ident ~ "(" ~ _s_opt ~ arg_list? ~ _s_opt ~ ")" }
 env_map      = { "{" ~ _s_opt ~ env_entry ~ (_s_opt ~ "," ~ _s_opt ~ env_entry)* ~ _s_opt ~ "}" }

--- a/roadmap.md
+++ b/roadmap.md
@@ -75,7 +75,7 @@ Everything in this document exists to reach that moment.
 | P2.M3 — AgentResult + Contract | Typed result contract plus claims/evidence/verification model | #193, #203 | Open |
 | P2.M4 — Session Adapters + Events | Agent adapters, polling, and event integration | #191, #192 | Open |
 | P2.M5 — Verification + Contradictions | Verification engine and contradiction/warden integration | #204, #205 | Open |
-| P2.M6 — Sandbox | `sandbox` isolation: spawn modifier + worktree | #194 | Open |
+| P2.M6 — Sandbox | `sandbox` isolation: spawn modifier + worktree | #194 ✅ | Done |
 | P2.M7 — Skills Foundation | Pluggable skill architecture, capability types, CLI delegation research | #163 ✅ #164 ✅ #165 | In Progress |
 | P2.M8 — CLI Skills | GitHub, Slack, Claude Code, Codex/Ollama SKILL.md files | #176-#179 | Open |
 | P2.M9 — Orchestration | Slack Monitor, Inbound Triager, approval gate | #180-#182 | Open |
@@ -685,7 +685,7 @@ Worktree isolation for safe agent execution:
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| #194 | sandbox isolation — spawn modifier + worktree | Open |
+| #194 | sandbox isolation — spawn modifier + worktree | Done ✅ |
 
 ### P2.M7: Skills Foundation
 
@@ -937,7 +937,7 @@ P2.M2  Session Core    ███████████████████
 P2.M3  Result+Contract ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M4  Adapters+Events ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M5  Verify+Contra   ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
-P2.M6  Sandbox         ░░░░░░░░░░░░░░░░░░░░  0/1  (  0%)
+P2.M6  Sandbox         ████████████████████  1/1  (100%)
 P2.M7  Skills          █████████████░░░░░░░  2/3  ( 67%)
 P2.M8  CLI Skills      ░░░░░░░░░░░░░░░░░░░░  0/4  (  0%)
 P2.M9  Orchestration   ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
@@ -1324,7 +1324,7 @@ Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (8/37 issues done)**
   ⬜ P2.M3: `AgentResult` + reliability contract — claims, evidence, verification (#193, #203)
   ⬜ P2.M4: session adapters + events — Claude/Codex/generic and event hooks (#191-#192)
   ⬜ P2.M5: verification + contradictions — trusted gating before repo mutations (#204-#205)
-  ⬜ P2.M6: `sandbox` — worktree isolation for safe execution (#194)
+  ✅ P2.M6: `sandbox` — worktree isolation for safe execution (#194 ✅)
   ✅ P2.M7: Skills foundation — pluggable architecture, rich types (#163 ✅, #164 ✅, #165 ✅)
   ⬜ P2.M8: CLI skills — GitHub, Slack, Claude Code, Codex/Ollama (#176-#179)
   ⬜ P2.M9: Orchestration — Slack Monitor, Triager, Approval gate (#180-#182)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -543,6 +543,7 @@ pub struct SessionExpr {
     pub gives: Option<Spanned<TypeName>>,
     pub on_progress: Option<Spanned<SessionHook>>,
     pub on_complete: Option<Spanned<SessionHook>>,
+    pub isolate: Option<IsolateConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -743,6 +744,23 @@ pub enum SpawnOption {
     ConfidenceCap(Spanned<Expr>),
     /// `with memory field: value`
     MemoryInit(Spanned<String>, Spanned<Expr>),
+    /// `isolate worktree "branch"`
+    Isolate(IsolateConfig),
+}
+
+// ── Sandbox isolation (issue #194) ────────────────────────────
+
+/// Isolation strategy for sandbox creation.
+#[derive(Debug, Clone)]
+pub enum IsolateStrategy {
+    Worktree,
+}
+
+/// Configuration for sandbox isolation on spawn or session.
+#[derive(Debug, Clone)]
+pub struct IsolateConfig {
+    pub strategy: Spanned<IsolateStrategy>,
+    pub branch: Box<Spanned<Expr>>,
 }
 
 // ── Find expression (runtime instance discovery, issue #84) ─

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -494,7 +494,7 @@ pub enum Expr {
     /// `session.status(id)` — imperative session method call (issue #192)
     SessionMethod(Spanned<String>, Vec<Spanned<CallArg>>),
     /// `session "label" prompt prompt_text agent "claude" ...`
-    Session(SessionExpr),
+    Session(Box<SessionExpr>),
     /// `find "alias"` / `find all template [where lifecycle == state]`
     Find(Box<FindExpr>),
     /// `try expr or expr`

--- a/src/checker/boundary_checker.rs
+++ b/src/checker/boundary_checker.rs
@@ -405,6 +405,9 @@ fn check_refs_in_stmt(
                         check_refs_in_expr(expr, boundary, registry, file, diagnostics);
                     }
                     SpawnOption::KnowledgeFilter(_) => {}
+                    SpawnOption::Isolate(iso) => {
+                        check_refs_in_expr(&iso.branch, boundary, registry, file, diagnostics);
+                    }
                 }
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -633,7 +633,7 @@ fn build_session_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     }
 
     Ok(Spanned::new(
-        Expr::Session(SessionExpr {
+        Expr::Session(Box::new(SessionExpr {
             name: Box::new(name),
             agent,
             prompt,
@@ -644,7 +644,7 @@ fn build_session_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
             on_progress,
             on_complete,
             isolate,
-        }),
+        })),
         span,
     ))
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -580,6 +580,7 @@ fn build_session_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
     let mut gives = None;
     let mut on_progress = None;
     let mut on_complete = None;
+    let mut isolate = None;
 
     for modifier in inner {
         match modifier.as_rule() {
@@ -618,6 +619,15 @@ fn build_session_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
                     _ => return Err(parse_error(&kind_pair, "unknown session hook kind")),
                 }
             }
+            Rule::session_isolate_modifier => {
+                let mod_span = to_span(&modifier);
+                let branch_arg = modifier.into_inner().next().unwrap();
+                let branch_expr = build_string_arg(branch_arg)?;
+                isolate = Some(IsolateConfig {
+                    strategy: Spanned::new(IsolateStrategy::Worktree, mod_span),
+                    branch: Box::new(branch_expr),
+                });
+            }
             _ => {}
         }
     }
@@ -633,6 +643,7 @@ fn build_session_expr(pair: Pair) -> anyhow::Result<Spanned<Expr>> {
             gives,
             on_progress,
             on_complete,
+            isolate,
         }),
         span,
     ))
@@ -1260,6 +1271,15 @@ fn build_spawn_stmt(pair: Pair) -> anyhow::Result<Spanned<Stmt>> {
                 let opt_span = to_span(&child);
                 let opt_inner = child.into_inner().next().unwrap();
                 let option = match opt_inner.as_rule() {
+                    Rule::spawn_isolate_option => {
+                        let branch_arg = opt_inner.into_inner().next().unwrap();
+                        let branch_expr = build_string_arg(branch_arg)?;
+                        let strategy_span = opt_span;
+                        SpawnOption::Isolate(IsolateConfig {
+                            strategy: Spanned::new(IsolateStrategy::Worktree, strategy_span),
+                            branch: Box::new(branch_expr),
+                        })
+                    }
                     Rule::spawn_knowledge_option => {
                         let pred = opt_inner.into_inner().next().unwrap(); // spawn_knowledge_pred
                         let cat_str_arg = pred.into_inner().next().unwrap(); // string_arg

--- a/src/runtime/agent.rs
+++ b/src/runtime/agent.rs
@@ -273,6 +273,8 @@ pub struct AgentProcess {
     pub timer_rx: mpsc::Receiver<TimerFired>,
     warden_tx: Option<mpsc::Sender<AgentSignal>>,
     storage: Option<crate::runtime::storage::SharedStorage>,
+    /// Worktree branch name for sandbox cleanup on agent exit (issue #194).
+    worktree_branch: Option<String>,
 }
 
 impl AgentProcess {
@@ -398,7 +400,20 @@ impl AgentProcess {
             timer_rx,
             warden_tx: None,
             storage,
+            worktree_branch: None,
         }
+    }
+
+    /// Set working directory for sandbox isolation (issue #194).
+    pub fn with_working_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.executor = self.executor.with_working_dir(dir);
+        self
+    }
+
+    /// Set worktree branch name for cleanup on agent exit (issue #194).
+    pub fn with_worktree_branch(mut self, branch: String) -> Self {
+        self.worktree_branch = Some(branch);
+        self
     }
 
     /// Get a reference to the shared context.
@@ -672,6 +687,12 @@ impl AgentProcess {
         for h in handles {
             let _ = h.await;
         }
+
+        // Cleanup worktree on agent exit (issue #194)
+        if let Some(ref branch) = self.worktree_branch {
+            let _ = crate::runtime::sandbox::remove_worktree(branch);
+        }
+
         Ok(())
     }
 

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -157,6 +157,8 @@ pub struct TaskExecutor {
     command_manager: Option<SharedCommandManager>,
     /// Session manager for long-running external agent sessions (issue #190).
     session_manager: Option<SharedSessionManager>,
+    /// Working directory override for sandbox isolation (issue #194).
+    working_dir: Option<std::path::PathBuf>,
 }
 
 impl Clone for TaskExecutor {
@@ -186,6 +188,7 @@ impl Clone for TaskExecutor {
             vector_index: self.vector_index.clone(),
             command_manager: self.command_manager.clone(),
             session_manager: self.session_manager.clone(),
+            working_dir: self.working_dir.clone(),
         }
     }
 }
@@ -246,7 +249,14 @@ impl TaskExecutor {
             session_manager: Some(
                 crate::runtime::session_manager::new_shared_default_session_manager(tracer.clone()),
             ),
+            working_dir: None,
         }
+    }
+
+    /// Set working directory for sandbox isolation (issue #194).
+    pub fn with_working_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.working_dir = Some(dir);
+        self
     }
 
     /// Attach a ForgeConfig for system runtime configuration.
@@ -548,6 +558,17 @@ impl TaskExecutor {
             .as_ref()
             .map(|gives| Self::type_name_to_string(&gives.node));
 
+        // Evaluate isolate modifier — create worktree for session (issue #194)
+        let mut worktree_branch: Option<String> = None;
+        if let Some(ref iso) = session.isolate {
+            let branch_val = self.eval_expr(&iso.branch, env).await?;
+            let branch = format!("{}", branch_val.value);
+            let dir = crate::runtime::sandbox::create_worktree(&branch)
+                .map_err(|e| RuntimeError::FlowError(format!("session isolate: {}", e)))?;
+            config.working_dir = Some(dir.to_string_lossy().to_string());
+            worktree_branch = Some(branch);
+        }
+
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SessionEvent>();
         let listener: SessionListener = Arc::new(move |event| {
             let _ = tx.send(event);
@@ -556,7 +577,7 @@ impl TaskExecutor {
         let run_fut = manager.run_to_completion(config, vec![listener]);
         tokio::pin!(run_fut);
 
-        loop {
+        let result = loop {
             tokio::select! {
                 state = &mut run_fut => {
                     let state = state.map_err(RuntimeError::FlowError)?;
@@ -571,10 +592,10 @@ impl TaskExecutor {
                     if let Some(ref hook) = session.on_complete {
                         self.emit_session_hook(&hook.node, output.clone(), env).await?;
                     }
-                    return if matches!(session.gives.as_ref().map(|g| &g.node), Some(TypeName::AgentResult)) {
-                        Ok(self.coerce_session_result_to_agent_result(output, state.cost_usd))
+                    break if matches!(session.gives.as_ref().map(|g| &g.node), Some(TypeName::AgentResult)) {
+                        self.coerce_session_result_to_agent_result(output, state.cost_usd)
                     } else {
-                        Ok(self.coerce_session_result_to_text(output))
+                        self.coerce_session_result_to_text(output)
                     };
                 }
                 event = rx.recv() => {
@@ -588,7 +609,14 @@ impl TaskExecutor {
                     }
                 }
             }
+        };
+
+        // Cleanup worktree after session completes (issue #194)
+        if let Some(branch) = worktree_branch {
+            let _ = crate::runtime::sandbox::remove_worktree(&branch);
         }
+
+        Ok(result)
     }
 
     fn coerce_session_result_to_text(&self, result: ConfidentValue) -> ConfidentValue {
@@ -1283,6 +1311,8 @@ impl TaskExecutor {
                     let mut knowledge_category: Option<String> = None;
                     let mut confidence_cap: Option<f32> = None;
                     let mut memory_inits: Vec<(String, ConfidentValue)> = Vec::new();
+                    let mut isolate_branch: Option<String> = None;
+                    let mut isolate_dir: Option<std::path::PathBuf> = None;
 
                     for opt in &spawn.options {
                         match &opt.node {
@@ -1306,6 +1336,16 @@ impl TaskExecutor {
                             SpawnOption::MemoryInit(field, expr) => {
                                 let val = self.eval_expr(expr, env).await?;
                                 memory_inits.push((field.node.clone(), val));
+                            }
+                            SpawnOption::Isolate(iso) => {
+                                let branch_val = self.eval_expr(&iso.branch, env).await?;
+                                let branch = format!("{}", branch_val.value);
+                                let dir = crate::runtime::sandbox::create_worktree(&branch)
+                                    .map_err(|e| {
+                                        RuntimeError::FlowError(format!("isolate: {}", e))
+                                    })?;
+                                isolate_branch = Some(branch);
+                                isolate_dir = Some(dir);
                             }
                         }
                     }
@@ -1362,19 +1402,31 @@ impl TaskExecutor {
                         ctx.memory.set(&field, val);
                     }
 
-                    // 7. Wire event bus
+                    // 7. Apply sandbox isolation (issue #194)
+                    if let Some(dir) = isolate_dir {
+                        child_process = child_process.with_working_dir(dir);
+                    }
+                    if let Some(ref branch) = isolate_branch {
+                        child_process = child_process.with_worktree_branch(branch.clone());
+                    }
+
+                    // 8. Wire event bus
                     if let Some(ref bus) = self.event_bus {
                         child_process = child_process.with_event_bus(bus.clone()).await;
                     }
 
-                    // 8. Register in instance registry
+                    // 9. Register in instance registry
                     let alias = if instance_name != *template_name {
                         Some(instance_name.as_str())
                     } else {
                         None
                     };
                     let instance_id = if let Some(ref ir) = self.instance_registry {
-                        let id = ir.write().await.register(template_name, alias);
+                        let id = ir.write().await.register_with_worktree(
+                            template_name,
+                            alias,
+                            isolate_branch.clone(),
+                        );
                         Some(id)
                     } else {
                         None
@@ -1450,17 +1502,22 @@ impl TaskExecutor {
                         }
                     }
 
-                    // 3. Unregister from instance registry
+                    // 3. Cleanup worktree + unregister from instance registry
                     if let Some(ref ir) = self.instance_registry {
                         let mut registry = ir.write().await;
                         if let Some(ref alias) = target_alias {
                             // Retire a specific instance by alias
                             if let Some(info) = registry.find_by_alias(alias) {
+                                // Clean up worktree before unregister (issue #194)
+                                if let Some(ref branch) = info.worktree_branch {
+                                    let _ = crate::runtime::sandbox::remove_worktree(branch);
+                                }
                                 registry.unregister(&info.instance_id);
                             }
                         }
                         // If no target, self-retirement — unregister happens via
                         // the RetireSignal propagation in the agent event loop.
+                        // Worktree cleanup for self-retire happens in AgentProcess::run() exit.
                     }
 
                     // 4. Signal termination
@@ -2559,10 +2616,12 @@ impl TaskExecutor {
                         }
                     };
 
-                    // 3. Apply working directory
+                    // 3. Apply working directory (explicit `in` overrides agent-level sandbox dir)
                     if let Some(ref wd_expr) = cmd_expr.working_dir {
                         let wd = self.eval_expr(wd_expr, env).await?;
                         process.current_dir(format!("{}", wd.value));
+                    } else if let Some(ref default_wd) = self.working_dir {
+                        process.current_dir(default_wd);
                     }
 
                     // 4. Apply environment variables

--- a/src/runtime/instance_registry.rs
+++ b/src/runtime/instance_registry.rs
@@ -35,6 +35,8 @@ pub struct InstanceInfo {
     pub status: InstanceStatus,
     /// Optional handle to the agent's runtime context (for deep introspection).
     pub context: Option<Arc<Mutex<AgentContext>>>,
+    /// Worktree branch name for sandbox cleanup on unregister (issue #194).
+    pub worktree_branch: Option<String>,
 }
 
 impl InstanceInfo {
@@ -142,11 +144,31 @@ impl InstanceRegistry {
         self.register_inner(agent_name, alias, Some(context))
     }
 
+    /// Register a new agent instance with worktree branch for sandbox isolation (issue #194).
+    pub fn register_with_worktree(
+        &mut self,
+        agent_name: &str,
+        alias: Option<&str>,
+        worktree_branch: Option<String>,
+    ) -> Uuid {
+        self.register_full(agent_name, alias, None, worktree_branch)
+    }
+
     fn register_inner(
         &mut self,
         agent_name: &str,
         alias: Option<&str>,
         context: Option<Arc<Mutex<AgentContext>>>,
+    ) -> Uuid {
+        self.register_full(agent_name, alias, context, None)
+    }
+
+    fn register_full(
+        &mut self,
+        agent_name: &str,
+        alias: Option<&str>,
+        context: Option<Arc<Mutex<AgentContext>>>,
+        worktree_branch: Option<String>,
     ) -> Uuid {
         let id = Uuid::new_v4();
         let info = InstanceInfo {
@@ -157,6 +179,7 @@ impl InstanceRegistry {
             spawned_at: Instant::now(),
             status: InstanceStatus::Running,
             context,
+            worktree_branch,
         };
         self.by_id.insert(id, info);
         self.by_name

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,6 +16,7 @@ pub mod knowledge_store;
 pub mod markdown;
 pub mod memory;
 pub mod pool;
+pub mod sandbox;
 pub mod session_adapter;
 pub mod session_manager;
 pub mod skill;

--- a/src/runtime/sandbox.rs
+++ b/src/runtime/sandbox.rs
@@ -1,0 +1,116 @@
+// FORGE sandbox isolation — issue #194
+// Creates and cleans up git worktrees for agent/session filesystem isolation.
+// Uses sync std::process::Command — these are fast internal infra ops, not user-facing commands.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Slug a branch name for use as a filesystem directory name.
+/// `"feature/fix-123"` → `"feature-fix-123"`
+pub fn branch_slug(branch: &str) -> String {
+    branch.replace(['/', '\\'], "-")
+}
+
+/// Compute the worktree path: `.forge-data/worktrees/{slug}/`
+pub fn worktree_path(branch: &str) -> PathBuf {
+    Path::new(".forge-data")
+        .join("worktrees")
+        .join(branch_slug(branch))
+}
+
+/// Create a git worktree for the given branch.
+/// If the branch does not exist, creates it from HEAD with `-b`.
+/// Returns the absolute path to the worktree directory.
+pub fn create_worktree(branch: &str) -> Result<PathBuf, String> {
+    let wt_path = worktree_path(branch);
+
+    // Collision check — another agent may already be using this branch
+    if wt_path.exists() {
+        return Err(format!(
+            "worktree path already exists: {} — another agent may be using branch '{}'",
+            wt_path.display(),
+            branch
+        ));
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = wt_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create worktree parent dir: {}", e))?;
+    }
+
+    let wt_str = wt_path.to_string_lossy().to_string();
+
+    // Try to add worktree with existing branch first
+    let output = Command::new("git")
+        .args(["worktree", "add", &wt_str, branch])
+        .output()
+        .map_err(|e| format!("failed to run git worktree add: {}", e))?;
+
+    if !output.status.success() {
+        // Branch might not exist — create it with -b
+        let output2 = Command::new("git")
+            .args(["worktree", "add", "-b", branch, &wt_str])
+            .output()
+            .map_err(|e| format!("failed to run git worktree add -b: {}", e))?;
+
+        if !output2.status.success() {
+            return Err(format!(
+                "git worktree add failed: {}",
+                String::from_utf8_lossy(&output2.stderr).trim()
+            ));
+        }
+    }
+
+    // Return absolute path
+    std::fs::canonicalize(&wt_path).map_err(|e| format!("failed to resolve worktree path: {}", e))
+}
+
+/// Remove a git worktree and clean up the directory.
+pub fn remove_worktree(branch: &str) -> Result<(), String> {
+    let wt_path = worktree_path(branch);
+
+    if !wt_path.exists() {
+        return Ok(()); // Already cleaned up
+    }
+
+    let wt_str = wt_path.to_string_lossy().to_string();
+
+    let output = Command::new("git")
+        .args(["worktree", "remove", "--force", &wt_str])
+        .output()
+        .map_err(|e| format!("failed to run git worktree remove: {}", e))?;
+
+    if !output.status.success() {
+        // Fallback: manually remove directory and prune
+        let _ = std::fs::remove_dir_all(&wt_path);
+        let _ = Command::new("git").args(["worktree", "prune"]).output();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn branch_slug_replaces_slashes() {
+        assert_eq!(branch_slug("feature/fix-123"), "feature-fix-123");
+        assert_eq!(branch_slug("main"), "main");
+        assert_eq!(branch_slug("a/b/c"), "a-b-c");
+        assert_eq!(branch_slug("back\\slash"), "back-slash");
+    }
+
+    #[test]
+    fn worktree_path_uses_slug() {
+        let path = worktree_path("feature/fix-123");
+        assert_eq!(path, PathBuf::from(".forge-data/worktrees/feature-fix-123"));
+    }
+
+    #[test]
+    fn worktree_path_simple_branch() {
+        let path = worktree_path("main");
+        assert_eq!(path, PathBuf::from(".forge-data/worktrees/main"));
+    }
+}

--- a/src/runtime/session_adapter.rs
+++ b/src/runtime/session_adapter.rs
@@ -30,6 +30,8 @@ pub struct CliCommand {
     pub program: String,
     pub args: Vec<String>,
     pub stdin_payload: Option<String>,
+    /// Working directory for sandbox isolation (issue #194).
+    pub working_dir: Option<String>,
 }
 
 /// Build the CLI command for starting a new session.
@@ -87,6 +89,7 @@ pub fn build_command(adapter: &AdapterConfig, config: &SessionConfig) -> CliComm
         program: adapter.command.clone(),
         args,
         stdin_payload,
+        working_dir: config.working_dir.clone(),
     }
 }
 
@@ -138,6 +141,7 @@ pub fn build_resume_command(adapter: &AdapterConfig, state: &SessionState) -> Op
         program: adapter.command.clone(),
         args,
         stdin_payload,
+        working_dir: state.config.working_dir.clone(),
     })
 }
 
@@ -455,6 +459,11 @@ impl ConfigDrivenDriver {
             } else {
                 Stdio::null()
             });
+
+        // Apply sandbox working directory (issue #194)
+        if let Some(ref wd) = cmd.working_dir {
+            command.current_dir(wd);
+        }
 
         let mut child = command
             .spawn()

--- a/src/runtime/session_manager.rs
+++ b/src/runtime/session_manager.rs
@@ -66,6 +66,9 @@ pub struct SessionConfig {
     pub budget_usd: Option<f32>,
     pub gives: Option<String>,
     pub cancel_timeout_secs: u64,
+    /// Working directory for sandbox isolation (issue #194).
+    #[serde(default)]
+    pub working_dir: Option<String>,
 }
 
 impl SessionConfig {
@@ -79,6 +82,7 @@ impl SessionConfig {
             budget_usd: None,
             gives: None,
             cancel_timeout_secs: 5,
+            working_dir: None,
         }
     }
 }

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -870,6 +870,32 @@ fn spawn_with_memory_init_only() {
     ForgeParser::parse(Rule::task_decl, src).unwrap();
 }
 
+// isolate worktree (#194)
+
+#[test]
+fn spawn_with_isolate_worktree() {
+    let src = "task run_it\n  do\n    spawn worker\n      isolate worktree \"feature/fix-123\"\n";
+    ForgeParser::parse(Rule::task_decl, src).unwrap();
+}
+
+#[test]
+fn spawn_with_isolate_and_knowledge() {
+    let src = "task run_it\n  do\n    id = spawn implementer\n      isolate worktree \"feature/new\"\n      with knowledge where category == \"CODE\"\n      with confidence_cap: 0.9\n";
+    ForgeParser::parse(Rule::task_decl, src).unwrap();
+}
+
+#[test]
+fn session_with_isolate_worktree() {
+    let src = r#"session "implement" agent "claude" prompt "do it" isolate worktree "feature/fix-123" timeout 30m"#;
+    ForgeParser::parse(Rule::session_expr, src).unwrap();
+}
+
+#[test]
+fn session_with_isolate_and_hooks() {
+    let src = r#"session "implement" agent "claude" prompt "do it" isolate worktree "feature/fix" on progress -> emit status(it)"#;
+    ForgeParser::parse(Rule::session_expr, src).unwrap();
+}
+
 // find_expr (#84)
 
 #[test]

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1393,6 +1393,77 @@ fn parse_spawn_knowledge_filter_only() {
     }
 }
 
+// ── Isolate worktree tests (#194) ───────────────────────────
+
+#[test]
+fn parse_spawn_with_isolate_worktree() {
+    let prog = parse_task_multiline(&["spawn worker", r#"  isolate worktree "feature/fix-123""#]);
+    match first_stmt(&prog) {
+        Stmt::Spawn(s) => {
+            assert_eq!(s.template.node, "worker");
+            assert_eq!(s.options.len(), 1);
+            match &s.options[0].node {
+                SpawnOption::Isolate(iso) => {
+                    assert!(matches!(&iso.strategy.node, IsolateStrategy::Worktree));
+                }
+                other => panic!("expected Isolate, got {:?}", other),
+            }
+        }
+        other => panic!("expected Spawn, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_spawn_isolate_with_other_options() {
+    let prog = parse_task_multiline(&[
+        r#"id = spawn implementer as "impl_1""#,
+        r#"  isolate worktree "feature/new""#,
+        r#"  with knowledge where category == "CODE""#,
+        r#"  with confidence_cap: 0.9"#,
+    ]);
+    match first_stmt(&prog) {
+        Stmt::Spawn(s) => {
+            assert_eq!(s.template.node, "implementer");
+            assert_eq!(s.options.len(), 3);
+            assert!(matches!(&s.options[0].node, SpawnOption::Isolate(_)));
+            assert!(matches!(
+                &s.options[1].node,
+                SpawnOption::KnowledgeFilter(_)
+            ));
+            assert!(matches!(&s.options[2].node, SpawnOption::ConfidenceCap(_)));
+        }
+        other => panic!("expected Spawn, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_session_with_isolate_worktree() {
+    let prog = parse_task_with(
+        r#"x = session "implement" agent "claude" prompt "do it" isolate worktree "feature/fix-123" timeout 30m"#,
+    );
+    match bind_expr(first_stmt(&prog)) {
+        Expr::Session(session) => {
+            assert!(session.agent.is_some());
+            assert!(session.prompt.is_some());
+            assert!(session.timeout.is_some());
+            let iso = session.isolate.as_ref().expect("isolate should be Some");
+            assert!(matches!(&iso.strategy.node, IsolateStrategy::Worktree));
+        }
+        other => panic!("expected Session, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_session_without_isolate() {
+    let prog = parse_task_with(r#"x = session "code-review" agent "claude""#);
+    match bind_expr(first_stmt(&prog)) {
+        Expr::Session(session) => {
+            assert!(session.isolate.is_none());
+        }
+        other => panic!("expected Session, got {:?}", other),
+    }
+}
+
 // ── Find expression tests (#84) ─────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `isolate worktree "branch"` modifier to `spawn` statements and `session` expressions
- Creates a git worktree at `.forge-data/worktrees/{branch-slug}/` for filesystem isolation
- Automatic cleanup on agent retire or session completion
- Full stack: grammar → AST → parser → runtime (sandbox.rs, executor, agent, session adapter)

## Changes
| Layer | Files | What |
|-------|-------|------|
| Grammar | `grammar/forge.pest` | `spawn_isolate_option`, `session_isolate_modifier` rules |
| AST | `src/ast.rs` | `IsolateStrategy`, `IsolateConfig` types |
| Parser | `src/parser.rs` | Parse isolate on spawn + session |
| Checker | `src/checker/boundary_checker.rs` | Handle new `SpawnOption::Isolate` variant |
| Runtime | `src/runtime/sandbox.rs` | **New** — worktree create/remove via git CLI |
| Runtime | `src/runtime/executor.rs` | Working dir on TaskExecutor; isolate in spawn/retire/session |
| Runtime | `src/runtime/agent.rs` | `with_working_dir`, `with_worktree_branch`, cleanup in `run()` |
| Runtime | `src/runtime/instance_registry.rs` | `worktree_branch` tracking on `InstanceInfo` |
| Runtime | `src/runtime/session_manager.rs` | `working_dir` field on `SessionConfig` |
| Runtime | `src/runtime/session_adapter.rs` | `working_dir` on `CliCommand`, applied in `spawn_process` |

## Test plan
- [x] 4 grammar tests: spawn isolate, spawn isolate+knowledge, session isolate, session isolate+hooks
- [x] 4 parser tests: spawn isolate, spawn isolate+options, session isolate, session without isolate
- [x] 3 sandbox unit tests: branch_slug, worktree_path slug, worktree_path simple
- [x] All 1037 existing tests pass
- [x] `cargo fmt` + `cargo clippy` clean

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)