### PR TITLE
feat: contradiction events and warden integration (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- Contradiction events and warden integration: `Contradiction` failure type in grammar/AST/parser/checker, `AgentSignal::Contradiction` variant, `SessionEvent::ContradictionDetected` with `session.contradiction` EventBus payload, `ContradictionSummary` persisted in session state for resume, verification gate in executor blocking high-risk actions on contradicted results (#205)
+- Default contradiction escalation policy: nudge → restart (after 2) → escalate (after 4) — built-in fallback when no explicit `on contradiction:` warden policy exists (#205)
+- Warden signal channel in SessionManager: contradictions detected during session verification are automatically reported to the warden for policy resolution (#205)
 - Verification engine: 5-stage validator pipeline (schema, reference, environment, execution, policy) that resolves pending `VerificationResult` from claims to `Verified`/`Insufficient`/`Contradicted`/`Error` by checking real filesystem and test state (#204)
 - `VerificationEngine` orchestrator with pluggable `Validator` trait, integrated into `SessionManager.mark_completed()` for automatic verification on session completion (#204)
 - Risk classification helper `classify_risk()` — derives `RiskClass` from AgentResult fields and metadata side-effect markers (#204)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- Verification engine: 5-stage validator pipeline (schema, reference, environment, execution, policy) that resolves pending `VerificationResult` from claims to `Verified`/`Insufficient`/`Contradicted`/`Error` by checking real filesystem and test state (#204)
+- `VerificationEngine` orchestrator with pluggable `Validator` trait, integrated into `SessionManager.mark_completed()` for automatic verification on session completion (#204)
+- Risk classification helper `classify_risk()` — derives `RiskClass` from AgentResult fields and metadata side-effect markers (#204)
 - Verification contract types: `Claim`, `Evidence`, `VerificationResult`, `Contradiction`, `RiskClass` — runtime claim-evidence-verification model for trust progression, accessible via `AgentResult.metadata.verification` (#203)
 - Implicit claim extraction from AgentResult fields: `files_changed`, `tests_run`/`tests_passed`, and `plan` automatically seed verification claims during session result parsing (#203)
 - `VerificationResult` predicates: `is_verified()`, `is_contradicted()`, `is_actionable(max_risk)` for downstream approval gates (#203)

--- a/adapters/codex/ADAPTER.toml
+++ b/adapters/codex/ADAPTER.toml
@@ -21,7 +21,7 @@ readwrite_args = ["--full-auto"]
 readwrite_tools = ["Edit", "Bash", "Write"]
 
 [adapter.result_mapping]
-plan = "content.text"
+plan = "item.text"
 session_id = "thread_id"
 confidence_default = 0.80
 

--- a/examples/session/session_engine_codex_live.forge
+++ b/examples/session/session_engine_codex_live.forge
@@ -1,0 +1,29 @@
+# Live verification engine test with Codex — issue #204
+# Spawns a real Codex session that creates a file, then checks
+# that the verification engine resolved claims against reality.
+
+task create_file
+  gives AgentResult
+  do
+    result = session "codex-engine-test" agent "codex" prompt "Create a file at examples/session/_codex_engine_test_output.txt with the content 'FORGE verification engine test — created by Codex'. Do NOT create any other files." tools ["Write", "Bash"] timeout 2m gives AgentResult
+    when result.sure -> give result
+    else -> give result
+
+fn main
+  say "=== Verification Engine — Codex Live Test ==="
+  say ""
+  result = create_file()
+  say "--- AgentResult ---"
+  say "plan: {result.plan}"
+  say "confidence: {result.confidence}"
+  say "cost: {result.cost_usd}"
+  say "files: {result.files_changed}"
+  say ""
+  say "--- Verification Engine Output ---"
+  say "status: {result.metadata.verification.status}"
+  say "risk_class: {result.metadata.verification.risk_class}"
+  say "claims: {result.metadata.verification.claims}"
+  say "evidence: {result.metadata.verification.evidence}"
+  say "contradictions: {result.metadata.verification.contradictions}"
+  say ""
+  say "=== Done ==="

--- a/examples/session/session_engine_live.forge
+++ b/examples/session/session_engine_live.forge
@@ -1,0 +1,29 @@
+# Live verification engine test — issue #204
+# Spawns a real Claude session that creates a file, then checks
+# that the verification engine resolved claims against reality.
+
+task create_file
+  gives AgentResult
+  do
+    result = session "engine-test" agent "claude" prompt "Create a file at examples/session/_engine_test_output.txt with the content 'FORGE verification engine test — created by Claude'. Then report what you did. Do NOT create any other files." tools ["Read", "Write", "Bash"] timeout 2m budget 0.50 gives AgentResult
+    when result.sure -> give result
+    else -> give result
+
+fn main
+  say "=== Verification Engine Live Test ==="
+  say ""
+  result = create_file()
+  say "--- AgentResult ---"
+  say "plan: {result.plan}"
+  say "confidence: {result.confidence}"
+  say "cost: {result.cost_usd}"
+  say "files: {result.files_changed}"
+  say ""
+  say "--- Verification Engine Output ---"
+  say "status: {result.metadata.verification.status}"
+  say "risk_class: {result.metadata.verification.risk_class}"
+  say "claims: {result.metadata.verification.claims}"
+  say "evidence: {result.metadata.verification.evidence}"
+  say "contradictions: {result.metadata.verification.contradictions}"
+  say ""
+  say "=== Done ==="

--- a/examples/session/session_verification.forge
+++ b/examples/session/session_verification.forge
@@ -17,4 +17,6 @@ fn main
   say "verification status: {result.metadata.verification.status}"
   say "verification risk_class: {result.metadata.verification.risk_class}"
   say "verification claims: {result.metadata.verification.claims}"
+  say "verification evidence: {result.metadata.verification.evidence}"
+  say "verification contradictions: {result.metadata.verification.contradictions}"
   say "done"

--- a/examples/session/session_verification_live.forge
+++ b/examples/session/session_verification_live.forge
@@ -1,0 +1,34 @@
+# Live verification contract test — real Claude session
+# Asks Claude to investigate the forge-workflow skill
+
+task investigate
+  gives AgentResult
+  do
+    result = session "skill-research" agent "claude" prompt "Look at the file workflows/dev-cycle.forge in this repo. Give a brief summary of what it defines — the agents, events, states, and how they connect. Keep your answer under 200 words." tools ["Read", "Glob", "Grep"] timeout 2m budget 0.50 gives AgentResult
+    when result.sure -> give result
+    else -> give result
+
+fn main
+  say "--- Running live Claude session ---"
+  result = investigate()
+  say ""
+  say "--- AgentResult ---"
+  say "plan: {result.plan}"
+  say "confidence: {result.confidence}"
+  say "cost_usd: {result.cost_usd}"
+  say "files_changed: {result.files_changed}"
+  say "approval_needed: {result.approval_needed}"
+  say ""
+  say "--- Metadata ---"
+  say "tokens_in: {result.metadata.tokens_in}"
+  say "tokens_out: {result.metadata.tokens_out}"
+  say "num_turns: {result.metadata.num_turns}"
+  say ""
+  say "--- Verification Engine ---"
+  say "status: {result.metadata.verification.status}"
+  say "risk_class: {result.metadata.verification.risk_class}"
+  say "claims: {result.metadata.verification.claims}"
+  say "evidence: {result.metadata.verification.evidence}"
+  say "contradictions: {result.metadata.verification.contradictions}"
+  say ""
+  say "--- Done ---"

--- a/grammar/forge.pest
+++ b/grammar/forge.pest
@@ -276,7 +276,7 @@ ward_policy = {
     (nl ~ i2 ~ after_clause)*
 }
 
-failure_type = @{ ("stuck" | "crash" | "hallucination" | "budget" | "timeout") ~ !(ASCII_ALPHANUMERIC | "_") }
+failure_type = @{ ("stuck" | "crash" | "hallucination" | "contradiction" | "budget" | "timeout") ~ !(ASCII_ALPHANUMERIC | "_") }
 
 ward_response = @{ ("nudge" | "downgrade" | "restart" | "replace" | "escalate") ~ !(ASCII_ALPHANUMERIC | "_") }
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -678,7 +678,7 @@ Worktree isolation for safe agent execution:
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| #204 | Phase 2 reliability: verification engine for coding sessions | Open |
+| #204 | Phase 2 reliability: verification engine for coding sessions | Done ✅ |
 | #205 | Phase 2 reliability: contradiction events and warden integration | Open |
 
 ### P2.M6: Sandbox Isolation
@@ -936,7 +936,7 @@ P2.M1  Command         ███████████████████
 P2.M2  Session Core    ████████████████████  2/2  (100%)  DONE
 P2.M3  Result+Contract ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M4  Adapters+Events ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
-P2.M5  Verify+Contra   ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
+P2.M5  Verify+Contra   ██████████░░░░░░░░░░  1/2  ( 50%)
 P2.M6  Sandbox         ████████████████████  1/1  (100%)
 P2.M7  Skills          █████████████░░░░░░░  2/3  ( 67%)
 P2.M8  CLI Skills      ░░░░░░░░░░░░░░░░░░░░  0/4  (  0%)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -354,6 +354,7 @@ pub enum FailureType {
     Stuck,
     Crash,
     Hallucination,
+    Contradiction,
     Budget,
     Timeout,
 }

--- a/src/checker/warden_checker.rs
+++ b/src/checker/warden_checker.rs
@@ -109,6 +109,7 @@ fn check_failure_type_coverage(warden: &WardenDecl, file: &str, diagnostics: &mu
         FailureType::Stuck,
         FailureType::Crash,
         FailureType::Hallucination,
+        FailureType::Contradiction,
         FailureType::Budget,
         FailureType::Timeout,
     ];
@@ -126,6 +127,7 @@ fn check_failure_type_coverage(warden: &WardenDecl, file: &str, diagnostics: &mu
             FailureType::Stuck => "stuck",
             FailureType::Crash => "crash",
             FailureType::Hallucination => "hallucination",
+            FailureType::Contradiction => "contradiction",
             FailureType::Budget => "budget",
             FailureType::Timeout => "timeout",
         })

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2220,6 +2220,7 @@ fn build_failure_type(pair: &Pair) -> anyhow::Result<Spanned<FailureType>> {
         "stuck" => FailureType::Stuck,
         "crash" => FailureType::Crash,
         "hallucination" => FailureType::Hallucination,
+        "contradiction" => FailureType::Contradiction,
         "budget" => FailureType::Budget,
         "timeout" => FailureType::Timeout,
         other => {

--- a/src/runtime/agent.rs
+++ b/src/runtime/agent.rs
@@ -132,11 +132,28 @@ impl EventSink {
 /// Signal from a managed agent to its warden.
 #[derive(Debug, Clone)]
 pub enum AgentSignal {
-    Stuck { agent_name: String },
-    Timeout { agent_name: String },
-    Hallucination { agent_name: String, detail: String },
-    BudgetExceeded { agent_name: String, detail: String },
-    Crash { agent_name: String },
+    Stuck {
+        agent_name: String,
+    },
+    Timeout {
+        agent_name: String,
+    },
+    Hallucination {
+        agent_name: String,
+        detail: String,
+    },
+    Contradiction {
+        agent_name: String,
+        detail: String,
+        severity: String,
+    },
+    BudgetExceeded {
+        agent_name: String,
+        detail: String,
+    },
+    Crash {
+        agent_name: String,
+    },
 }
 
 // ── Stuck Detector ───────────────────────────────────────────────────────────
@@ -422,7 +439,14 @@ impl AgentProcess {
     }
 
     /// Attach a warden signal channel for reporting stuck status.
+    /// Also wires the signal into the session manager for contradiction
+    /// reporting (issue #205).
     pub fn with_warden_signal(mut self, tx: mpsc::Sender<AgentSignal>) -> Self {
+        // Wire warden signal into the session manager so contradictions
+        // detected during verification can reach the warden.
+        if let Some(mgr) = self.executor.session_manager() {
+            mgr.set_warden_signal(tx.clone());
+        }
         self.warden_tx = Some(tx);
         self
     }

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -17,6 +17,7 @@ use crate::runtime::session_manager::{
     SessionConfig, SessionEvent, SessionListener, SharedSessionManager,
 };
 use crate::runtime::timer_engine::TimerEngine;
+use crate::runtime::verification::{RiskClass, VerificationResult, VerificationStatus};
 use crate::tracer::{LLMResponseInfo, Tracer};
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -617,6 +618,70 @@ impl TaskExecutor {
         }
 
         Ok(result)
+    }
+
+    /// Check if a session result passes the verification gate for the given risk level.
+    /// Returns Ok(()) if the action is allowed, or an error describing why it's blocked.
+    /// Backward-compatible: allows everything when no verification engine is configured
+    /// or when verification hasn't run yet (Pending status). Issue #205.
+    pub fn check_verification_gate(
+        result: &ConfidentValue,
+        max_risk: RiskClass,
+    ) -> Result<(), RuntimeError> {
+        let vr = match Self::extract_verification_from_result(result) {
+            Some(vr) => vr,
+            None => return Ok(()), // No verification metadata — allow (backward compat)
+        };
+
+        match vr.status {
+            VerificationStatus::Pending => Ok(()), // Not yet checked — allow
+            VerificationStatus::Verified => {
+                if vr.is_actionable(max_risk) {
+                    Ok(())
+                } else {
+                    Err(RuntimeError::FlowError(format!(
+                        "verification gate: result verified but risk class {:?} exceeds allowed {:?}",
+                        vr.risk_class, max_risk
+                    )))
+                }
+            }
+            VerificationStatus::Contradicted => Err(RuntimeError::FlowError(format!(
+                "verification gate: {} contradiction(s) detected — blocking {:?} action",
+                vr.contradictions.len(),
+                max_risk
+            ))),
+            VerificationStatus::Insufficient => {
+                if max_risk >= RiskClass::ExternalSideEffect {
+                    Err(RuntimeError::FlowError(
+                        "verification gate: insufficient evidence for external side-effect action"
+                            .to_string(),
+                    ))
+                } else {
+                    Ok(()) // Allow lower-risk actions with insufficient evidence
+                }
+            }
+            VerificationStatus::Error => Err(RuntimeError::FlowError(
+                "verification gate: verification engine error — cannot authorize action"
+                    .to_string(),
+            )),
+        }
+    }
+
+    /// Extract a VerificationResult from an AgentResult's metadata.verification field.
+    fn extract_verification_from_result(result: &ConfidentValue) -> Option<VerificationResult> {
+        let fields = match &result.value {
+            Value::Record(f) => f,
+            _ => return None,
+        };
+        let meta = match fields.get("metadata") {
+            Some(cv) => match &cv.value {
+                Value::Record(m) => m,
+                _ => return None,
+            },
+            None => return None,
+        };
+        meta.get("verification")
+            .and_then(|cv| VerificationResult::from_value(&cv.value))
     }
 
     fn coerce_session_result_to_text(&self, result: ConfidentValue) -> ConfidentValue {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -29,6 +29,7 @@ pub mod system;
 pub mod timer_engine;
 pub mod vector_index;
 pub mod verification;
+pub mod verification_engine;
 pub mod warded;
 pub mod warden;
 pub mod watcher;

--- a/src/runtime/session_manager.rs
+++ b/src/runtime/session_manager.rs
@@ -17,8 +17,10 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Notify};
 use uuid::Uuid;
 
+use crate::runtime::agent::AgentSignal;
 use crate::runtime::confidence::{ConfidentValue, Value};
 use crate::runtime::event_bus::{EventPayload, SharedEventBus};
+use crate::runtime::verification::{ContradictionSeverity, VerificationResult};
 use crate::tracer::Tracer;
 
 pub type SessionId = String;
@@ -94,6 +96,17 @@ pub struct SessionProgress {
     pub cost_delta_usd: f32,
 }
 
+/// Lightweight summary of verification contradictions for quick session-level
+/// access without parsing the full AgentResult metadata (issue #205).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContradictionSummary {
+    pub count: usize,
+    pub high_severity_count: usize,
+    pub max_severity: String,
+    pub verification_status: String,
+    pub risk_class: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionState {
     pub id: SessionId,
@@ -109,6 +122,10 @@ pub struct SessionState {
     pub progress_events: Vec<SessionProgress>,
     pub output: Option<ConfidentValue>,
     pub error: Option<String>,
+    /// Contradiction summary from verification (issue #205).
+    /// Persisted for quick resume-time access without parsing full metadata.
+    #[serde(default)]
+    pub contradiction_summary: Option<ContradictionSummary>,
 }
 
 impl SessionState {
@@ -128,6 +145,7 @@ impl SessionState {
             progress_events: Vec::new(),
             output: None,
             error: None,
+            contradiction_summary: None,
         }
     }
 
@@ -176,6 +194,15 @@ pub enum SessionEvent {
     ResumeFailed {
         session_id: SessionId,
         error: String,
+    },
+    /// Emitted when verification detects contradictions in a completed session (issue #205).
+    ContradictionDetected {
+        session_id: SessionId,
+        contradiction_count: usize,
+        high_severity_count: usize,
+        max_severity: String,
+        verification_status: String,
+        risk_class: String,
     },
 }
 
@@ -257,6 +284,8 @@ pub struct SessionManager {
     base_dir: PathBuf,
     tracer: Option<Tracer>,
     event_bus: Arc<Mutex<Option<SharedEventBus>>>,
+    /// Warden signal channel for reporting contradiction failures (issue #205).
+    warden_signal_tx: Arc<Mutex<Option<mpsc::Sender<AgentSignal>>>>,
     polling_cancel: Arc<AtomicBool>,
     inner: Arc<Mutex<SessionManagerInner>>,
     verification_engine: Option<Arc<crate::runtime::verification_engine::VerificationEngine>>,
@@ -270,6 +299,7 @@ impl SessionManager {
             base_dir,
             tracer: None,
             event_bus: Arc::new(Mutex::new(None)),
+            warden_signal_tx: Arc::new(Mutex::new(None)),
             polling_cancel: Arc::new(AtomicBool::new(false)),
             inner: Arc::new(Mutex::new(SessionManagerInner {
                 sessions: HashMap::new(),
@@ -301,6 +331,11 @@ impl SessionManager {
     /// Set the event bus on an already-constructed (possibly Arc'd) manager.
     pub fn set_event_bus(&self, bus: SharedEventBus) {
         *self.event_bus.lock().unwrap() = Some(bus);
+    }
+
+    /// Set the warden signal channel for reporting contradiction failures (issue #205).
+    pub fn set_warden_signal(&self, tx: mpsc::Sender<AgentSignal>) {
+        *self.warden_signal_tx.lock().unwrap() = Some(tx);
     }
 
     /// Start polling active sessions at the given interval, publishing
@@ -940,6 +975,29 @@ impl SessionManager {
         self.transition_status(session_id, SessionStatus::Completing);
         let result = self.inject_cost(result, session_id);
         let result = self.run_verification(result, session_id).await;
+
+        // Extract verification result for contradiction handling (issue #205).
+        let verification_result = Self::extract_verification_result(&result);
+        let contradiction_summary = verification_result.as_ref().and_then(|vr| {
+            if vr.has_contradictions() {
+                let max_severity = vr
+                    .contradictions
+                    .iter()
+                    .map(|c| c.severity)
+                    .max()
+                    .unwrap_or(ContradictionSeverity::Low);
+                Some(ContradictionSummary {
+                    count: vr.contradictions.len(),
+                    high_severity_count: vr.high_severity_contradictions().len(),
+                    max_severity: max_severity.as_str().to_string(),
+                    verification_status: vr.status.as_str().to_string(),
+                    risk_class: vr.risk_class.as_str().to_string(),
+                })
+            } else {
+                None
+            }
+        });
+
         let (snapshot, notify) = {
             let mut inner = self.inner.lock().unwrap();
             let Some(entry) = inner.sessions.get_mut(session_id) else {
@@ -947,6 +1005,7 @@ impl SessionManager {
             };
             entry.state.status = SessionStatus::Done;
             entry.state.output = Some(result.clone());
+            entry.state.contradiction_summary = contradiction_summary.clone();
             entry.state.updated_at = Utc::now();
             let notify = entry.live.as_ref().map(|live| live.notify.clone());
             entry.live = None;
@@ -963,6 +1022,32 @@ impl SessionManager {
             duration_secs,
             final_status: SessionStatus::Done,
         });
+
+        // Emit contradiction event and signal warden if contradictions found (issue #205).
+        if let Some(ref summary) = contradiction_summary {
+            self.dispatch_event(SessionEvent::ContradictionDetected {
+                session_id: session_id.to_string(),
+                contradiction_count: summary.count,
+                high_severity_count: summary.high_severity_count,
+                max_severity: summary.max_severity.clone(),
+                verification_status: summary.verification_status.clone(),
+                risk_class: summary.risk_class.clone(),
+            });
+
+            // Signal warden for contradiction handling.
+            // Use the agent name from config (not session UUID) so the warden
+            // can match it to its managed agent list.
+            let agent_name = snapshot.config.agent.clone();
+            self.send_warden_signal(AgentSignal::Contradiction {
+                agent_name,
+                detail: format!(
+                    "{} contradiction(s) detected ({} high severity)",
+                    summary.count, summary.high_severity_count
+                ),
+                severity: summary.max_severity.clone(),
+            });
+        }
+
         self.dispatch_event(SessionEvent::StateChanged {
             session_id: session_id.to_string(),
             status: SessionStatus::Done,
@@ -1091,6 +1176,41 @@ impl SessionManager {
         crate::runtime::verification_engine::inject_resolved_verification(result, vr)
     }
 
+    /// Extract a VerificationResult from the metadata.verification field of
+    /// a completed AgentResult ConfidentValue (issue #205).
+    fn extract_verification_result(result: &ConfidentValue) -> Option<VerificationResult> {
+        let fields = match &result.value {
+            Value::Record(f) => f,
+            _ => return None,
+        };
+        let meta = match fields.get("metadata") {
+            Some(cv) => match &cv.value {
+                Value::Record(m) => m,
+                _ => return None,
+            },
+            None => return None,
+        };
+        meta.get("verification")
+            .and_then(|cv| VerificationResult::from_value(&cv.value))
+    }
+
+    /// Send a signal to the warden (non-blocking, drop-on-full consistent with
+    /// event bus design; Principle V).
+    fn send_warden_signal(&self, signal: AgentSignal) {
+        let tx = self.warden_signal_tx.lock().unwrap().clone();
+        if let Some(tx) = tx {
+            if tx.try_send(signal).is_err() {
+                if let Some(ref t) = self.tracer {
+                    t.event_delivery_failed(
+                        "session.contradiction",
+                        "warden_signal",
+                        "full_or_closed",
+                    );
+                }
+            }
+        }
+    }
+
     fn state_path(&self, session_id: &str) -> PathBuf {
         self.base_dir.join(format!("{}.json", session_id))
     }
@@ -1209,7 +1329,8 @@ fn session_id_of(event: &SessionEvent) -> Option<&str> {
         | SessionEvent::Failed { session_id, .. }
         | SessionEvent::Cancelled { session_id }
         | SessionEvent::ResumeAttempted { session_id }
-        | SessionEvent::ResumeFailed { session_id, .. } => Some(session_id.as_str()),
+        | SessionEvent::ResumeFailed { session_id, .. }
+        | SessionEvent::ContradictionDetected { session_id, .. } => Some(session_id.as_str()),
     }
 }
 
@@ -1273,6 +1394,34 @@ fn session_event_to_payload(event: &SessionEvent) -> Option<EventPayload> {
             Some(EventPayload {
                 event_name: "session.cancelled".to_string(),
                 args: vec![text(session_id)],
+                source_agent: "session_manager".to_string(),
+                fields,
+            })
+        }
+        SessionEvent::ContradictionDetected {
+            session_id,
+            contradiction_count,
+            high_severity_count,
+            max_severity,
+            verification_status,
+            risk_class,
+        } => {
+            let mut fields = HashMap::new();
+            fields.insert("session_id".to_string(), text(session_id));
+            fields.insert(
+                "contradiction_count".to_string(),
+                num(*contradiction_count as f64),
+            );
+            fields.insert(
+                "high_severity_count".to_string(),
+                num(*high_severity_count as f64),
+            );
+            fields.insert("max_severity".to_string(), text(max_severity));
+            fields.insert("verification_status".to_string(), text(verification_status));
+            fields.insert("risk_class".to_string(), text(risk_class));
+            Some(EventPayload {
+                event_name: "session.contradiction".to_string(),
+                args: vec![num(*contradiction_count as f64)],
                 source_agent: "session_manager".to_string(),
                 fields,
             })

--- a/src/runtime/session_manager.rs
+++ b/src/runtime/session_manager.rs
@@ -1069,10 +1069,14 @@ impl SessionManager {
             None => return result,
         };
 
+        // Use the session's working_dir (set by `isolate worktree`), or fall
+        // back to the process working directory so the ReferenceValidator can
+        // check claimed files against the actual project.
         let working_dir = self
             .session_state(session_id)
             .and_then(|s| s.config.working_dir.clone())
-            .map(std::path::PathBuf::from);
+            .map(std::path::PathBuf::from)
+            .or_else(|| std::env::current_dir().ok());
 
         let (fields, claims) =
             crate::runtime::verification_engine::extract_verification_inputs(&result);

--- a/src/runtime/session_manager.rs
+++ b/src/runtime/session_manager.rs
@@ -259,6 +259,7 @@ pub struct SessionManager {
     event_bus: Arc<Mutex<Option<SharedEventBus>>>,
     polling_cancel: Arc<AtomicBool>,
     inner: Arc<Mutex<SessionManagerInner>>,
+    verification_engine: Option<Arc<crate::runtime::verification_engine::VerificationEngine>>,
 }
 
 impl SessionManager {
@@ -275,6 +276,7 @@ impl SessionManager {
                 listeners: HashMap::new(),
                 drivers: HashMap::new(),
             })),
+            verification_engine: None,
         }
     }
 
@@ -285,6 +287,14 @@ impl SessionManager {
 
     pub fn with_event_bus(self, bus: SharedEventBus) -> Self {
         *self.event_bus.lock().unwrap() = Some(bus);
+        self
+    }
+
+    pub fn with_verification_engine(
+        mut self,
+        engine: crate::runtime::verification_engine::VerificationEngine,
+    ) -> Self {
+        self.verification_engine = Some(Arc::new(engine));
         self
     }
 
@@ -929,6 +939,7 @@ impl SessionManager {
     async fn mark_completed(&self, session_id: &str, result: ConfidentValue) {
         self.transition_status(session_id, SessionStatus::Completing);
         let result = self.inject_cost(result, session_id);
+        let result = self.run_verification(result, session_id).await;
         let (snapshot, notify) = {
             let mut inner = self.inner.lock().unwrap();
             let Some(entry) = inner.sessions.get_mut(session_id) else {
@@ -1048,6 +1059,32 @@ impl SessionManager {
                 source: result.source,
             },
         }
+    }
+
+    /// Run the verification engine (if configured) on a completed session result.
+    /// Updates metadata.verification from Pending to the resolved status.
+    async fn run_verification(&self, result: ConfidentValue, session_id: &str) -> ConfidentValue {
+        let engine = match &self.verification_engine {
+            Some(e) => Arc::clone(e),
+            None => return result,
+        };
+
+        let working_dir = self
+            .session_state(session_id)
+            .and_then(|s| s.config.working_dir.clone())
+            .map(std::path::PathBuf::from);
+
+        let (fields, claims) =
+            crate::runtime::verification_engine::extract_verification_inputs(&result);
+
+        let ctx = crate::runtime::verification_engine::VerificationContext {
+            working_dir,
+            agent_fields: fields,
+            claims,
+        };
+
+        let vr = engine.verify(&ctx).await;
+        crate::runtime::verification_engine::inject_resolved_verification(result, vr)
     }
 
     fn state_path(&self, session_id: &str) -> PathBuf {
@@ -1247,7 +1284,11 @@ pub fn default_session_dir(root: impl AsRef<Path>) -> PathBuf {
 
 pub fn new_shared_default_session_manager(tracer: Option<Tracer>) -> SharedSessionManager {
     let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let manager = SessionManager::new(default_session_dir(&root)).with_tracer(tracer);
+    let manager = SessionManager::new(default_session_dir(&root))
+        .with_tracer(tracer)
+        .with_verification_engine(
+            crate::runtime::verification_engine::VerificationEngine::coding_session(),
+        );
 
     // Auto-register adapters from the resolution chain:
     //   1. Project local: ./adapters/{name}/ADAPTER.toml

--- a/src/runtime/verification_engine.rs
+++ b/src/runtime/verification_engine.rs
@@ -1,0 +1,1133 @@
+// FORGE verification engine — issue #204
+//
+// Runtime verification engine that validates agent claims against the real
+// environment. Takes the pending VerificationResult from #203 (with extracted
+// claims) and resolves it to Verified/Insufficient/Contradicted/Error by
+// running a sequence of validator stages.
+//
+// Validator stages (paper Section 7.2):
+//   1. Schema   — AgentResult structural checks
+//   2. Reference — claimed files/symbols exist on disk
+//   3. Environment — working directory is valid git state
+//   4. Execution — tests actually pass (cargo test)
+//   5. Policy   — risk class vs verification state
+//
+// #205 (contradiction events) will emit results to wardens.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::runtime::confidence::{ConfidentValue, Value};
+use crate::runtime::verification::*;
+
+// ── Context & Result types ───────────────────────────────────
+
+/// Context passed to each validator stage.
+pub struct VerificationContext {
+    /// Sandbox working directory (from SessionConfig).
+    pub working_dir: Option<PathBuf>,
+    /// The AgentResult top-level fields (plan, files_changed, etc.).
+    pub agent_fields: HashMap<String, ConfidentValue>,
+    /// The claims extracted during parse_final().
+    pub claims: Vec<Claim>,
+}
+
+/// Result from a single validator stage.
+pub struct StageResult {
+    pub evidence: Vec<Evidence>,
+    pub contradictions: Vec<Contradiction>,
+    /// If true, the engine stops running further stages.
+    pub fatal: bool,
+}
+
+impl StageResult {
+    pub fn empty() -> Self {
+        Self {
+            evidence: Vec::new(),
+            contradictions: Vec::new(),
+            fatal: false,
+        }
+    }
+}
+
+// ── Validator trait ──────────────────────────────────────────
+
+#[async_trait]
+pub trait Validator: Send + Sync {
+    /// Human-readable name for tracing.
+    fn name(&self) -> &str;
+
+    /// Run this validation stage.
+    async fn validate(&self, ctx: &VerificationContext) -> StageResult;
+}
+
+// ── VerificationEngine ──────────────────────────────────────
+
+pub struct VerificationEngine {
+    validators: Vec<Box<dyn Validator>>,
+}
+
+impl Default for VerificationEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VerificationEngine {
+    pub fn new() -> Self {
+        Self {
+            validators: Vec::new(),
+        }
+    }
+
+    /// Build the default coding-session engine with all 5 stages.
+    pub fn coding_session() -> Self {
+        let mut engine = Self::new();
+        engine.add(Box::new(SchemaValidator));
+        engine.add(Box::new(ReferenceValidator));
+        engine.add(Box::new(EnvironmentValidator));
+        engine.add(Box::new(ExecutionValidator::default()));
+        engine.add(Box::new(PolicyValidator));
+        engine
+    }
+
+    pub fn add(&mut self, validator: Box<dyn Validator>) {
+        self.validators.push(validator);
+    }
+
+    /// Run all validators in sequence, aggregate evidence/contradictions,
+    /// and resolve final VerificationStatus.
+    pub async fn verify(&self, ctx: &VerificationContext) -> VerificationResult {
+        let mut all_evidence: Vec<Evidence> = Vec::new();
+        let mut all_contradictions: Vec<Contradiction> = Vec::new();
+        let mut had_error = false;
+
+        for validator in &self.validators {
+            let stage = validator.validate(ctx).await;
+            all_evidence.extend(stage.evidence);
+            all_contradictions.extend(stage.contradictions);
+            if stage.fatal {
+                had_error = true;
+                break;
+            }
+        }
+
+        let risk_class = classify_risk(&ctx.agent_fields);
+        let status = resolve_status(&ctx.claims, &all_evidence, &all_contradictions, had_error);
+
+        VerificationResult {
+            status,
+            claims: ctx.claims.clone(),
+            evidence: all_evidence,
+            contradictions: all_contradictions,
+            risk_class,
+        }
+    }
+}
+
+// ── Status resolution ───────────────────────────────────────
+
+/// Determine the final VerificationStatus from claims, evidence, and contradictions.
+fn resolve_status(
+    claims: &[Claim],
+    evidence: &[Evidence],
+    contradictions: &[Contradiction],
+    had_error: bool,
+) -> VerificationStatus {
+    if had_error {
+        return VerificationStatus::Error;
+    }
+    if !contradictions.is_empty() {
+        return VerificationStatus::Contradicted;
+    }
+    if claims.is_empty() {
+        // No claims to verify — nothing to contradict but nothing confirmed either.
+        return VerificationStatus::Insufficient;
+    }
+    // Check that every claim has at least one supporting evidence.
+    let has_support = |claim: &Claim| {
+        evidence
+            .iter()
+            .any(|e| e.polarity == EvidencePolarity::Supports && evidence_matches_claim(e, claim))
+    };
+    if claims.iter().all(has_support) {
+        VerificationStatus::Verified
+    } else {
+        VerificationStatus::Insufficient
+    }
+}
+
+/// Check whether a piece of evidence is relevant to a specific claim.
+fn evidence_matches_claim(evidence: &Evidence, claim: &Claim) -> bool {
+    match (evidence.kind, claim.kind) {
+        (EvidenceKind::SchemaValidation, _) => true, // schema evidence supports all claims
+        (EvidenceKind::FileExists, ClaimKind::FilesChanged) => true,
+        (EvidenceKind::SymbolExists, ClaimKind::SymbolReference) => true,
+        (EvidenceKind::TestResult, ClaimKind::TestsPass) => true,
+        (EvidenceKind::PolicyCheck, _) => false, // policy evidence doesn't support claims directly
+        (EvidenceKind::AgentAssessment, ClaimKind::TaskInterpretation) => true,
+        (EvidenceKind::AgentAssessment, ClaimKind::TaskComplete) => true,
+        _ => false,
+    }
+}
+
+// ── Risk classification ─────────────────────────────────────
+
+/// Classify the risk level of an agent result from its fields.
+pub fn classify_risk(fields: &HashMap<String, ConfidentValue>) -> RiskClass {
+    // Check metadata for side-effect markers.
+    if let Some(cv) = fields.get("metadata") {
+        if let Value::Record(meta) = &cv.value {
+            // If metadata explicitly sets a risk class, use it.
+            if let Some(rc_cv) = meta.get("risk_class") {
+                if let Some(rc) = RiskClass::from_value(&rc_cv.value) {
+                    return rc;
+                }
+            }
+            // Check for side-effect indicators.
+            for key in &["git_push", "pr_create", "deploy", "merge"] {
+                if meta.contains_key(*key) {
+                    return RiskClass::ExternalSideEffect;
+                }
+            }
+        }
+    }
+
+    // files_changed non-empty → at minimum FileSystem.
+    if let Some(cv) = fields.get("files_changed") {
+        if let Value::Array(items) = &cv.value {
+            if !items.is_empty() {
+                return RiskClass::FileSystem;
+            }
+        }
+    }
+
+    // State mutations (memory, knowledge writes).
+    if let Some(cv) = fields.get("metadata") {
+        if let Value::Record(meta) = &cv.value {
+            for key in &["memory_write", "knowledge_write", "state_mutation"] {
+                if meta.contains_key(*key) {
+                    return RiskClass::StateMutation;
+                }
+            }
+        }
+    }
+
+    RiskClass::Informational
+}
+
+// ── SchemaValidator ─────────────────────────────────────────
+
+/// Checks AgentResult has expected structural fields.
+pub struct SchemaValidator;
+
+#[async_trait]
+impl Validator for SchemaValidator {
+    fn name(&self) -> &str {
+        "schema"
+    }
+
+    async fn validate(&self, ctx: &VerificationContext) -> StageResult {
+        let mut evidence = Vec::new();
+        let mut contradictions = Vec::new();
+
+        // Check plan field exists and is non-empty text.
+        let has_plan = ctx
+            .agent_fields
+            .get("plan")
+            .map(|cv| matches!(&cv.value, Value::Text(s) if !s.is_empty()))
+            .unwrap_or(false);
+
+        if has_plan {
+            evidence.push(Evidence::new(
+                EvidenceKind::SchemaValidation,
+                "AgentResult contains a non-empty plan",
+                EvidencePolarity::Supports,
+                1.0,
+            ));
+        }
+
+        // Check confidence field exists.
+        let has_confidence = ctx
+            .agent_fields
+            .get("confidence")
+            .map(|cv| matches!(&cv.value, Value::Number(_)))
+            .unwrap_or(false);
+
+        if has_confidence {
+            evidence.push(Evidence::new(
+                EvidenceKind::SchemaValidation,
+                "AgentResult contains a confidence score",
+                EvidencePolarity::Supports,
+                1.0,
+            ));
+        }
+
+        // If there are FilesChanged claims, files_changed field must be an array.
+        let has_file_claims = ctx.claims.iter().any(|c| c.kind == ClaimKind::FilesChanged);
+        if has_file_claims {
+            let has_files_array = ctx
+                .agent_fields
+                .get("files_changed")
+                .map(|cv| matches!(&cv.value, Value::Array(_)))
+                .unwrap_or(false);
+
+            if has_files_array {
+                evidence.push(Evidence::new(
+                    EvidenceKind::SchemaValidation,
+                    "files_changed field is a valid array",
+                    EvidencePolarity::Supports,
+                    1.0,
+                ));
+            } else {
+                let e = Evidence::new(
+                    EvidenceKind::SchemaValidation,
+                    "FilesChanged claim exists but files_changed field is missing or invalid",
+                    EvidencePolarity::Contradicts,
+                    1.0,
+                );
+                if let Some(claim) = ctx
+                    .claims
+                    .iter()
+                    .find(|c| c.kind == ClaimKind::FilesChanged)
+                {
+                    contradictions.push(Contradiction::new(
+                        claim.clone(),
+                        e.clone(),
+                        ContradictionSeverity::Medium,
+                    ));
+                }
+                evidence.push(e);
+            }
+        }
+
+        StageResult {
+            evidence,
+            contradictions,
+            fatal: false,
+        }
+    }
+}
+
+// ── ReferenceValidator ──────────────────────────────────────
+
+/// Checks claimed files exist on disk in the working directory.
+pub struct ReferenceValidator;
+
+#[async_trait]
+impl Validator for ReferenceValidator {
+    fn name(&self) -> &str {
+        "reference"
+    }
+
+    async fn validate(&self, ctx: &VerificationContext) -> StageResult {
+        let working_dir = match &ctx.working_dir {
+            Some(d) => d,
+            None => {
+                return StageResult {
+                    evidence: vec![Evidence::new(
+                        EvidenceKind::FileExists,
+                        "No working directory configured; skipping file reference checks",
+                        EvidencePolarity::Neutral,
+                        0.0,
+                    )],
+                    contradictions: Vec::new(),
+                    fatal: false,
+                };
+            }
+        };
+
+        let mut evidence = Vec::new();
+        let mut contradictions = Vec::new();
+
+        // Check each file in files_changed.
+        if let Some(cv) = ctx.agent_fields.get("files_changed") {
+            if let Value::Array(items) = &cv.value {
+                for item in items {
+                    if let Value::Text(path_str) = &item.value {
+                        let full_path = working_dir.join(path_str);
+                        if full_path.exists() {
+                            evidence.push(Evidence::new(
+                                EvidenceKind::FileExists,
+                                format!("File exists: {path_str}"),
+                                EvidencePolarity::Supports,
+                                1.0,
+                            ));
+                        } else {
+                            let e = Evidence::new(
+                                EvidenceKind::FileExists,
+                                format!("File does not exist: {path_str}"),
+                                EvidencePolarity::Contradicts,
+                                1.0,
+                            );
+                            if let Some(claim) = ctx
+                                .claims
+                                .iter()
+                                .find(|c| c.kind == ClaimKind::FilesChanged)
+                            {
+                                contradictions.push(Contradiction::new(
+                                    claim.clone(),
+                                    e.clone(),
+                                    ContradictionSeverity::High,
+                                ));
+                            }
+                            evidence.push(e);
+                        }
+                    }
+                }
+            }
+        }
+
+        StageResult {
+            evidence,
+            contradictions,
+            fatal: false,
+        }
+    }
+}
+
+// ── EnvironmentValidator ────────────────────────────────────
+
+/// Checks working directory is a valid git repository.
+pub struct EnvironmentValidator;
+
+#[async_trait]
+impl Validator for EnvironmentValidator {
+    fn name(&self) -> &str {
+        "environment"
+    }
+
+    async fn validate(&self, ctx: &VerificationContext) -> StageResult {
+        let working_dir = match &ctx.working_dir {
+            Some(d) => d,
+            None => {
+                return StageResult {
+                    evidence: vec![Evidence::new(
+                        EvidenceKind::Other,
+                        "No working directory configured; skipping environment checks",
+                        EvidencePolarity::Neutral,
+                        0.0,
+                    )],
+                    contradictions: Vec::new(),
+                    fatal: false,
+                };
+            }
+        };
+
+        let mut evidence = Vec::new();
+
+        // Check directory exists.
+        if working_dir.is_dir() {
+            evidence.push(Evidence::new(
+                EvidenceKind::Other,
+                "Working directory exists",
+                EvidencePolarity::Supports,
+                1.0,
+            ));
+        } else {
+            evidence.push(Evidence::new(
+                EvidenceKind::Other,
+                format!(
+                    "Working directory does not exist: {}",
+                    working_dir.display()
+                ),
+                EvidencePolarity::Contradicts,
+                1.0,
+            ));
+            return StageResult {
+                evidence,
+                contradictions: Vec::new(),
+                fatal: true,
+            };
+        }
+
+        // Check for git repository (regular .git dir or worktree marker file).
+        let git_path = working_dir.join(".git");
+        if git_path.exists() {
+            evidence.push(Evidence::new(
+                EvidenceKind::Other,
+                "Working directory is a git repository",
+                EvidencePolarity::Supports,
+                1.0,
+            ));
+        } else {
+            evidence.push(Evidence::new(
+                EvidenceKind::Other,
+                "Working directory is not a git repository",
+                EvidencePolarity::Neutral,
+                0.5,
+            ));
+        }
+
+        StageResult {
+            evidence,
+            contradictions: Vec::new(),
+            fatal: false,
+        }
+    }
+}
+
+// ── ExecutionValidator ──────────────────────────────────────
+
+/// Runs tests if TestsPass claims exist.
+pub struct ExecutionValidator {
+    pub timeout: Duration,
+}
+
+impl Default for ExecutionValidator {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(120),
+        }
+    }
+}
+
+#[async_trait]
+impl Validator for ExecutionValidator {
+    fn name(&self) -> &str {
+        "execution"
+    }
+
+    async fn validate(&self, ctx: &VerificationContext) -> StageResult {
+        // Only run if there is a TestsPass claim.
+        let test_claim = ctx.claims.iter().find(|c| c.kind == ClaimKind::TestsPass);
+        let test_claim = match test_claim {
+            Some(c) => c,
+            None => return StageResult::empty(),
+        };
+
+        let working_dir = match &ctx.working_dir {
+            Some(d) if d.is_dir() => d,
+            _ => {
+                return StageResult {
+                    evidence: vec![Evidence::new(
+                        EvidenceKind::TestResult,
+                        "No valid working directory; cannot run tests",
+                        EvidencePolarity::Neutral,
+                        0.0,
+                    )],
+                    contradictions: Vec::new(),
+                    fatal: false,
+                };
+            }
+        };
+
+        // Detect test command.
+        let (cmd, args) = if working_dir.join("Cargo.toml").exists() {
+            ("cargo", vec!["test"])
+        } else if working_dir.join("package.json").exists() {
+            ("npm", vec!["test"])
+        } else {
+            return StageResult {
+                evidence: vec![Evidence::new(
+                    EvidenceKind::TestResult,
+                    "No recognized test runner (Cargo.toml or package.json) found",
+                    EvidencePolarity::Neutral,
+                    0.0,
+                )],
+                contradictions: Vec::new(),
+                fatal: false,
+            };
+        };
+
+        // Run tests with timeout.
+        let result = tokio::time::timeout(
+            self.timeout,
+            tokio::process::Command::new(cmd)
+                .args(&args)
+                .current_dir(working_dir)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .output(),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(output)) => {
+                if output.status.success() {
+                    StageResult {
+                        evidence: vec![Evidence::new(
+                            EvidenceKind::TestResult,
+                            format!("{cmd} {}", args.join(" ")),
+                            EvidencePolarity::Supports,
+                            1.0,
+                        )],
+                        contradictions: Vec::new(),
+                        fatal: false,
+                    }
+                } else {
+                    let stderr = String::from_utf8_lossy(&output.stderr)
+                        .chars()
+                        .take(500)
+                        .collect::<String>();
+                    let e = Evidence::new(
+                        EvidenceKind::TestResult,
+                        format!(
+                            "Tests failed (exit {}): {}",
+                            output.status.code().unwrap_or(-1),
+                            stderr.trim()
+                        ),
+                        EvidencePolarity::Contradicts,
+                        1.0,
+                    );
+                    let contradiction = Contradiction::new(
+                        test_claim.clone(),
+                        e.clone(),
+                        ContradictionSeverity::High,
+                    );
+                    StageResult {
+                        evidence: vec![e],
+                        contradictions: vec![contradiction],
+                        fatal: false,
+                    }
+                }
+            }
+            Ok(Err(err)) => StageResult {
+                evidence: vec![Evidence::new(
+                    EvidenceKind::TestResult,
+                    format!("Failed to spawn test process: {err}"),
+                    EvidencePolarity::Contradicts,
+                    1.0,
+                )],
+                contradictions: Vec::new(),
+                fatal: true,
+            },
+            Err(_) => StageResult {
+                evidence: vec![Evidence::new(
+                    EvidenceKind::TestResult,
+                    format!("Test execution timed out after {}s", self.timeout.as_secs()),
+                    EvidencePolarity::Contradicts,
+                    1.0,
+                )],
+                contradictions: Vec::new(),
+                fatal: true,
+            },
+        }
+    }
+}
+
+// ── PolicyValidator ─────────────────────────────────────────
+
+/// Checks risk class against accumulated verification state.
+pub struct PolicyValidator;
+
+#[async_trait]
+impl Validator for PolicyValidator {
+    fn name(&self) -> &str {
+        "policy"
+    }
+
+    async fn validate(&self, ctx: &VerificationContext) -> StageResult {
+        let risk = classify_risk(&ctx.agent_fields);
+
+        match risk {
+            RiskClass::ExternalSideEffect => {
+                // External side effects require explicit verification — flag as
+                // needing attention. The actual blocking happens in downstream
+                // consumers via is_actionable().
+                StageResult {
+                    evidence: vec![Evidence::new(
+                        EvidenceKind::PolicyCheck,
+                        "Risk class is ExternalSideEffect; requires verified preconditions",
+                        EvidencePolarity::Neutral,
+                        1.0,
+                    )],
+                    contradictions: Vec::new(),
+                    fatal: false,
+                }
+            }
+            RiskClass::FileSystem => StageResult {
+                evidence: vec![Evidence::new(
+                    EvidenceKind::PolicyCheck,
+                    "Risk class is FileSystem; standard verification sufficient",
+                    EvidencePolarity::Supports,
+                    1.0,
+                )],
+                contradictions: Vec::new(),
+                fatal: false,
+            },
+            _ => StageResult {
+                evidence: vec![Evidence::new(
+                    EvidenceKind::PolicyCheck,
+                    format!("Risk class is {}; no elevated policy gate", risk.as_str()),
+                    EvidencePolarity::Supports,
+                    1.0,
+                )],
+                contradictions: Vec::new(),
+                fatal: false,
+            },
+        }
+    }
+}
+
+// ── Helpers for SessionManager integration ──────────────────
+
+/// Extract verification inputs from a completed AgentResult ConfidentValue.
+/// Returns the agent fields and the claims from the pending VerificationResult.
+pub fn extract_verification_inputs(
+    result: &ConfidentValue,
+) -> (HashMap<String, ConfidentValue>, Vec<Claim>) {
+    let fields = match &result.value {
+        Value::Record(f) => f.clone(),
+        _ => return (HashMap::new(), Vec::new()),
+    };
+
+    // Extract claims from the pending verification result in metadata.
+    let claims = fields
+        .get("metadata")
+        .and_then(|cv| match &cv.value {
+            Value::Record(meta) => meta.get("verification"),
+            _ => None,
+        })
+        .and_then(|cv| VerificationResult::from_value(&cv.value))
+        .map(|vr| vr.claims)
+        .unwrap_or_default();
+
+    (fields, claims)
+}
+
+/// Inject a resolved VerificationResult back into the AgentResult ConfidentValue.
+pub fn inject_resolved_verification(
+    mut result: ConfidentValue,
+    vr: VerificationResult,
+) -> ConfidentValue {
+    if let Value::Record(ref mut fields) = result.value {
+        if let Some(meta_cv) = fields.get_mut("metadata") {
+            if let Value::Record(ref mut meta) = meta_cv.value {
+                meta.insert(
+                    "verification".to_string(),
+                    ConfidentValue::deterministic(vr.to_value()),
+                );
+                return result;
+            }
+        }
+        // If metadata doesn't exist as a record, create it.
+        let mut meta = HashMap::new();
+        meta.insert(
+            "verification".to_string(),
+            ConfidentValue::deterministic(vr.to_value()),
+        );
+        fields.insert(
+            "metadata".to_string(),
+            ConfidentValue::deterministic(Value::Record(meta)),
+        );
+    }
+    result
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ConfidenceSource;
+    use tempfile::TempDir;
+
+    fn make_context(
+        working_dir: Option<PathBuf>,
+        fields: HashMap<String, ConfidentValue>,
+        claims: Vec<Claim>,
+    ) -> VerificationContext {
+        VerificationContext {
+            working_dir,
+            agent_fields: fields,
+            claims,
+        }
+    }
+
+    fn text_cv(s: &str) -> ConfidentValue {
+        ConfidentValue::deterministic(Value::Text(s.to_string()))
+    }
+
+    fn num_cv(n: f64) -> ConfidentValue {
+        ConfidentValue::deterministic(Value::Number(n))
+    }
+
+    fn array_cv(items: Vec<&str>) -> ConfidentValue {
+        ConfidentValue::deterministic(Value::Array(items.iter().map(|s| text_cv(s)).collect()))
+    }
+
+    fn make_claim(kind: ClaimKind, desc: &str) -> Claim {
+        Claim::new(kind, desc, 0.9, ConfidenceSource::Deterministic)
+    }
+
+    // ── resolve_status ──────────────────────────────────────
+
+    #[test]
+    fn resolve_status_error_on_fatal() {
+        let status = resolve_status(&[], &[], &[], true);
+        assert_eq!(status, VerificationStatus::Error);
+    }
+
+    #[test]
+    fn resolve_status_contradicted_on_contradictions() {
+        let claim = make_claim(ClaimKind::FilesChanged, "changed files");
+        let evidence = Evidence::new(
+            EvidenceKind::FileExists,
+            "file missing",
+            EvidencePolarity::Contradicts,
+            1.0,
+        );
+        let contradiction =
+            Contradiction::new(claim.clone(), evidence, ContradictionSeverity::High);
+        let status = resolve_status(&[claim], &[], &[contradiction], false);
+        assert_eq!(status, VerificationStatus::Contradicted);
+    }
+
+    #[test]
+    fn resolve_status_insufficient_no_claims() {
+        let status = resolve_status(&[], &[], &[], false);
+        assert_eq!(status, VerificationStatus::Insufficient);
+    }
+
+    #[test]
+    fn resolve_status_verified_all_supported() {
+        let claim = make_claim(ClaimKind::FilesChanged, "changed src/main.rs");
+        let evidence = Evidence::new(
+            EvidenceKind::FileExists,
+            "file exists",
+            EvidencePolarity::Supports,
+            1.0,
+        );
+        let status = resolve_status(&[claim], &[evidence], &[], false);
+        assert_eq!(status, VerificationStatus::Verified);
+    }
+
+    #[test]
+    fn resolve_status_insufficient_unsupported_claim() {
+        let claim = make_claim(ClaimKind::TestsPass, "all tests pass");
+        // No TestResult evidence, only FileExists.
+        let evidence = Evidence::new(
+            EvidenceKind::FileExists,
+            "file exists",
+            EvidencePolarity::Supports,
+            1.0,
+        );
+        let status = resolve_status(&[claim], &[evidence], &[], false);
+        assert_eq!(status, VerificationStatus::Insufficient);
+    }
+
+    // ── classify_risk ───────────────────────────────────────
+
+    #[test]
+    fn classify_risk_informational_empty() {
+        let fields = HashMap::new();
+        assert_eq!(classify_risk(&fields), RiskClass::Informational);
+    }
+
+    #[test]
+    fn classify_risk_filesystem_with_files() {
+        let mut fields = HashMap::new();
+        fields.insert("files_changed".to_string(), array_cv(vec!["src/main.rs"]));
+        assert_eq!(classify_risk(&fields), RiskClass::FileSystem);
+    }
+
+    #[test]
+    fn classify_risk_external_with_metadata() {
+        let mut fields = HashMap::new();
+        let mut meta = HashMap::new();
+        meta.insert(
+            "git_push".to_string(),
+            ConfidentValue::deterministic(Value::Bool(true)),
+        );
+        fields.insert(
+            "metadata".to_string(),
+            ConfidentValue::deterministic(Value::Record(meta)),
+        );
+        assert_eq!(classify_risk(&fields), RiskClass::ExternalSideEffect);
+    }
+
+    #[test]
+    fn classify_risk_explicit_from_metadata() {
+        let mut fields = HashMap::new();
+        let mut meta = HashMap::new();
+        meta.insert(
+            "risk_class".to_string(),
+            ConfidentValue::deterministic(Value::Text("state_mutation".to_string())),
+        );
+        fields.insert(
+            "metadata".to_string(),
+            ConfidentValue::deterministic(Value::Record(meta)),
+        );
+        assert_eq!(classify_risk(&fields), RiskClass::StateMutation);
+    }
+
+    // ── SchemaValidator ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn schema_validator_complete_fields() {
+        let mut fields = HashMap::new();
+        fields.insert("plan".to_string(), text_cv("implement feature X"));
+        fields.insert("confidence".to_string(), num_cv(0.9));
+        fields.insert("files_changed".to_string(), array_cv(vec!["src/main.rs"]));
+        let claims = vec![make_claim(ClaimKind::FilesChanged, "files changed")];
+        let ctx = make_context(None, fields, claims);
+
+        let result = SchemaValidator.validate(&ctx).await;
+        assert!(result.contradictions.is_empty());
+        assert_eq!(result.evidence.len(), 3); // plan + confidence + files_array
+        assert!(result
+            .evidence
+            .iter()
+            .all(|e| e.polarity == EvidencePolarity::Supports));
+    }
+
+    #[tokio::test]
+    async fn schema_validator_missing_files_array_with_claim() {
+        let fields = HashMap::new();
+        let claims = vec![make_claim(ClaimKind::FilesChanged, "files changed")];
+        let ctx = make_context(None, fields, claims);
+
+        let result = SchemaValidator.validate(&ctx).await;
+        assert_eq!(result.contradictions.len(), 1);
+    }
+
+    // ── ReferenceValidator ──────────────────────────────────
+
+    #[tokio::test]
+    async fn reference_validator_files_exist() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("foo.rs"), "fn main() {}").unwrap();
+
+        let mut fields = HashMap::new();
+        fields.insert("files_changed".to_string(), array_cv(vec!["foo.rs"]));
+        let claims = vec![make_claim(ClaimKind::FilesChanged, "changed foo.rs")];
+        let ctx = make_context(Some(dir.path().to_path_buf()), fields, claims);
+
+        let result = ReferenceValidator.validate(&ctx).await;
+        assert!(result.contradictions.is_empty());
+        assert_eq!(result.evidence.len(), 1);
+        assert_eq!(result.evidence[0].polarity, EvidencePolarity::Supports);
+    }
+
+    #[tokio::test]
+    async fn reference_validator_file_missing() {
+        let dir = TempDir::new().unwrap();
+        let mut fields = HashMap::new();
+        fields.insert(
+            "files_changed".to_string(),
+            array_cv(vec!["nonexistent.rs"]),
+        );
+        let claims = vec![make_claim(
+            ClaimKind::FilesChanged,
+            "changed nonexistent.rs",
+        )];
+        let ctx = make_context(Some(dir.path().to_path_buf()), fields, claims);
+
+        let result = ReferenceValidator.validate(&ctx).await;
+        assert_eq!(result.contradictions.len(), 1);
+        assert_eq!(
+            result.contradictions[0].severity,
+            ContradictionSeverity::High
+        );
+    }
+
+    #[tokio::test]
+    async fn reference_validator_no_working_dir() {
+        let fields = HashMap::new();
+        let ctx = make_context(None, fields, Vec::new());
+
+        let result = ReferenceValidator.validate(&ctx).await;
+        assert_eq!(result.evidence.len(), 1);
+        assert_eq!(result.evidence[0].polarity, EvidencePolarity::Neutral);
+    }
+
+    // ── EnvironmentValidator ────────────────────────────────
+
+    #[tokio::test]
+    async fn environment_validator_valid_git_dir() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+
+        let ctx = make_context(Some(dir.path().to_path_buf()), HashMap::new(), Vec::new());
+        let result = EnvironmentValidator.validate(&ctx).await;
+
+        assert!(result
+            .evidence
+            .iter()
+            .any(|e| e.description.contains("git repository")));
+        assert!(!result.fatal);
+    }
+
+    #[tokio::test]
+    async fn environment_validator_nonexistent_dir() {
+        let ctx = make_context(
+            Some(PathBuf::from("/nonexistent/path/xyz")),
+            HashMap::new(),
+            Vec::new(),
+        );
+        let result = EnvironmentValidator.validate(&ctx).await;
+        assert!(result.fatal);
+    }
+
+    #[tokio::test]
+    async fn environment_validator_no_working_dir() {
+        let ctx = make_context(None, HashMap::new(), Vec::new());
+        let result = EnvironmentValidator.validate(&ctx).await;
+        assert_eq!(result.evidence[0].polarity, EvidencePolarity::Neutral);
+    }
+
+    // ── ExecutionValidator ───────────────────────────────────
+
+    #[tokio::test]
+    async fn execution_validator_skips_without_test_claim() {
+        let dir = TempDir::new().unwrap();
+        let ctx = make_context(Some(dir.path().to_path_buf()), HashMap::new(), Vec::new());
+        let result = ExecutionValidator::default().validate(&ctx).await;
+        assert!(result.evidence.is_empty());
+    }
+
+    #[tokio::test]
+    async fn execution_validator_skips_no_test_runner() {
+        let dir = TempDir::new().unwrap();
+        let claims = vec![make_claim(ClaimKind::TestsPass, "all tests pass")];
+        let ctx = make_context(Some(dir.path().to_path_buf()), HashMap::new(), claims);
+        let result = ExecutionValidator::default().validate(&ctx).await;
+        assert_eq!(result.evidence.len(), 1);
+        assert_eq!(result.evidence[0].polarity, EvidencePolarity::Neutral);
+    }
+
+    // ── PolicyValidator ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn policy_validator_informational() {
+        let ctx = make_context(None, HashMap::new(), Vec::new());
+        let result = PolicyValidator.validate(&ctx).await;
+        assert_eq!(result.evidence.len(), 1);
+        assert_eq!(result.evidence[0].polarity, EvidencePolarity::Supports);
+    }
+
+    #[tokio::test]
+    async fn policy_validator_external_side_effect() {
+        let mut fields = HashMap::new();
+        let mut meta = HashMap::new();
+        meta.insert(
+            "git_push".to_string(),
+            ConfidentValue::deterministic(Value::Bool(true)),
+        );
+        fields.insert(
+            "metadata".to_string(),
+            ConfidentValue::deterministic(Value::Record(meta)),
+        );
+
+        let ctx = make_context(None, fields, Vec::new());
+        let result = PolicyValidator.validate(&ctx).await;
+        assert_eq!(result.evidence[0].polarity, EvidencePolarity::Neutral);
+    }
+
+    // ── Full engine pipeline ────────────────────────────────
+
+    #[tokio::test]
+    async fn engine_verified_with_existing_files() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("src.rs"), "fn main() {}").unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+
+        let mut fields = HashMap::new();
+        fields.insert("plan".to_string(), text_cv("implement feature"));
+        fields.insert("confidence".to_string(), num_cv(0.9));
+        fields.insert("files_changed".to_string(), array_cv(vec!["src.rs"]));
+
+        let claims = vec![
+            make_claim(ClaimKind::TaskInterpretation, "interpreted task"),
+            make_claim(ClaimKind::FilesChanged, "changed src.rs"),
+        ];
+
+        // Use only schema + reference + environment + policy (skip execution — no Cargo.toml).
+        let mut engine = VerificationEngine::new();
+        engine.add(Box::new(SchemaValidator));
+        engine.add(Box::new(ReferenceValidator));
+        engine.add(Box::new(EnvironmentValidator));
+        engine.add(Box::new(PolicyValidator));
+
+        let ctx = make_context(Some(dir.path().to_path_buf()), fields, claims);
+        let result = engine.verify(&ctx).await;
+
+        assert_eq!(result.status, VerificationStatus::Verified);
+        assert!(result.contradictions.is_empty());
+        assert_eq!(result.risk_class, RiskClass::FileSystem);
+    }
+
+    #[tokio::test]
+    async fn engine_contradicted_with_missing_files() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+
+        let mut fields = HashMap::new();
+        fields.insert("plan".to_string(), text_cv("implement feature"));
+        fields.insert("confidence".to_string(), num_cv(0.9));
+        fields.insert("files_changed".to_string(), array_cv(vec!["missing.rs"]));
+
+        let claims = vec![make_claim(ClaimKind::FilesChanged, "changed missing.rs")];
+
+        let mut engine = VerificationEngine::new();
+        engine.add(Box::new(SchemaValidator));
+        engine.add(Box::new(ReferenceValidator));
+
+        let ctx = make_context(Some(dir.path().to_path_buf()), fields, claims);
+        let result = engine.verify(&ctx).await;
+
+        assert_eq!(result.status, VerificationStatus::Contradicted);
+        assert!(!result.contradictions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn engine_insufficient_no_claims() {
+        let dir = TempDir::new().unwrap();
+        let ctx = make_context(Some(dir.path().to_path_buf()), HashMap::new(), Vec::new());
+
+        let engine = VerificationEngine::coding_session();
+        let result = engine.verify(&ctx).await;
+        assert_eq!(result.status, VerificationStatus::Insufficient);
+    }
+
+    // ── extract/inject helpers ──────────────────────────────
+
+    #[test]
+    fn extract_and_inject_round_trip() {
+        let mut fields = ConfidentValue::default_agent_result_fields();
+        fields.insert("plan".to_string(), text_cv("my plan"));
+
+        let claims = vec![make_claim(ClaimKind::TaskInterpretation, "interpreted")];
+        let mut meta = HashMap::new();
+        let mut pending = VerificationResult::pending();
+        pending.claims = claims.clone();
+        meta.insert(
+            "verification".to_string(),
+            ConfidentValue::deterministic(pending.to_value()),
+        );
+        fields.insert(
+            "metadata".to_string(),
+            ConfidentValue::deterministic(Value::Record(meta)),
+        );
+
+        let result = ConfidentValue::deterministic(Value::Record(fields));
+        let (extracted_fields, extracted_claims) = extract_verification_inputs(&result);
+
+        assert!(!extracted_fields.is_empty());
+        assert_eq!(extracted_claims.len(), 1);
+        assert_eq!(extracted_claims[0].kind, ClaimKind::TaskInterpretation);
+
+        // Inject a resolved result.
+        let resolved = VerificationResult {
+            status: VerificationStatus::Verified,
+            claims: extracted_claims,
+            evidence: vec![Evidence::new(
+                EvidenceKind::SchemaValidation,
+                "ok",
+                EvidencePolarity::Supports,
+                1.0,
+            )],
+            contradictions: Vec::new(),
+            risk_class: RiskClass::Informational,
+        };
+
+        let injected = inject_resolved_verification(result, resolved);
+        let (_, new_claims) = extract_verification_inputs(&injected);
+        // After injection the claims come from the resolved result.
+        assert_eq!(new_claims.len(), 1);
+    }
+}

--- a/src/runtime/warded.rs
+++ b/src/runtime/warded.rs
@@ -404,6 +404,14 @@ impl WardedRuntime {
                             };
                             self.handle_signal(fs).await?;
                         }
+                        Some(AgentSignal::Contradiction { agent_name, detail, severity }) => {
+                            let fs = FailureSignal {
+                                agent_name,
+                                failure_type: FailureType::Contradiction,
+                                detail: format!("[{}] {}", severity, detail),
+                            };
+                            self.handle_signal(fs).await?;
+                        }
                         Some(AgentSignal::BudgetExceeded { agent_name, detail }) => {
                             let fs = FailureSignal {
                                 agent_name,

--- a/src/runtime/warden.rs
+++ b/src/runtime/warden.rs
@@ -105,6 +105,33 @@ pub fn resolve_policy<'a>(
         .map(|p| &p.node)
 }
 
+/// Built-in default policy for contradiction failures.
+/// Paper Section 7.3: nudge → restart (after 2) → escalate (after 4).
+/// Used as a fallback when no explicit `on contradiction:` policy is declared.
+pub fn default_contradiction_policy() -> WardPolicy {
+    WardPolicy {
+        failure_type: Spanned::new(FailureType::Contradiction, Span { start: 0, end: 0 }),
+        response: Spanned::new(WardResponse::Nudge, Span { start: 0, end: 0 }),
+        scope: Spanned::new(WardScope::This, Span { start: 0, end: 0 }),
+        after_clauses: vec![
+            Spanned::new(
+                AfterClause {
+                    count: 2,
+                    response: Spanned::new(WardResponse::Restart, Span { start: 0, end: 0 }),
+                },
+                Span { start: 0, end: 0 },
+            ),
+            Spanned::new(
+                AfterClause {
+                    count: 4,
+                    response: Spanned::new(WardResponse::Escalate, Span { start: 0, end: 0 }),
+                },
+                Span { start: 0, end: 0 },
+            ),
+        ],
+    }
+}
+
 /// Given a policy and the current retry count, determine the effective response
 /// by walking the escalation ladder.
 pub fn effective_response(policy: &WardPolicy, retry_count: u64) -> WardResponse {
@@ -139,13 +166,24 @@ impl Warden {
 
     /// Handle a failure signal from a managed agent.
     /// Returns the action taken, or None if no policy covers this failure type.
+    /// For `Contradiction` failures, falls back to the built-in default policy
+    /// when no explicit `on contradiction:` policy is declared.
     pub fn handle_failure(
         &mut self,
         signal: &FailureSignal,
         agent_overrides: &[Spanned<WardPolicy>],
         timestamp_ms: u64,
     ) -> Option<WardAction> {
-        let policy = resolve_policy(&self.decl, agent_overrides, signal.failure_type)?;
+        // Try explicit policy first; fall back to built-in default for contradictions.
+        let fallback;
+        let policy = match resolve_policy(&self.decl, agent_overrides, signal.failure_type) {
+            Some(p) => p,
+            None if signal.failure_type == FailureType::Contradiction => {
+                fallback = default_contradiction_policy();
+                &fallback
+            }
+            None => return None,
+        };
 
         let retry_count =
             self.retry_tracker
@@ -217,6 +255,7 @@ impl Warden {
             FailureType::Stuck,
             FailureType::Crash,
             FailureType::Hallucination,
+            FailureType::Contradiction,
             FailureType::Budget,
             FailureType::Timeout,
         ] {

--- a/tests/contradiction_event_tests.rs
+++ b/tests/contradiction_event_tests.rs
@@ -1,0 +1,598 @@
+// Integration tests for contradiction events and warden integration (issue #205).
+//
+// Tests cover:
+// - Grammar/parser: `on contradiction:` in warden declarations
+// - Checker: coverage warning includes "contradiction"
+// - Warden runtime: default contradiction policy, escalation ladder
+// - Session manager: ContradictionSummary persistence, event emission
+// - Executor: verification gate blocks contradicted actions
+// - EventBus: `session.contradiction` payload shape
+
+use std::collections::HashMap;
+
+use forge::ast::*;
+use forge::checker::warden_checker;
+use forge::runtime::confidence::{ConfidentValue, Value};
+use forge::runtime::executor::TaskExecutor;
+use forge::runtime::session_manager::ContradictionSummary;
+use forge::runtime::verification::*;
+use forge::runtime::warden::*;
+use forge::types::ConfidenceSource;
+
+fn sp<T>(node: T) -> Spanned<T> {
+    Spanned::new(node, Span { start: 0, end: 0 })
+}
+
+// ── Grammar / Parser Tests ─────────────────────────────────────
+
+#[test]
+fn parse_contradiction_failure_type() {
+    let src = r#"warden code_guardian
+  manages [coder]
+
+  on contradiction: nudge, self
+    after 2: restart
+    after 4: escalate
+
+agent coder
+  on start
+    say "coding"
+"#;
+    let program = forge::parser::parse(src).expect("parse failed");
+    let w = program
+        .items
+        .iter()
+        .find_map(|item| match &item.node {
+            TopLevel::Warden(w) => Some(w),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(w.policies.len(), 1);
+    let policy = &w.policies[0].node;
+    assert_eq!(policy.failure_type.node, FailureType::Contradiction);
+    assert_eq!(policy.response.node, WardResponse::Nudge);
+    assert_eq!(policy.scope.node, WardScope::This);
+    assert_eq!(policy.after_clauses.len(), 2);
+    assert_eq!(policy.after_clauses[0].node.count, 2);
+    assert_eq!(
+        policy.after_clauses[0].node.response.node,
+        WardResponse::Restart
+    );
+    assert_eq!(policy.after_clauses[1].node.count, 4);
+    assert_eq!(
+        policy.after_clauses[1].node.response.node,
+        WardResponse::Escalate
+    );
+}
+
+#[test]
+fn parse_warden_with_all_six_failure_types() {
+    let src = r#"warden full_guard
+  manages [worker]
+
+  on stuck: nudge, self
+  on crash: restart, all
+  on hallucination: replace, downstream
+  on contradiction: nudge, self
+    after 2: restart
+    after 4: escalate
+  on budget: escalate, self
+  on timeout: restart, self
+
+agent worker
+  on start
+    say "working"
+"#;
+    let program = forge::parser::parse(src).expect("parse failed");
+    let w = program
+        .items
+        .iter()
+        .find_map(|item| match &item.node {
+            TopLevel::Warden(w) => Some(w),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(w.policies.len(), 6);
+    let types: Vec<FailureType> = w
+        .policies
+        .iter()
+        .map(|p| p.node.failure_type.node)
+        .collect();
+    assert!(types.contains(&FailureType::Contradiction));
+}
+
+#[test]
+fn parse_agent_with_contradiction_warden_override() {
+    let src = r#"agent coder
+  warden_override
+    on contradiction: escalate, self
+
+  on start
+    say "coding"
+"#;
+    let program = forge::parser::parse(src).expect("parse failed");
+    let agent = program
+        .items
+        .iter()
+        .find_map(|item| match &item.node {
+            TopLevel::Agent(a) => Some(a),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(agent.warden_override.len(), 1);
+    assert_eq!(
+        agent.warden_override[0].node.failure_type.node,
+        FailureType::Contradiction
+    );
+    assert_eq!(
+        agent.warden_override[0].node.response.node,
+        WardResponse::Escalate
+    );
+}
+
+// ── Checker Tests ──────────────────────────────────────────────
+
+#[test]
+fn checker_warns_missing_contradiction_coverage() {
+    let src = r#"warden old_style
+  manages [worker]
+
+  on stuck: nudge, self
+  on crash: restart, all
+  on hallucination: replace, downstream
+  on budget: escalate, self
+  on timeout: restart, self
+
+agent worker
+  on start
+    say "working"
+"#;
+    let program = forge::parser::parse(src).expect("parse failed");
+    let diagnostics = warden_checker::check(&program, "test.forge");
+
+    let warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| matches!(d.kind, forge::diagnostic::DiagnosticKind::Warning))
+        .collect();
+    assert_eq!(warnings.len(), 1, "should warn about missing contradiction");
+    assert!(
+        warnings[0].message.contains("contradiction"),
+        "warning should mention 'contradiction', got: {}",
+        warnings[0].message
+    );
+}
+
+#[test]
+fn checker_full_six_type_coverage_no_warnings() {
+    let src = r#"warden complete_guard
+  manages [worker]
+
+  on stuck: nudge, self
+  on crash: restart, all
+  on hallucination: replace, downstream
+  on contradiction: nudge, self
+  on budget: escalate, self
+  on timeout: restart, self
+
+agent worker
+  on start
+    say "working"
+"#;
+    let program = forge::parser::parse(src).expect("parse failed");
+    let diagnostics = warden_checker::check(&program, "test.forge");
+
+    let warnings: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| matches!(d.kind, forge::diagnostic::DiagnosticKind::Warning))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        0,
+        "full six-type coverage should produce no warnings"
+    );
+}
+
+// ── Default Contradiction Policy ───────────────────────────────
+
+#[test]
+fn default_contradiction_policy_shape() {
+    let policy = default_contradiction_policy();
+    assert_eq!(policy.failure_type.node, FailureType::Contradiction);
+    assert_eq!(policy.response.node, WardResponse::Nudge);
+    assert_eq!(policy.scope.node, WardScope::This);
+    assert_eq!(policy.after_clauses.len(), 2);
+    assert_eq!(policy.after_clauses[0].node.count, 2);
+    assert_eq!(
+        policy.after_clauses[0].node.response.node,
+        WardResponse::Restart
+    );
+    assert_eq!(policy.after_clauses[1].node.count, 4);
+    assert_eq!(
+        policy.after_clauses[1].node.response.node,
+        WardResponse::Escalate
+    );
+}
+
+#[test]
+fn default_contradiction_policy_escalation_ladder() {
+    let policy = default_contradiction_policy();
+
+    // First failure: nudge
+    assert_eq!(effective_response(&policy, 1), WardResponse::Nudge);
+
+    // At threshold 2: restart
+    assert_eq!(effective_response(&policy, 2), WardResponse::Restart);
+    assert_eq!(effective_response(&policy, 3), WardResponse::Restart);
+
+    // At threshold 4: escalate
+    assert_eq!(effective_response(&policy, 4), WardResponse::Escalate);
+    assert_eq!(effective_response(&policy, 10), WardResponse::Escalate);
+}
+
+// ── Warden: Contradiction Handling with Default Fallback ───────
+
+#[test]
+fn warden_handles_contradiction_with_default_fallback() {
+    // Warden with NO explicit contradiction policy — should use built-in default
+    let decl = WardenDecl {
+        name: sp("test_warden".to_string()),
+        manages: vec![sp("coder".to_string())],
+        policies: vec![sp(WardPolicy {
+            failure_type: sp(FailureType::Stuck),
+            response: sp(WardResponse::Nudge),
+            scope: sp(WardScope::This),
+            after_clauses: vec![],
+        })],
+        max_retries: None,
+    };
+    let mut warden = Warden::new(decl, None);
+
+    let signal = FailureSignal {
+        agent_name: "coder".to_string(),
+        failure_type: FailureType::Contradiction,
+        detail: "[high] 2 contradictions found".to_string(),
+    };
+
+    // First contradiction — should get nudge from default policy
+    let action = warden.handle_failure(&signal, &[], 1000);
+    assert!(
+        action.is_some(),
+        "should fall back to default contradiction policy"
+    );
+    let a = action.unwrap();
+    assert_eq!(a.response, WardResponse::Nudge);
+    assert_eq!(a.scope, WardScope::This);
+    assert_eq!(a.retry_count, 1);
+}
+
+#[test]
+fn warden_contradiction_escalates_via_default_policy() {
+    let decl = WardenDecl {
+        name: sp("test_warden".to_string()),
+        manages: vec![sp("coder".to_string())],
+        policies: vec![], // No explicit policies at all
+        max_retries: None,
+    };
+    let mut warden = Warden::new(decl, None);
+
+    let signal = FailureSignal {
+        agent_name: "coder".to_string(),
+        failure_type: FailureType::Contradiction,
+        detail: "test".to_string(),
+    };
+
+    // Fire 2 failures — should escalate to restart
+    warden.handle_failure(&signal, &[], 1000);
+    let action = warden.handle_failure(&signal, &[], 2000).unwrap();
+    assert_eq!(action.response, WardResponse::Restart);
+
+    // Fire 2 more — should escalate to escalate (count = 4)
+    warden.handle_failure(&signal, &[], 3000);
+    let action = warden.handle_failure(&signal, &[], 4000).unwrap();
+    assert_eq!(action.response, WardResponse::Escalate);
+}
+
+#[test]
+fn warden_uses_explicit_contradiction_policy_over_default() {
+    let decl = WardenDecl {
+        name: sp("strict_warden".to_string()),
+        manages: vec![sp("coder".to_string())],
+        policies: vec![sp(WardPolicy {
+            failure_type: sp(FailureType::Contradiction),
+            response: sp(WardResponse::Escalate),
+            scope: sp(WardScope::All),
+            after_clauses: vec![],
+        })],
+        max_retries: None,
+    };
+    let mut warden = Warden::new(decl, None);
+
+    let signal = FailureSignal {
+        agent_name: "coder".to_string(),
+        failure_type: FailureType::Contradiction,
+        detail: "test".to_string(),
+    };
+
+    // Should use explicit policy (immediate escalate), not default (nudge)
+    let action = warden.handle_failure(&signal, &[], 1000).unwrap();
+    assert_eq!(action.response, WardResponse::Escalate);
+    assert_eq!(action.scope, WardScope::All);
+}
+
+#[test]
+fn warden_release_clears_contradiction_retry_state() {
+    let decl = WardenDecl {
+        name: sp("test_warden".to_string()),
+        manages: vec![sp("coder".to_string())],
+        policies: vec![],
+        max_retries: None,
+    };
+    let mut warden = Warden::new(decl, None);
+
+    let signal = FailureSignal {
+        agent_name: "coder".to_string(),
+        failure_type: FailureType::Contradiction,
+        detail: "test".to_string(),
+    };
+
+    warden.handle_failure(&signal, &[], 1000);
+    warden.handle_failure(&signal, &[], 2000);
+    assert_eq!(
+        warden
+            .retry_tracker
+            .count("coder", FailureType::Contradiction),
+        2
+    );
+
+    warden.release("coder");
+    assert_eq!(
+        warden
+            .retry_tracker
+            .count("coder", FailureType::Contradiction),
+        0
+    );
+}
+
+// ── ContradictionSummary Persistence ───────────────────────────
+
+#[test]
+fn contradiction_summary_serde_roundtrip() {
+    let summary = ContradictionSummary {
+        count: 3,
+        high_severity_count: 1,
+        max_severity: "high".to_string(),
+        verification_status: "contradicted".to_string(),
+        risk_class: "file_system".to_string(),
+    };
+
+    let json = serde_json::to_string(&summary).unwrap();
+    let deserialized: ContradictionSummary = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.count, 3);
+    assert_eq!(deserialized.high_severity_count, 1);
+    assert_eq!(deserialized.max_severity, "high");
+    assert_eq!(deserialized.verification_status, "contradicted");
+    assert_eq!(deserialized.risk_class, "file_system");
+}
+
+#[test]
+fn session_state_backward_compat_without_contradiction_summary() {
+    // Simulates loading a session JSON that was persisted before #205
+    // (no contradiction_summary field). The #[serde(default)] on the
+    // contradiction_summary field means old JSON files deserialize cleanly.
+    use forge::runtime::session_manager::SessionState;
+
+    // Build a minimal session state JSON without the contradiction_summary field.
+    let json = r#"{
+        "id": "session-123",
+        "config": {
+            "name": "test",
+            "agent": "coder",
+            "prompt": "fix bug",
+            "tools": [],
+            "timeout_secs": null,
+            "budget_usd": null,
+            "gives": null,
+            "cancel_timeout_secs": 30
+        },
+        "status": "Done",
+        "external_session_id": null,
+        "process_id": null,
+        "started_at": "2026-04-10T00:00:00Z",
+        "updated_at": "2026-04-10T00:00:00Z",
+        "cost_usd": 0.0,
+        "budget_exceeded": false,
+        "latest_progress": null,
+        "progress_events": [],
+        "output": null,
+        "error": null
+    }"#;
+
+    // Should deserialize cleanly with None for contradiction_summary
+    let loaded: SessionState = serde_json::from_str(json).unwrap();
+    assert!(loaded.contradiction_summary.is_none());
+    assert_eq!(loaded.id, "session-123");
+}
+
+// ── Executor: Verification Gate ────────────────────────────────
+
+fn make_agent_result_with_verification(
+    status: VerificationStatus,
+    risk: RiskClass,
+) -> ConfidentValue {
+    let vr = VerificationResult {
+        status,
+        claims: vec![],
+        evidence: vec![],
+        contradictions: if status == VerificationStatus::Contradicted {
+            vec![Contradiction::new(
+                Claim::new(
+                    ClaimKind::TaskComplete,
+                    "task done",
+                    0.9,
+                    ConfidenceSource::LLMDirect(0.9),
+                ),
+                Evidence::new(
+                    EvidenceKind::TestResult,
+                    "tests failed",
+                    EvidencePolarity::Contradicts,
+                    1.0,
+                ),
+                ContradictionSeverity::High,
+            )]
+        } else {
+            vec![]
+        },
+        risk_class: risk,
+    };
+
+    let mut meta = HashMap::new();
+    meta.insert(
+        "verification".to_string(),
+        ConfidentValue::deterministic(vr.to_value()),
+    );
+
+    let mut fields = HashMap::new();
+    fields.insert(
+        "plan".to_string(),
+        ConfidentValue::from_skill(Value::Text("fix bug".into()), 0.85),
+    );
+    fields.insert(
+        "metadata".to_string(),
+        ConfidentValue::deterministic(Value::Record(meta)),
+    );
+
+    ConfidentValue::from_agent_result(fields)
+}
+
+#[test]
+fn verification_gate_allows_verified_result() {
+    let result =
+        make_agent_result_with_verification(VerificationStatus::Verified, RiskClass::FileSystem);
+    assert!(TaskExecutor::check_verification_gate(&result, RiskClass::FileSystem).is_ok());
+}
+
+#[test]
+fn verification_gate_allows_verified_lower_risk() {
+    let result =
+        make_agent_result_with_verification(VerificationStatus::Verified, RiskClass::Informational);
+    assert!(TaskExecutor::check_verification_gate(&result, RiskClass::FileSystem).is_ok());
+}
+
+#[test]
+fn verification_gate_blocks_contradicted() {
+    let result = make_agent_result_with_verification(
+        VerificationStatus::Contradicted,
+        RiskClass::FileSystem,
+    );
+    let err = TaskExecutor::check_verification_gate(&result, RiskClass::ExternalSideEffect);
+    assert!(err.is_err());
+    let msg = format!("{}", err.unwrap_err());
+    assert!(
+        msg.contains("contradiction"),
+        "error should mention contradiction: {}",
+        msg
+    );
+}
+
+#[test]
+fn verification_gate_blocks_insufficient_for_external_side_effect() {
+    let result = make_agent_result_with_verification(
+        VerificationStatus::Insufficient,
+        RiskClass::FileSystem,
+    );
+    let err = TaskExecutor::check_verification_gate(&result, RiskClass::ExternalSideEffect);
+    assert!(err.is_err());
+    let msg = format!("{}", err.unwrap_err());
+    assert!(msg.contains("insufficient"), "error: {}", msg);
+}
+
+#[test]
+fn verification_gate_allows_insufficient_for_lower_risk() {
+    let result = make_agent_result_with_verification(
+        VerificationStatus::Insufficient,
+        RiskClass::FileSystem,
+    );
+    // FileSystem < ExternalSideEffect, so lower risk actions are allowed with insufficient
+    assert!(TaskExecutor::check_verification_gate(&result, RiskClass::FileSystem).is_ok());
+}
+
+#[test]
+fn verification_gate_allows_pending() {
+    let result =
+        make_agent_result_with_verification(VerificationStatus::Pending, RiskClass::Informational);
+    assert!(TaskExecutor::check_verification_gate(&result, RiskClass::ExternalSideEffect).is_ok());
+}
+
+#[test]
+fn verification_gate_blocks_error_status() {
+    let result =
+        make_agent_result_with_verification(VerificationStatus::Error, RiskClass::Informational);
+    let err = TaskExecutor::check_verification_gate(&result, RiskClass::FileSystem);
+    assert!(err.is_err());
+}
+
+#[test]
+fn verification_gate_allows_no_verification_metadata() {
+    // Plain result without any verification metadata — backward compat
+    let mut fields = HashMap::new();
+    fields.insert(
+        "plan".to_string(),
+        ConfidentValue::from_skill(Value::Text("fix bug".into()), 0.85),
+    );
+    let result = ConfidentValue::from_agent_result(fields);
+
+    assert!(TaskExecutor::check_verification_gate(&result, RiskClass::ExternalSideEffect).is_ok());
+}
+
+#[test]
+fn verification_gate_blocks_verified_but_high_risk() {
+    // Verified but risk_class exceeds allowed max
+    let result = make_agent_result_with_verification(
+        VerificationStatus::Verified,
+        RiskClass::ExternalSideEffect,
+    );
+    // Gate allows up to FileSystem, but result is ExternalSideEffect
+    let err = TaskExecutor::check_verification_gate(&result, RiskClass::FileSystem);
+    assert!(err.is_err());
+    let msg = format!("{}", err.unwrap_err());
+    assert!(msg.contains("risk class"), "error: {}", msg);
+}
+
+// ── EventBus Payload Shape ─────────────────────────────────────
+
+#[test]
+fn contradiction_detected_event_payload() {
+    use forge::runtime::session_manager::SessionEvent;
+
+    let event = SessionEvent::ContradictionDetected {
+        session_id: "sess-001".to_string(),
+        contradiction_count: 2,
+        high_severity_count: 1,
+        max_severity: "high".to_string(),
+        verification_status: "contradicted".to_string(),
+        risk_class: "file_system".to_string(),
+    };
+
+    // Verify the event carries all expected fields
+    match &event {
+        SessionEvent::ContradictionDetected {
+            session_id,
+            contradiction_count,
+            high_severity_count,
+            max_severity,
+            verification_status,
+            risk_class,
+        } => {
+            assert_eq!(session_id, "sess-001");
+            assert_eq!(*contradiction_count, 2);
+            assert_eq!(*high_severity_count, 1);
+            assert_eq!(max_severity, "high");
+            assert_eq!(verification_status, "contradicted");
+            assert_eq!(risk_class, "file_system");
+        }
+        _ => panic!("wrong event variant"),
+    }
+}

--- a/tests/verification_engine_tests.rs
+++ b/tests/verification_engine_tests.rs
@@ -1,0 +1,203 @@
+// Integration tests for the verification engine (issue #204).
+
+use std::collections::HashMap;
+
+use forge::runtime::confidence::{ConfidentValue, Value};
+use forge::runtime::verification::*;
+use forge::runtime::verification_engine::*;
+use forge::types::ConfidenceSource;
+
+fn text_cv(s: &str) -> ConfidentValue {
+    ConfidentValue::deterministic(Value::Text(s.to_string()))
+}
+
+fn num_cv(n: f64) -> ConfidentValue {
+    ConfidentValue::deterministic(Value::Number(n))
+}
+
+fn array_cv(items: Vec<&str>) -> ConfidentValue {
+    ConfidentValue::deterministic(Value::Array(items.iter().map(|s| text_cv(s)).collect()))
+}
+
+fn make_claim(kind: ClaimKind, desc: &str) -> Claim {
+    Claim::new(kind, desc, 0.9, ConfidenceSource::Deterministic)
+}
+
+// ── Full pipeline: verified scenario ────────────────────────
+
+#[tokio::test]
+async fn engine_verifies_valid_agent_result() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("src.rs"), "fn main() {}").unwrap();
+    std::fs::create_dir(dir.path().join(".git")).unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("plan".to_string(), text_cv("implement feature X"));
+    fields.insert("confidence".to_string(), num_cv(0.92));
+    fields.insert("files_changed".to_string(), array_cv(vec!["src.rs"]));
+
+    let claims = vec![
+        make_claim(ClaimKind::TaskInterpretation, "understood task"),
+        make_claim(ClaimKind::FilesChanged, "changed src.rs"),
+    ];
+
+    // Skip execution validator (no Cargo.toml in temp dir).
+    let mut engine = VerificationEngine::new();
+    engine.add(Box::new(SchemaValidator));
+    engine.add(Box::new(ReferenceValidator));
+    engine.add(Box::new(EnvironmentValidator));
+    engine.add(Box::new(PolicyValidator));
+
+    let ctx = VerificationContext {
+        working_dir: Some(dir.path().to_path_buf()),
+        agent_fields: fields,
+        claims,
+    };
+
+    let result = engine.verify(&ctx).await;
+
+    assert_eq!(result.status, VerificationStatus::Verified);
+    assert!(result.contradictions.is_empty());
+    assert_eq!(result.risk_class, RiskClass::FileSystem);
+    assert!(result.evidence.len() >= 3);
+}
+
+// ── Full pipeline: contradicted scenario ────────────────────
+
+#[tokio::test]
+async fn engine_contradicts_missing_files() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join(".git")).unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("plan".to_string(), text_cv("add new module"));
+    fields.insert("confidence".to_string(), num_cv(0.88));
+    fields.insert(
+        "files_changed".to_string(),
+        array_cv(vec!["new_module.rs", "tests/test_module.rs"]),
+    );
+
+    let claims = vec![make_claim(
+        ClaimKind::FilesChanged,
+        "changed new_module.rs and tests/test_module.rs",
+    )];
+
+    let mut engine = VerificationEngine::new();
+    engine.add(Box::new(SchemaValidator));
+    engine.add(Box::new(ReferenceValidator));
+
+    let ctx = VerificationContext {
+        working_dir: Some(dir.path().to_path_buf()),
+        agent_fields: fields,
+        claims,
+    };
+
+    let result = engine.verify(&ctx).await;
+
+    assert_eq!(result.status, VerificationStatus::Contradicted);
+    assert_eq!(result.contradictions.len(), 2); // one per missing file
+    assert!(result
+        .contradictions
+        .iter()
+        .all(|c| c.severity == ContradictionSeverity::High));
+}
+
+// ── Extract + inject round-trip with pending result ─────────
+
+#[test]
+fn extract_inject_resolves_pending_to_verified() {
+    // Build an AgentResult with pending verification.
+    let mut fields = ConfidentValue::default_agent_result_fields();
+    fields.insert("plan".to_string(), text_cv("fix bug"));
+    fields.insert("files_changed".to_string(), array_cv(vec!["lib.rs"]));
+
+    let claims = extract_implicit_claims(&fields);
+    let mut meta = HashMap::new();
+    inject_pending_verification(&mut meta, claims);
+    fields.insert(
+        "metadata".to_string(),
+        ConfidentValue::deterministic(Value::Record(meta)),
+    );
+
+    let agent_result = ConfidentValue::deterministic(Value::Record(fields));
+
+    // Extract inputs.
+    let (extracted_fields, extracted_claims) = extract_verification_inputs(&agent_result);
+    assert!(!extracted_claims.is_empty());
+    assert!(extracted_fields.contains_key("plan"));
+
+    // Simulate a resolved verification.
+    let resolved = VerificationResult {
+        status: VerificationStatus::Verified,
+        claims: extracted_claims,
+        evidence: vec![Evidence::new(
+            EvidenceKind::FileExists,
+            "lib.rs exists",
+            EvidencePolarity::Supports,
+            1.0,
+        )],
+        contradictions: Vec::new(),
+        risk_class: RiskClass::FileSystem,
+    };
+
+    let injected = inject_resolved_verification(agent_result, resolved);
+
+    // Verify the metadata now has the resolved status.
+    if let Value::Record(ref fields) = injected.value {
+        if let Some(meta_cv) = fields.get("metadata") {
+            if let Value::Record(ref meta) = meta_cv.value {
+                let vr = meta
+                    .get("verification")
+                    .and_then(|cv| VerificationResult::from_value(&cv.value))
+                    .expect("verification result should be present");
+                assert_eq!(vr.status, VerificationStatus::Verified);
+                assert_eq!(vr.risk_class, RiskClass::FileSystem);
+                assert!(!vr.evidence.is_empty());
+                return;
+            }
+        }
+    }
+    panic!("could not extract resolved verification from injected result");
+}
+
+// ── Insufficient when no claims ─────────────────────────────
+
+#[tokio::test]
+async fn engine_insufficient_with_empty_result() {
+    let engine = VerificationEngine::coding_session();
+    let ctx = VerificationContext {
+        working_dir: None,
+        agent_fields: HashMap::new(),
+        claims: Vec::new(),
+    };
+
+    let result = engine.verify(&ctx).await;
+    assert_eq!(result.status, VerificationStatus::Insufficient);
+    assert_eq!(result.risk_class, RiskClass::Informational);
+}
+
+// ── Risk classification ─────────────────────────────────────
+
+#[test]
+fn classify_risk_from_agent_fields() {
+    // Empty → Informational
+    assert_eq!(classify_risk(&HashMap::new()), RiskClass::Informational);
+
+    // files_changed → FileSystem
+    let mut fields = HashMap::new();
+    fields.insert("files_changed".to_string(), array_cv(vec!["main.rs"]));
+    assert_eq!(classify_risk(&fields), RiskClass::FileSystem);
+
+    // git_push in metadata → ExternalSideEffect
+    let mut fields2 = HashMap::new();
+    let mut meta = HashMap::new();
+    meta.insert(
+        "git_push".to_string(),
+        ConfidentValue::deterministic(Value::Bool(true)),
+    );
+    fields2.insert(
+        "metadata".to_string(),
+        ConfidentValue::deterministic(Value::Record(meta)),
+    );
+    assert_eq!(classify_risk(&fields2), RiskClass::ExternalSideEffect);
+}

--- a/tests/warden_tests.rs
+++ b/tests/warden_tests.rs
@@ -295,6 +295,7 @@ fn checker_full_coverage_no_warnings() {
   on stuck: nudge, self
   on crash: restart, all
   on hallucination: replace, downstream
+  on contradiction: nudge, self
   on budget: escalate, self
   on timeout: restart, self
 


### PR DESCRIPTION
## Summary
- Add `Contradiction` as a 6th failure type in FORGE grammar, AST, parser, and checker
- Wire `AgentSignal::Contradiction` through `WardedRuntime` to trigger warden policies
- Emit `SessionEvent::ContradictionDetected` + `session.contradiction` EventBus payload when verification finds contradictions
- Persist `ContradictionSummary` in `SessionState` for quick resume-time access
- Built-in default escalation policy: nudge → restart (after 2) → escalate (after 4) — fallback when no explicit `on contradiction:` policy exists
- Verification gate in executor: `check_verification_gate()` blocks high-risk actions when status is Contradicted/Error/Insufficient
- 23 new tests covering parser, checker, warden, session manager, persistence, executor gate, and event payload

## Design rationale
From the confidence/verification paper (Section 7.3): contradictions are semantically distinct from hallucinations. Hallucination = heuristic confidence detection during execution. Contradiction = deterministic evidence-based refutation after verification. Separate failure types allow operators to define different escalation ladders.

## Files changed (12 files, +899 -8)
- `grammar/forge.pest` — `contradiction` added to `failure_type` rule
- `src/ast.rs` — `FailureType::Contradiction` variant
- `src/parser.rs` — parser mapping
- `src/checker/warden_checker.rs` — coverage check includes contradiction
- `src/runtime/agent.rs` — `AgentSignal::Contradiction` + warden signal wiring to session manager
- `src/runtime/warden.rs` — `default_contradiction_policy()`, fallback in `handle_failure()`, `release()` update
- `src/runtime/warded.rs` — signal match arm for contradiction
- `src/runtime/session_manager.rs` — `ContradictionSummary`, `SessionEvent::ContradictionDetected`, warden signal channel, `mark_completed` integration, `session.contradiction` EventBus payload
- `src/runtime/executor.rs` — `check_verification_gate()` + `extract_verification_from_result()`
- `tests/contradiction_event_tests.rs` — 23 new tests
- `tests/warden_tests.rs` — updated for 6-type coverage
- `CHANGELOG.md` — updated

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all tests pass (900+ including 23 new)
- [x] Parser: `on contradiction: nudge, self` + escalation ladder
- [x] Checker: coverage warning includes "contradiction"
- [x] Warden: default policy fallback, escalation progression
- [x] Session: backward-compat deserialization without contradiction_summary
- [x] Executor: gate blocks contradicted, allows verified/pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)