### PR TITLE
feat: Slack skill — bidirectional Web API via curl (SKILL.md) (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- Slack skill — bidirectional Web API via `curl` with 13 typed capabilities: send-message, send-rich-message (Block Kit), reply-thread, add-reaction, list-channels, read-history (incremental polling), read-thread, detect-mentions, send-approval (interactive buttons + webhook callback), edit-message, delete-message, pin-message, member-info (#177)
 - GitHub skill — `gh` CLI wrapper with 8 typed capabilities: create-issue, list-issues, create-branch, create-pr, check-ci, merge-pr, delete-branch, close-issue (#176)
 - Contradiction events and warden integration: `Contradiction` failure type in grammar/AST/parser/checker, `AgentSignal::Contradiction` variant, `SessionEvent::ContradictionDetected` with `session.contradiction` EventBus payload, `ContradictionSummary` persisted in session state for resume, verification gate in executor blocking high-risk actions on contradicted results (#205)
 - Default contradiction escalation policy: nudge → restart (after 2) → escalate (after 4) — built-in fallback when no explicit `on contradiction:` warden policy exists (#205)

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,0 +1,472 @@
+---
+name: slack
+description: Slack operations via the Web API — messages, channels, threads, reactions, and approvals.
+timeout: 120
+allowed-tools:
+  - Bash(curl:*)
+capabilities:
+  - name: send_message
+    inputs: [Text, Text]
+    output: Text
+  - name: send_rich_message
+    inputs: [Text, Text]
+    output: Text
+  - name: reply_thread
+    inputs: [Text, Text, Text]
+    output: Text
+  - name: add_reaction
+    inputs: [Text, Text, Text]
+    output: Text
+  - name: list_channels
+    inputs: [Text]
+    output: Text
+  - name: read_history
+    inputs: [Text, Text, Text]
+    output: Text
+  - name: read_thread
+    inputs: [Text, Text]
+    output: Text
+  - name: detect_mentions
+    inputs: [Text, Text]
+    output: Text
+  - name: send_approval
+    inputs: [Text, Text, Text]
+    output: Text
+  - name: edit_message
+    inputs: [Text, Text, Text]
+    output: Text
+  - name: delete_message
+    inputs: [Text, Text]
+    output: Text
+  - name: pin_message
+    inputs: [Text, Text]
+    output: Text
+  - name: member_info
+    inputs: [Text]
+    output: Text
+---
+
+# Slack Skill
+
+Use this skill to interact with Slack workspaces via the Web API and `curl`.
+Only run commands that start with `curl` targeting `https://slack.com/api/`. Do not run arbitrary shell commands.
+
+## Prerequisites
+
+The `SLACK_BOT_TOKEN` environment variable must be set to a valid bot token (`xoxb-...`).
+
+Before any operation, verify the token:
+
+```bash
+curl -s "https://slack.com/api/auth.test" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN"
+```
+
+If the response contains `"ok": false`, return `"ERROR: Slack auth failed. Check SLACK_BOT_TOKEN."` and stop.
+
+### Required Bot Token Scopes
+
+| Scope | Used by |
+|---|---|
+| `chat:write` | send_message, send_rich_message, reply_thread, edit_message, delete_message |
+| `channels:history` | read_history, read_thread, detect_mentions (public channels) |
+| `groups:history` | read_history, read_thread, detect_mentions (private channels) |
+| `im:history` | read_history (DMs) |
+| `mpim:history` | read_history (group DMs) |
+| `channels:read` | list_channels (public) |
+| `groups:read` | list_channels (private) |
+| `im:read` | list_channels (DMs) |
+| `mpim:read` | list_channels (group DMs) |
+| `reactions:write` | add_reaction |
+| `pins:write` | pin_message |
+| `users:read` | member_info |
+
+### Bot Token Setup
+
+1. Go to https://api.slack.com/apps and click **Create New App** → **From scratch**
+2. Under **OAuth & Permissions**, add the scopes listed above to **Bot Token Scopes**
+3. Click **Install to Workspace** and authorize
+4. Copy the **Bot User OAuth Token** (`xoxb-...`) and set it as `SLACK_BOT_TOKEN`
+5. Invite the bot to channels it needs to access: `/invite @YourBotName`
+
+## Capabilities
+
+### `send_message(channel, text)`
+
+Send a plain-text message to a channel or DM.
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "text": "Hello from FORGE"
+  }'
+```
+
+Return the `ts` (message timestamp) from the response on success. This `ts` is the message ID used by other capabilities.
+
+### `send_rich_message(channel, blocks_json)`
+
+Send a message with Block Kit layout blocks for rich formatting.
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "text": "Fallback text for notifications",
+    "blocks": [
+      {
+        "type": "header",
+        "text": {"type": "plain_text", "text": "Deploy Report"}
+      },
+      {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "*Status:* All checks passed\n*Branch:* `main`\n*Commit:* `abc1234`"}
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "View the full report:"},
+        "accessory": {
+          "type": "button",
+          "text": {"type": "plain_text", "text": "Open Dashboard"},
+          "url": "https://example.com/dashboard"
+        }
+      }
+    ]
+  }'
+```
+
+Always include a `text` field as fallback for notifications and accessibility. The `blocks` array accepts any valid Block Kit layout block — see https://api.slack.com/reference/block-kit/blocks.
+
+Return the `ts` on success.
+
+### `reply_thread(channel, thread_ts, text)`
+
+Reply to a message in a thread. The `thread_ts` is the `ts` of the parent message.
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "thread_ts": "1712023032.123400",
+    "text": "Thread reply from FORGE"
+  }'
+```
+
+To also broadcast the reply to the channel, add `"reply_broadcast": true`. Use sparingly — only when everyone needs visibility.
+
+Return the `ts` on success.
+
+### `add_reaction(channel, timestamp, emoji)`
+
+Add an emoji reaction to a message. Use the emoji name without colons.
+
+```bash
+curl -s -X POST "https://slack.com/api/reactions.add" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "timestamp": "1712023032.123400",
+    "name": "white_check_mark"
+  }'
+```
+
+Common emoji names: `white_check_mark`, `eyes`, `thumbsup`, `thumbsdown`, `rocket`, `warning`, `x`.
+
+Return confirmation on success.
+
+### `list_channels(filter)`
+
+List channels the bot has access to. The `filter` parameter sets the channel types to include.
+
+```bash
+curl -s "https://slack.com/api/conversations.list" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  --data-urlencode "types=public_channel,private_channel" \
+  --data-urlencode "exclude_archived=true" \
+  --data-urlencode "limit=200"
+```
+
+Valid types: `public_channel`, `private_channel`, `mpim` (group DMs), `im` (DMs).
+
+The response includes a `channels` array with `id`, `name`, `purpose`, `topic`, and `num_members`.
+
+For pagination, if `response_metadata.next_cursor` is non-empty, pass it as `cursor` in the next request:
+
+```bash
+curl -s "https://slack.com/api/conversations.list" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  --data-urlencode "types=public_channel" \
+  --data-urlencode "cursor=dXNlcjpVMDYxTkZUVDI=" \
+  --data-urlencode "limit=200"
+```
+
+Return the JSON array of channels.
+
+### `read_history(channel, oldest, limit)`
+
+Read messages from a channel. Use `oldest` (Unix timestamp) for incremental polling — only messages after that timestamp are returned.
+
+```bash
+curl -s "https://slack.com/api/conversations.history" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  --data-urlencode "channel=C0123456789" \
+  --data-urlencode "oldest=1712023032.000000" \
+  --data-urlencode "limit=50"
+```
+
+Omit `oldest` to get the most recent messages. The response `messages` array is in reverse chronological order (newest first). Each message has `ts`, `user`, `text`, and optionally `thread_ts` (if it is a thread parent or reply).
+
+For pagination, check `has_more` and use `response_metadata.next_cursor`.
+
+Return the JSON messages array.
+
+### `read_thread(channel, thread_ts)`
+
+Read all replies in a thread. The `thread_ts` is the parent message timestamp.
+
+```bash
+curl -s "https://slack.com/api/conversations.replies" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  --data-urlencode "channel=C0123456789" \
+  --data-urlencode "ts=1712023032.123400"
+```
+
+The first message in the response is the thread parent. Subsequent messages are replies in chronological order.
+
+Return the JSON messages array.
+
+### `detect_mentions(channel, oldest)`
+
+Read channel history and filter for messages that @mention the bot. This is a composite operation.
+
+Step 1 — Get the bot user ID:
+
+```bash
+curl -s "https://slack.com/api/auth.test" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" | jq -r '.user_id'
+```
+
+Step 2 — Read history and filter for mentions:
+
+```bash
+curl -s "https://slack.com/api/conversations.history" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  --data-urlencode "channel=C0123456789" \
+  --data-urlencode "oldest=1712023032.000000" \
+  --data-urlencode "limit=100" \
+  | jq '[.messages[] | select(.text | contains("<@BOT_USER_ID>"))]'
+```
+
+Replace `BOT_USER_ID` with the value from Step 1. Store the latest `ts` from the results to use as `oldest` in the next poll cycle.
+
+Return the filtered messages array.
+
+### `send_approval(channel, text, callback_url)`
+
+Send a message with interactive Approve/Reject buttons. When a user clicks a button, Slack sends a POST to the `callback_url` with the action payload.
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "text": "Approval required: Deploy v2.1.0 to production",
+    "blocks": [
+      {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "*Approval Required*\nDeploy v2.1.0 to production"}
+      },
+      {
+        "type": "actions",
+        "block_id": "approval_actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Approve"},
+            "style": "primary",
+            "action_id": "approve",
+            "value": "approved"
+          },
+          {
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Reject"},
+            "style": "danger",
+            "action_id": "reject",
+            "value": "rejected"
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+To receive button clicks, configure an **Interactivity Request URL** in your Slack app settings (https://api.slack.com/apps → your app → **Interactivity & Shortcuts** → set the Request URL to your `callback_url`).
+
+When a user clicks a button, Slack POSTs a JSON payload to the callback URL containing `actions[0].action_id` (`approve` or `reject`) and `user.id` (who clicked).
+
+Return the `ts` on success.
+
+### `edit_message(channel, timestamp, text)`
+
+Update an existing message. The bot can only edit messages it posted.
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.update" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "ts": "1712023032.123400",
+    "text": "Updated message text"
+  }'
+```
+
+Return confirmation on success.
+
+### `delete_message(channel, timestamp)`
+
+Delete a message. The bot can only delete messages it posted (unless it has `chat:write.public` scope).
+
+```bash
+curl -s -X POST "https://slack.com/api/chat.delete" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "ts": "1712023032.123400"
+  }'
+```
+
+Return confirmation on success.
+
+### `pin_message(channel, timestamp)`
+
+Pin a message to a channel.
+
+```bash
+curl -s -X POST "https://slack.com/api/pins.add" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel": "C0123456789",
+    "timestamp": "1712023032.123400"
+  }'
+```
+
+Return confirmation on success.
+
+### `member_info(user_id)`
+
+Get profile information for a Slack user.
+
+```bash
+curl -s "https://slack.com/api/users.info" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  --data-urlencode "user=U0123456789"
+```
+
+The response `user` object includes `real_name`, `display_name`, `email` (if `users:read.email` scope is added), `title`, `status_text`, and `tz`.
+
+Return the user profile JSON.
+
+## Rate Limit Guidance
+
+Slack uses tiered rate limits. The relevant tiers for this skill:
+
+| Tier | Limit | Methods |
+|---|---|---|
+| Tier 2 | ~20 req/min | `chat.postMessage`, `chat.update`, `chat.delete`, `reactions.add`, `pins.add` |
+| Tier 3 | ~50 req/min | `conversations.history`, `conversations.list`, `conversations.replies` |
+| Tier 4 | ~100 req/min | `users.info`, `auth.test` |
+
+When rate-limited, the API returns HTTP 429 with a `Retry-After` header (seconds to wait). Respect it:
+
+```bash
+# Check for rate limiting in response headers
+curl -s -D - "https://slack.com/api/conversations.history" \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  --data-urlencode "channel=C0123456789" \
+  --data-urlencode "limit=50" \
+  | head -20
+```
+
+If you see `HTTP/2 429`, wait the number of seconds in `Retry-After` before retrying.
+
+For bulk operations (reading many channels), add 1-second delays between requests to stay well under limits.
+
+## Error Handling
+
+### Authentication failures
+
+If any request returns `"error": "not_authed"` or `"error": "invalid_auth"`:
+
+Return `"ERROR: Slack auth failed. Verify SLACK_BOT_TOKEN is set and valid."` — do not retry.
+
+### Missing scopes
+
+If a request returns `"error": "missing_scope"` with a `"needed"` field:
+
+Return `"ERROR: Missing Slack scope '<needed>'. Add it at https://api.slack.com/apps under OAuth & Permissions."` — do not retry.
+
+### Channel not found
+
+If a request returns `"error": "channel_not_found"`:
+
+Return `"ERROR: Channel not found. Verify the channel ID and that the bot is a member."` — do not guess alternatives.
+
+### Bot not in channel
+
+If a request returns `"error": "not_in_channel"`:
+
+Return `"ERROR: Bot is not in this channel. Invite it with /invite @BotName in Slack."` — do not retry.
+
+### Rate limited
+
+If a request returns HTTP 429 or `"error": "ratelimited"`:
+
+Return `"ERROR: Rate limited. Retry after <Retry-After> seconds."` — wait before retrying.
+
+### Message not found
+
+If `chat.update` or `chat.delete` returns `"error": "message_not_found"`:
+
+Return `"ERROR: Message not found. Verify the channel and timestamp."` — do not retry.
+
+## Safety Rules
+
+- Only run `curl` commands targeting `https://slack.com/api/*`. No other URLs.
+- Never log, echo, or print `$SLACK_BOT_TOKEN` in output.
+- Do not run arbitrary shell commands beyond `curl` and `jq` for parsing.
+- Return the curl command that was run alongside the result for auditability (with the token replaced by `$SLACK_BOT_TOKEN`).
+- Do not delete messages you did not post unless explicitly instructed.
+- Do not store or cache message content outside the current session.
+
+## Session Adapter Mapping
+
+| FORGE session field | curl mapping |
+|---|---|
+| `channel` | `"channel"` in JSON body or `channel` query param |
+| `token` | `Authorization: Bearer $SLACK_BOT_TOKEN` header |
+| `output_mode = json` | All Slack API responses are JSON by default |
+| `timeout` | Managed by FORGE skill executor |
+
+## AgentResult Mapping
+
+| Slack API response | AgentResult field |
+|---|---|
+| `ts` (message timestamp) | `output` |
+| JSON array (messages, channels) | `output` (structured) |
+| `"ok": false` with `"error"` | `output` (prefixed with `ERROR:`) |
+| curl command executed | `metadata.command` |

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -190,7 +190,7 @@ Return confirmation on success.
 List channels the bot has access to. The `filter` parameter sets the channel types to include.
 
 ```bash
-curl -s "https://slack.com/api/conversations.list" \
+curl -s -G "https://slack.com/api/conversations.list" \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   --data-urlencode "types=public_channel,private_channel" \
   --data-urlencode "exclude_archived=true" \
@@ -204,7 +204,7 @@ The response includes a `channels` array with `id`, `name`, `purpose`, `topic`, 
 For pagination, if `response_metadata.next_cursor` is non-empty, pass it as `cursor` in the next request:
 
 ```bash
-curl -s "https://slack.com/api/conversations.list" \
+curl -s -G "https://slack.com/api/conversations.list" \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   --data-urlencode "types=public_channel" \
   --data-urlencode "cursor=dXNlcjpVMDYxTkZUVDI=" \
@@ -218,7 +218,7 @@ Return the JSON array of channels.
 Read messages from a channel. Use `oldest` (Unix timestamp) for incremental polling — only messages after that timestamp are returned.
 
 ```bash
-curl -s "https://slack.com/api/conversations.history" \
+curl -s -G "https://slack.com/api/conversations.history" \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   --data-urlencode "channel=C0123456789" \
   --data-urlencode "oldest=1712023032.000000" \
@@ -236,7 +236,7 @@ Return the JSON messages array.
 Read all replies in a thread. The `thread_ts` is the parent message timestamp.
 
 ```bash
-curl -s "https://slack.com/api/conversations.replies" \
+curl -s -G "https://slack.com/api/conversations.replies" \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   --data-urlencode "channel=C0123456789" \
   --data-urlencode "ts=1712023032.123400"
@@ -260,7 +260,7 @@ curl -s "https://slack.com/api/auth.test" \
 Step 2 — Read history and filter for mentions:
 
 ```bash
-curl -s "https://slack.com/api/conversations.history" \
+curl -s -G "https://slack.com/api/conversations.history" \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   --data-urlencode "channel=C0123456789" \
   --data-urlencode "oldest=1712023032.000000" \
@@ -372,7 +372,7 @@ Return confirmation on success.
 Get profile information for a Slack user.
 
 ```bash
-curl -s "https://slack.com/api/users.info" \
+curl -s -G "https://slack.com/api/users.info" \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   --data-urlencode "user=U0123456789"
 ```
@@ -395,7 +395,7 @@ When rate-limited, the API returns HTTP 429 with a `Retry-After` header (seconds
 
 ```bash
 # Check for rate limiting in response headers
-curl -s -D - "https://slack.com/api/conversations.history" \
+curl -s -D - -G "https://slack.com/api/conversations.history" \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   --data-urlencode "channel=C0123456789" \
   --data-urlencode "limit=50" \


### PR DESCRIPTION
## Summary
- Adds `skills/slack/SKILL.md` — zero-dependency Slack integration using `curl` + bot token (`xoxb-`)
- **13 capabilities**: send_message, send_rich_message (Block Kit), reply_thread, add_reaction, list_channels, read_history (incremental polling via `oldest`), read_thread, detect_mentions, send_approval (interactive buttons + webhook callback), edit_message, delete_message, pin_message, member_info
- Follows the same SKILL.md pattern as `skills/github/SKILL.md` with frontmatter, capabilities, error handling, rate limits, and safety rules
- Bonus capabilities (edit/delete/pin/member_info) inspired by OpenClaw's Slack skill

## Acceptance Criteria (from #177)
- [x] `skills/slack/SKILL.md` following Anthropic SKILL.md spec
- [x] **Outbound**: chat.postMessage, Block Kit (rich messages), threaded replies, reactions.add
- [x] **Inbound**: conversations.history (with oldest param for incremental polling), parse JSON, detect @mentions, conversations.list
- [x] **Approval flow**: send message with approve/reject buttons + webhook callback URL
- [x] Authentication docs: bot token setup, required scopes (chat:write, channels:history, channels:read, reactions:write, pins:write, users:read)
- [x] Rate limit guidance (Tier 2: 20 req/min posting, Tier 3: 50 req/min history, Tier 4: 100 req/min users)
- [x] `allowed-tools: Bash(curl:*)` in frontmatter

## Test plan
- [ ] Verify SKILL.md frontmatter parses correctly (name, description, allowed-tools, capabilities)
- [ ] Verify curl command examples use correct Slack Web API endpoints
- [ ] Verify all existing tests still pass (`cargo test`)
- [ ] Manual: set SLACK_BOT_TOKEN and test send_message against a test workspace

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)