### PR TITLE
feat: GitHub skill — gh CLI wrapper (SKILL.md) (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- GitHub skill — `gh` CLI wrapper with 8 typed capabilities: create-issue, list-issues, create-branch, create-pr, check-ci, merge-pr, delete-branch, close-issue (#176)
 - Contradiction events and warden integration: `Contradiction` failure type in grammar/AST/parser/checker, `AgentSignal::Contradiction` variant, `SessionEvent::ContradictionDetected` with `session.contradiction` EventBus payload, `ContradictionSummary` persisted in session state for resume, verification gate in executor blocking high-risk actions on contradicted results (#205)
 - Default contradiction escalation policy: nudge → restart (after 2) → escalate (after 4) — built-in fallback when no explicit `on contradiction:` warden policy exists (#205)
 - Warden signal channel in SessionManager: contradictions detected during session verification are automatically reported to the warden for policy resolution (#205)

--- a/examples/skills/forge.project.toml
+++ b/examples/skills/forge.project.toml
@@ -1,0 +1,10 @@
+[project]
+name = "github-skill-demo"
+version = "0.1.0"
+description = "Demonstrates the GitHub skill for gh CLI operations"
+
+[build]
+entry = "github_ops.forge"
+
+[skills]
+github = { path = "../../skills/github" }

--- a/examples/skills/github_ops.forge
+++ b/examples/skills/github_ops.forge
@@ -1,11 +1,13 @@
 # GitHub operations via the github skill.
 # Demonstrates creating, listing, and closing issues.
 #
-# Usage: forge run examples/skills/github_ops.forge
+# Usage: forge run --manifest examples/skills/forge.project.toml
 # Requires: gh auth login
 
 use
-  skill.github
+  skill.github.create_issue
+  skill.github.list_issues
+  skill.github.close_issue
 
 task create_test_issue
   needs repo: Text

--- a/examples/skills/github_ops.forge
+++ b/examples/skills/github_ops.forge
@@ -1,0 +1,37 @@
+# GitHub operations via the github skill.
+# Demonstrates creating, listing, and closing issues.
+#
+# Usage: forge run examples/skills/github_ops.forge
+# Requires: gh auth login
+
+use
+  skill.github
+
+task create_test_issue
+  needs repo: Text
+  gives Text
+  do
+    url = skill.github.create_issue(repo, "[test] Forge skill demo", "Automated issue from github_ops.forge — safe to close.")
+    when url.sure -> give url
+    else -> give "ERROR: could not create issue"
+
+task list_open_issues
+  needs repo: Text
+  gives Text
+  do
+    issues = skill.github.list_issues(repo, "--state open --limit 5")
+    when issues.sure -> give issues
+    else -> give "ERROR: could not list issues"
+
+task close_test_issue
+  needs repo: Text, issue_number: Text
+  gives Text
+  do
+    result = skill.github.close_issue(repo, issue_number)
+    when result.sure -> give result
+    else -> give "ERROR: could not close issue"
+
+fn main
+  say "=== GitHub Skill Demo ==="
+  say list_open_issues("ncmlabs/forge")
+  say "=== Done ==="

--- a/examples/skills/github_ops.forge
+++ b/examples/skills/github_ops.forge
@@ -5,9 +5,7 @@
 # Requires: gh auth login
 
 use
-  skill.github.create_issue
-  skill.github.list_issues
-  skill.github.close_issue
+  skill.github
 
 task create_test_issue
   needs repo: Text

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: github
+description: GitHub operations via the gh CLI — issues, PRs, branches, and CI checks.
+timeout: 120
+allowed-tools:
+  - Bash(gh:*)
+capabilities:
+  - name: create_issue
+    inputs: [Text, Text, Text]
+    output: Text
+  - name: list_issues
+    inputs: [Text, Text]
+    output: Text
+  - name: create_branch
+    inputs: [Text, Text]
+    output: Text
+  - name: create_pr
+    inputs: [Text, Text, Text, Text]
+    output: Text
+  - name: check_ci
+    inputs: [Text, Text]
+    output: Text
+  - name: merge_pr
+    inputs: [Text, Text]
+    output: Text
+  - name: delete_branch
+    inputs: [Text, Text]
+    output: Text
+  - name: close_issue
+    inputs: [Text, Text]
+    output: Text
+---
+
+# GitHub Skill
+
+Use this skill to perform GitHub operations via the `gh` CLI.
+Only run commands that start with `gh`. Do not run arbitrary shell commands.
+
+## Prerequisites
+
+The `gh` CLI must be installed and authenticated. Before any operation, verify:
+
+```bash
+gh auth status
+```
+
+If this fails, return `"ERROR: gh not authenticated. Run 'gh auth login' to authenticate."` and stop.
+
+## Capabilities
+
+### `create_issue(repo, title, body)`
+
+Create a new issue on a GitHub repository.
+
+```bash
+gh issue create -R "$repo" --title "$title" --body "$body"
+```
+
+Return the issue URL printed by `gh` on success.
+
+To add labels, append `--label "bug,urgent"`. To assign, append `--assignee "@me"`.
+
+### `list_issues(repo, filter)`
+
+List issues with optional filtering. The `filter` parameter accepts space-separated flags.
+
+```bash
+gh issue list -R "$repo" --json number,title,state,labels,assignees --limit 30
+```
+
+Common filters (append to command):
+- `--state open` or `--state closed`
+- `--label "bug"`
+- `--assignee "@me"`
+- `--search "query"`
+
+Return the JSON array output.
+
+### `create_branch(repo, branch_name)`
+
+Create a new branch from the default branch HEAD.
+
+```bash
+gh api "repos/$repo/git/refs" \
+  -f "ref=refs/heads/$branch_name" \
+  -f "sha=$(gh api "repos/$repo/git/ref/heads/main" -q '.object.sha')"
+```
+
+If the default branch is not `main`, first determine it:
+
+```bash
+gh repo view "$repo" --json defaultBranchRef -q '.defaultBranchRef.name'
+```
+
+Return confirmation with the branch name and SHA on success.
+
+### `create_pr(repo, branch, title, body)`
+
+Create a pull request from the given branch to the default branch.
+
+```bash
+gh pr create -R "$repo" --head "$branch" --title "$title" --body "$body"
+```
+
+To target a different base branch, append `--base "development"`.
+
+Return the PR URL printed by `gh` on success.
+
+### `check_ci(repo, ref)`
+
+Check CI status for a PR number or git ref.
+
+For a PR number:
+
+```bash
+gh pr checks "$ref" -R "$repo" --json name,state,conclusion
+```
+
+For a commit SHA:
+
+```bash
+gh run list -R "$repo" --commit "$ref" --json status,conclusion,name --limit 10
+```
+
+Return the JSON output. Summarize pass/fail counts if multiple checks exist.
+
+### `merge_pr(repo, pr_number)`
+
+Merge a pull request.
+
+First verify the PR is mergeable:
+
+```bash
+gh pr view "$pr_number" -R "$repo" --json mergeable,mergeStateStatus -q '.mergeable'
+```
+
+If mergeable, proceed:
+
+```bash
+gh pr merge "$pr_number" -R "$repo" --merge
+```
+
+Use `--merge` by default. Only use `--squash` or `--rebase` if the caller specifies it in the arguments.
+
+Return the merge result message.
+
+### `delete_branch(repo, branch_name)`
+
+Delete a remote branch.
+
+First verify the branch exists and is not the default branch:
+
+```bash
+gh api "repos/$repo/git/ref/heads/$branch_name" -q '.ref'
+```
+
+If it exists and is not the default branch:
+
+```bash
+gh api -X DELETE "repos/$repo/git/refs/heads/$branch_name"
+```
+
+Return confirmation or error.
+
+### `close_issue(repo, issue_number)`
+
+Close an issue.
+
+```bash
+gh issue close "$issue_number" -R "$repo"
+```
+
+To close with a comment:
+
+```bash
+gh issue close "$issue_number" -R "$repo" --comment "Closing: resolved"
+```
+
+Return confirmation message.
+
+## Error Handling
+
+### Authentication failures
+
+If `gh auth status` returns non-zero or any command returns `"not logged in"`:
+
+Return `"ERROR: gh not authenticated. Run 'gh auth login' to authenticate."` — do not retry.
+
+### Rate limits
+
+If a command returns `"API rate limit exceeded"` or HTTP 403 with rate-limit headers:
+
+Return `"ERROR: GitHub API rate limit exceeded. Retry after rate limit resets."` — do not retry.
+
+### Not found
+
+If a command returns `"Could not resolve"`, `"not found"`, or HTTP 404:
+
+Return `"ERROR: Resource not found — verify the repo, issue number, or branch name."` — do not guess alternatives.
+
+### Merge conflicts
+
+If `gh pr merge` fails with `"not mergeable"`, `"merge conflict"`, or `"blocked"`:
+
+Return `"ERROR: PR cannot be merged — conflicts or failing checks. Resolve before retrying."` — do not force merge.
+
+## Safety Rules
+
+- Only run commands starting with `gh`. No arbitrary shell commands.
+- Never force-push or delete the default branch.
+- Always verify a resource exists before attempting destructive operations (delete_branch, merge_pr).
+- Use `--merge` strategy by default. Only use `--squash` or `--rebase` when explicitly requested.
+- Return the full `gh` command that was run alongside the result for auditability.
+- Do not store or log authentication tokens.
+
+## Session Adapter Mapping
+
+| FORGE session field | gh CLI |
+|---|---|
+| `repo` | `-R "$repo"` flag on all commands |
+| `output_mode = json` | `--json` flag for structured output |
+| `timeout` | Managed by FORGE skill executor |
+| `auth` | `gh auth status` pre-check |
+
+## AgentResult Mapping
+
+| gh output | AgentResult field |
+|---|---|
+| Issue/PR URL | `output` |
+| JSON list | `output` (structured) |
+| Error message | `output` (prefixed with `ERROR:`) |
+| Command executed | `metadata.command` |

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -281,6 +281,13 @@ impl CapabilityRegistry {
     pub fn resolve(&self, name: &str) -> Option<&CapabilitySignature> {
         self.capabilities.get(name)
     }
+
+    /// Check if `name` is a namespace prefix for one or more capabilities.
+    /// e.g. "skill.github" matches "skill.github.create_issue", "skill.github.list_issues", etc.
+    pub fn has_namespace(&self, name: &str) -> bool {
+        let prefix = format!("{}.", name);
+        self.capabilities.keys().any(|k| k.starts_with(&prefix))
+    }
 }
 
 // ── Check context ────────────────────────────────────────────
@@ -315,7 +322,9 @@ impl CheckContext {
         for item in &program.items {
             if let TopLevel::Use(use_decl) = &item.node {
                 for cap in &use_decl.capabilities {
-                    if self.registry.resolve(&cap.node).is_none() {
+                    if self.registry.resolve(&cap.node).is_none()
+                        && !self.registry.has_namespace(&cap.node)
+                    {
                         self.errors.push(ResolveError::UnknownCapability {
                             name: cap.node.clone(),
                             span_start: cap.span.start,

--- a/src/runtime/skill_executor.rs
+++ b/src/runtime/skill_executor.rs
@@ -345,11 +345,11 @@ impl SkillExecutor {
         let has_bash = allowed_tools.is_empty()
             || allowed_tools
                 .iter()
-                .any(|t| t == "Bash" || t == "bash_exec");
+                .any(|t| t == "Bash" || t == "bash_exec" || t.starts_with("Bash("));
         let has_http = allowed_tools.is_empty()
             || allowed_tools
                 .iter()
-                .any(|t| t == "WebFetch" || t == "http_request");
+                .any(|t| t == "WebFetch" || t == "http_request" || t.starts_with("WebFetch("));
 
         if has_bash {
             tools.push(ToolDefinition {

--- a/tests/skill_e2e_test.rs
+++ b/tests/skill_e2e_test.rs
@@ -112,6 +112,106 @@ async fn skill_e2e_mock_tool_use() {
     );
 }
 
+// ── E2E: GitHub skill live integration (requires gh auth) ──────
+
+#[tokio::test]
+#[ignore] // Run with: cargo test github_e2e -- --ignored
+async fn github_e2e_create_verify_close() {
+    // Skip if gh is not authenticated
+    let auth = std::process::Command::new("gh")
+        .args(["auth", "status"])
+        .output();
+    match auth {
+        Ok(o) if o.status.success() => {}
+        _ => {
+            eprintln!("Skipping: gh not authenticated");
+            return;
+        }
+    }
+
+    let repo = "ncmlabs/forge";
+    let test_title = "[test] Integration test issue — safe to close";
+    let test_body = "Automated integration test for GitHub skill (#176). This issue will be closed automatically.";
+
+    // Step 1: Create issue
+    let create = std::process::Command::new("gh")
+        .args([
+            "issue", "create", "-R", repo, "--title", test_title, "--body", test_body,
+        ])
+        .output()
+        .expect("gh issue create failed");
+    assert!(
+        create.status.success(),
+        "create issue failed: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+    let issue_url = String::from_utf8_lossy(&create.stdout).trim().to_string();
+    assert!(
+        issue_url.contains("/issues/"),
+        "expected issue URL, got: {}",
+        issue_url
+    );
+
+    // Extract issue number from URL
+    let issue_number = issue_url
+        .rsplit('/')
+        .next()
+        .expect("could not extract issue number");
+
+    // Step 2: Verify issue exists via list
+    let list = std::process::Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "-R",
+            repo,
+            "--json",
+            "number,title",
+            "--search",
+            test_title,
+        ])
+        .output()
+        .expect("gh issue list failed");
+    assert!(list.status.success());
+    let list_output = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        list_output.contains(issue_number),
+        "created issue {} not found in list: {}",
+        issue_number,
+        list_output
+    );
+
+    // Step 3: Close the issue
+    let close = std::process::Command::new("gh")
+        .args(["issue", "close", issue_number, "-R", repo])
+        .output()
+        .expect("gh issue close failed");
+    assert!(
+        close.status.success(),
+        "close issue failed: {}",
+        String::from_utf8_lossy(&close.stderr)
+    );
+
+    // Step 4: Verify closed
+    let view = std::process::Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            issue_number,
+            "-R",
+            repo,
+            "--json",
+            "state",
+            "-q",
+            ".state",
+        ])
+        .output()
+        .expect("gh issue view failed");
+    assert!(view.status.success());
+    let state = String::from_utf8_lossy(&view.stdout).trim().to_string();
+    assert_eq!(state, "CLOSED", "issue should be closed, got: {}", state);
+}
+
 // ── Mock provider: multi-turn sequence drains correctly ─────────
 
 #[tokio::test]

--- a/tests/skill_e2e_test.rs
+++ b/tests/skill_e2e_test.rs
@@ -13,6 +13,7 @@ use forge::llm::ToolCallRequest;
 use forge::runtime::skill_executor::SkillExecutor;
 use forge::runtime::skill_loader::SkillLoader;
 use forge::runtime::skill_registry::SkillRegistry;
+use forge::tracer::Tracer;
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -230,6 +231,7 @@ async fn mock_tool_call_sequence_drains() {
         ]);
 
     let providers = mock_registry(mock);
+    let _tracer = Tracer::with_capture(); // Principle VIII: trace oracle calls
 
     // Turn 1: should have tool calls
     let req = forge::llm::CompletionRequest::simple("test");

--- a/tests/skill_e2e_test.rs
+++ b/tests/skill_e2e_test.rs
@@ -159,27 +159,30 @@ async fn github_e2e_create_verify_close() {
         .next()
         .expect("could not extract issue number");
 
-    // Step 2: Verify issue exists via list
-    let list = std::process::Command::new("gh")
+    // Step 2: Verify issue exists via direct view (avoids search index lag)
+    let view = std::process::Command::new("gh")
         .args([
             "issue",
-            "list",
+            "view",
+            issue_number,
             "-R",
             repo,
             "--json",
-            "number,title",
-            "--search",
-            test_title,
+            "number,title,state",
         ])
         .output()
-        .expect("gh issue list failed");
-    assert!(list.status.success());
-    let list_output = String::from_utf8_lossy(&list.stdout);
+        .expect("gh issue view failed");
     assert!(
-        list_output.contains(issue_number),
-        "created issue {} not found in list: {}",
+        view.status.success(),
+        "issue {} not found: {}",
         issue_number,
-        list_output
+        String::from_utf8_lossy(&view.stderr)
+    );
+    let view_output = String::from_utf8_lossy(&view.stdout);
+    assert!(
+        view_output.contains("OPEN"),
+        "issue should be open, got: {}",
+        view_output
     );
 
     // Step 3: Close the issue

--- a/tests/skill_integration_tests.rs
+++ b/tests/skill_integration_tests.rs
@@ -707,6 +707,39 @@ fn use_skill_validated_at_compile_time() {
 }
 
 #[test]
+fn use_skill_namespace_imports_all_typed_capabilities() {
+    // `use skill.github` should pass when typed capabilities like
+    // skill.github.create_issue, skill.github.list_issues exist
+    let source = "use\n  skill.github\n\ntask run\n  gives Text\n  do\n    give skill.github.create_issue(\"repo\", \"title\", \"body\")\n";
+    let program = forge::parser::parse(source).unwrap();
+
+    let mut sigs = std::collections::HashMap::new();
+    sigs.insert(
+        "skill.github.create_issue".into(),
+        forge::types::CapabilitySignature {
+            inputs: vec![
+                forge::types::ForgeType::Text,
+                forge::types::ForgeType::Text,
+                forge::types::ForgeType::Text,
+            ],
+            output: forge::types::ForgeType::Text,
+        },
+    );
+    sigs.insert(
+        "skill.github.list_issues".into(),
+        forge::types::CapabilitySignature {
+            inputs: vec![forge::types::ForgeType::Text, forge::types::ForgeType::Text],
+            output: forge::types::ForgeType::Text,
+        },
+    );
+    let ctx = forge::resolver::CheckContext::with_skills("test.forge", sigs);
+    assert!(
+        ctx.check(&program).is_ok(),
+        "use skill.github should pass when typed capabilities exist under that namespace"
+    );
+}
+
+#[test]
 fn use_typed_skill_capability_validated_at_compile_time() {
     let source = "use\n  skill.github.create_issue\n\ntask run\n  gives Text\n  do\n    give skill.github.create_issue(\"repo\", \"title\", \"body\")\n";
     let program = forge::parser::parse(source).unwrap();

--- a/tests/skill_integration_tests.rs
+++ b/tests/skill_integration_tests.rs
@@ -94,6 +94,7 @@ fn skill_loader_parses_repo_reference_cli_skills() {
     for (path, expected_name, expected_capabilities) in [
         ("skills/claude-code/SKILL.md", "claude", 4usize),
         ("skills/codex/SKILL.md", "codex", 4usize),
+        ("skills/github/SKILL.md", "github", 8usize),
     ] {
         let skill = SkillLoader::parse_skill_md(Path::new(path)).unwrap();
         assert_eq!(skill.manifest.name, expected_name);
@@ -160,6 +161,73 @@ fn skill_loader_discovers_multiple_skills() {
     let names: Vec<&str> = skills.iter().map(|s| s.manifest.name.as_str()).collect();
     assert!(names.contains(&"skill-a"));
     assert!(names.contains(&"skill-b"));
+}
+
+#[test]
+fn skill_loader_parses_github_skill() {
+    let skill = SkillLoader::parse_skill_md(Path::new("skills/github/SKILL.md")).unwrap();
+    assert_eq!(skill.manifest.name, "github");
+    assert_eq!(skill.manifest.capabilities.len(), 8);
+    assert!(
+        skill.manifest.legacy_signature.is_none(),
+        "typed skill should not have legacy signature"
+    );
+    assert_eq!(skill.manifest.timeout_secs, 120);
+    assert!(
+        skill
+            .manifest
+            .allowed_tools
+            .iter()
+            .any(|t| t.contains("gh")),
+        "allowed-tools should reference gh"
+    );
+    let cap_names: Vec<&str> = skill
+        .manifest
+        .capabilities
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    for expected in [
+        "create_issue",
+        "list_issues",
+        "create_branch",
+        "create_pr",
+        "check_ci",
+        "merge_pr",
+        "delete_branch",
+        "close_issue",
+    ] {
+        assert!(
+            cap_names.contains(&expected),
+            "missing capability: {}",
+            expected
+        );
+    }
+}
+
+#[test]
+fn github_skill_registers_all_capabilities() {
+    let skill = SkillLoader::parse_skill_md(Path::new("skills/github/SKILL.md")).unwrap();
+    let mut registry = SkillRegistry::new();
+    registry.register(skill);
+
+    let sigs = registry.capability_signatures();
+    for cap in [
+        "skill.github.create_issue",
+        "skill.github.list_issues",
+        "skill.github.create_branch",
+        "skill.github.create_pr",
+        "skill.github.check_ci",
+        "skill.github.merge_pr",
+        "skill.github.delete_branch",
+        "skill.github.close_issue",
+    ] {
+        assert!(sigs.contains_key(cap), "missing signature for {}", cap);
+    }
+    assert!(
+        !sigs.contains_key("skill.github"),
+        "typed skill should not have legacy entry"
+    );
 }
 
 // ── Skill Registry Tests ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `skills/github/SKILL.md` with 8 typed capabilities for GitHub operations via the `gh` CLI: create-issue, list-issues, create-branch, create-pr, check-ci, merge-pr, delete-branch, close-issue
- Error handling guidance for auth failures, rate limits, merge conflicts, and not-found errors
- `Bash(gh:*)` allowed-tools frontmatter, multi-capability typed signatures
- Loader/registry tests validating all 8 capabilities parse and register correctly
- Live E2E integration test (`#[ignore]`) for create-issue → verify → close lifecycle
- Example `.forge` file demonstrating `skill.github` usage

Closes #176

## Test plan

- [x] `cargo test --test skill_integration_tests` — 27 tests pass (including 2 new: `skill_loader_parses_github_skill`, `github_skill_registers_all_capabilities`)
- [x] `cargo test --test skill_e2e_test` — 2 pass, 1 ignored (live gh test)
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets` — clean
- [ ] Manual: `cargo test github_e2e -- --ignored` with `gh` authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)