### PR TITLE
Add mock-only FORGE example validation gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Added
+- Mock-only FORGE example validation gate: every checked-in `.forge` example is classified in `examples/validation.toml`, expected-error examples assert diagnostics, live/external examples are counted as skipped, and `scripts/check-forge-examples.sh` runs the fast `FORGE_MOCK=1` validation path (#231)
 - Slack skill — bidirectional Web API via `curl` with 13 typed capabilities: send-message, send-rich-message (Block Kit), reply-thread, add-reaction, list-channels, read-history (incremental polling), read-thread, detect-mentions, send-approval (interactive buttons + webhook callback), edit-message, delete-message, pin-message, member-info (#177)
 - GitHub skill — `gh` CLI wrapper with 8 typed capabilities: create-issue, list-issues, create-branch, create-pr, check-ci, merge-pr, delete-branch, close-issue (#176)
 - Contradiction events and warden integration: `Contradiction` failure type in grammar/AST/parser/checker, `AgentSignal::Contradiction` variant, `SessionEvent::ContradictionDetected` with `session.contradiction` EventBus payload, `ContradictionSummary` persisted in session state for resume, verification gate in executor blocking high-risk actions on contradicted results (#205)

--- a/docs/training-development-workflow.md
+++ b/docs/training-development-workflow.md
@@ -41,3 +41,13 @@ cargo clippy --all-targets -- -D warnings
 ```
 
 For language and runtime changes, also run a `.forge` example that exercises the changed surface. For documentation-only updates, run representative parser/checker examples and note whether real-LLM execution was skipped.
+
+## Example Corpus Gate
+
+Use the mock-only example gate before changing checked-in `.forge` examples:
+
+```bash
+bash scripts/check-forge-examples.sh
+```
+
+The gate uses `examples/validation.toml` to classify every example under `examples/` and `workflows/`. Required validation must stay deterministic: parser/checker APIs and `FORGE_MOCK=1` are allowed; real LLM providers, live Claude/Codex sessions, credentials, and external side effects stay in `live_only` buckets.

--- a/examples/validation.toml
+++ b/examples/validation.toml
@@ -1,0 +1,217 @@
+# FORGE example validation manifest.
+#
+# `check = "ok"` means parser/resolver/checkers must produce no errors.
+# Warnings are allowed and remain visible in the test summary.
+# `check = "error"` means the example intentionally fails with the listed text.
+# `run = "mock"` means the example may execute in required CI with FORGE_MOCK=1.
+# `run = "live_only"` means runtime execution requires external agents, providers,
+# credentials, or side effects and is skipped by required CI.
+
+[[cases]]
+name = "agent examples"
+paths = [
+  "examples/agents/debate.forge",
+  "examples/agents/fact_check_pool.forge",
+  "examples/agents/learning_agent.forge",
+  "examples/agents/quiz_tutor.forge",
+  "examples/agents/support_bot.forge",
+]
+check = "ok"
+
+[[cases]]
+name = "hello world"
+paths = ["examples/basics/hello.forge"]
+check = "ok"
+run = "mock"
+
+[[cases]]
+name = "command examples"
+paths = [
+  "examples/command/command_argv.forge",
+  "examples/command/command_background.forge",
+  "examples/command/command_background_cancel.forge",
+  "examples/command/command_env.forge",
+  "examples/command/command_fail.forge",
+  "examples/command/command_stderr.forge",
+  "examples/command/command_success.forge",
+  "examples/command/command_timeout.forge",
+  "examples/command/command_workdir.forge",
+  "examples/command/exec_compose.forge",
+  "examples/command/exec_fail.forge",
+  "examples/command/exec_multi.forge",
+  "examples/command/skill_finder.forge",
+]
+check = "ok"
+
+[[cases]]
+name = "mock-runnable exec examples"
+paths = [
+  "examples/command/exec_success.forge",
+  "examples/command/exec_when_dispatch.forge",
+  "examples/command/skill_bot.forge",
+]
+check = "ok"
+run = "mock"
+
+[[cases]]
+name = "boundary expected error"
+paths = [
+  "examples/errors/boundary_error_client.forge",
+  "examples/errors/boundary_error_server.forge",
+]
+check = "error"
+expect = ["server-only symbol"]
+merge = true
+
+[[cases]]
+name = "exec pure expected error"
+paths = ["examples/errors/exec_pure_error.forge"]
+check = "error"
+expect = ["cannot use", "exec"]
+
+[[cases]]
+name = "exec uncertain expected error"
+paths = ["examples/errors/exec_uncertain_error.forge"]
+check = "error"
+expect = ["unhandled uncertain"]
+
+[[cases]]
+name = "pure expected error"
+paths = ["examples/errors/pure_error.forge"]
+check = "error"
+expect = ["cannot use", "reason"]
+
+[[cases]]
+name = "states expected error"
+paths = ["examples/errors/states_error.forge"]
+check = "error"
+expect = ["illegal transition"]
+
+[[cases]]
+name = "uncertain expected error"
+paths = ["examples/errors/uncertain_error.forge"]
+check = "error"
+expect = ["unhandled uncertain"]
+
+[[cases]]
+name = "llm examples"
+paths = [
+  "examples/llm/code_review.forge",
+  "examples/llm/docgen.forge",
+  "examples/llm/research.forge",
+  "examples/llm/security_scanner.forge",
+]
+check = "ok"
+
+[[cases]]
+name = "mock-runnable classify example"
+paths = ["examples/llm/classify.forge"]
+check = "ok"
+run = "mock"
+
+[[cases]]
+name = "observer web example"
+paths = [
+  "examples/observer/server.forge",
+  "examples/observer/shared.forge",
+]
+check = "ok"
+
+[[cases]]
+name = "sentinel web example"
+paths = [
+  "examples/sentinel/server.forge",
+  "examples/sentinel/shared.forge",
+]
+check = "ok"
+config = "examples/sentinel/forge.config.toml"
+merge = true
+
+[[cases]]
+name = "basic server example"
+paths = ["examples/server/hello_server.forge"]
+check = "ok"
+
+[[cases]]
+name = "session examples"
+paths = [
+  "examples/session/session_contradiction.forge",
+  "examples/session/session_hooks.forge",
+  "examples/session/session_isolate.forge",
+  "examples/session/session_placeholder.forge",
+  "examples/session/session_status.forge",
+  "examples/session/session_verification.forge",
+]
+check = "ok"
+
+[[cases]]
+name = "live session examples"
+paths = [
+  "examples/session/session_contradiction_live.forge",
+  "examples/session/session_engine_codex_live.forge",
+  "examples/session/session_engine_live.forge",
+  "examples/session/session_verification_live.forge",
+]
+check = "ok"
+run = "live_only"
+
+[[cases]]
+name = "local skill project example"
+paths = ["examples/skill_project/main.forge"]
+check = "ok"
+manifest = "examples/skill_project/forge.project.toml"
+
+[[cases]]
+name = "github skill example"
+paths = ["examples/skills/github_ops.forge"]
+check = "ok"
+manifest = "examples/skills/forge.project.toml"
+run = "live_only"
+
+[[cases]]
+name = "tic-tac-toe multi-file example"
+paths = [
+  "examples/tictactoe/platform.forge",
+  "examples/tictactoe/room_agent.forge",
+  "examples/tictactoe/ai_opponent.forge",
+  "examples/tictactoe/matchmaking.forge",
+]
+check = "ok"
+manifest = "examples/tictactoe/forge.project.toml"
+merge = true
+
+[[cases]]
+name = "wiki multi-file example"
+paths = [
+  "examples/wiki/server.forge",
+  "examples/wiki/shared.forge",
+]
+check = "ok"
+config = "examples/wiki/forge.config.toml"
+merge = true
+
+[[cases]]
+name = "wiki client boundary example"
+paths = ["examples/wiki/client.forge"]
+check = "ok"
+
+[[cases]]
+name = "development lifecycle workflow"
+paths = ["workflows/dev-cycle.forge"]
+check = "ok"
+
+[[cases]]
+name = "forge-sensei single-file workflow"
+paths = ["workflows/forge-sensei.forge"]
+check = "ok"
+
+[[cases]]
+name = "forge-sensei multi-file workflow"
+paths = [
+  "workflows/forge-sensei/core.forge",
+  "workflows/forge-sensei/agent.forge",
+  "workflows/forge-sensei/web.forge",
+]
+check = "ok"
+manifest = "workflows/forge-sensei/forge.project.toml"
+merge = true

--- a/roadmap.md
+++ b/roadmap.md
@@ -82,7 +82,7 @@ Everything in this document exists to reach that moment.
 | P2.M10 — Dev System | ProjectAgent, Executor, FORGE + forge-wiki two-project proof | #183-#185 | Open |
 | P2.M11 — Knowledge School | forge-sensei curriculum + toolkit knowledge transfer | #166, #167 | Open |
 | P2.M12 — Toolkit Agents | Generator contract, Task/Flow/Agent/System generators, Repair, Test, SpecAnalyzer | #168-#175 | Open |
-| P2.M13 — Polish | CostEstimator, DocumentationAgent, reference/skill refresh | #186-#187, #229 | In Progress |
+| P2.M13 — Polish | CostEstimator, DocumentationAgent, reference/skill refresh, example validation | #186-#187, #229, #231 ✅ | In Progress |
 
 ### Future Layers
 
@@ -747,6 +747,7 @@ Worktree isolation for safe agent execution:
 | #186 | CostEstimator agent | Open |
 | #187 | DocumentationAgent | Open |
 | #229 | Reference, skill, and example refresh | In Progress |
+| #231 | Mock-only FORGE example validation CI gate | Done ✅ |
 
 ---
 
@@ -945,9 +946,9 @@ P2.M9  Orchestration   ░░░░░░░░░░░░░░░░░░░
 P2.M10 Dev System      ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
 P2.M11 Knowledge       ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M12 Toolkit         ░░░░░░░░░░░░░░░░░░░░  0/8  (  0%)
-P2.M13 Polish          ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
+P2.M13 Polish          █████░░░░░░░░░░░░░░░  1/4  ( 25%)
 ─────────────────────────────────────────────────────────
-Phase 2 Overall         ████░░░░░░░░░░░░░░░░  8/38 ( 21%)
+Phase 2 Overall         █████░░░░░░░░░░░░░░░  9/39 ( 23%)
 ```
 
 ---
@@ -1319,7 +1320,7 @@ Phase 1 (Layer 1): Build FORGE — **SHIPPED v0.1.0 on 2026-04-09**
   ⬜ WASM compilation (Cranelift backend) — deferred, not blocking Phase 2
   Goal: tic-tac-toe system runs end-to-end ✅
 
-Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (8/38 issues done)**
+Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (9/39 issues done)**
   ✅ P2.M1: `command` primitive — grammar, sync, background (#160-#162)
   ✅ P2.M2: `session` core — grammar and lifecycle manager done (#189 ✅, #190 ✅)
   ⬜ P2.M3: `AgentResult` + reliability contract — claims, evidence, verification (#193, #203)
@@ -1332,7 +1333,7 @@ Phase 2 (Layer 2): Build the toolkit — **IN PROGRESS (8/38 issues done)**
   ⬜ P2.M10: Dev system — ProjectAgent, Executor, two-project proof (#183-#185)
   ⬜ P2.M11: Knowledge school — sensei curriculum, knowledge transfer (#166-#167)
   ⬜ P2.M12: Toolkit agents — Generator contract, 7 generators (#168-#175)
-  ⬜ P2.M13: Polish — CostEstimator, DocumentationAgent, reference/skill refresh (#186-#187, #229)
+  ⬜ P2.M13: Polish — CostEstimator, DocumentationAgent, reference/skill refresh, example validation (#186-#187, #229, #231 ✅)
   Goal: describe a system → get runnable FORGE code; dev orchestration for FORGE + forge-wiki
 
 Phase 3 (Layer 3): Build the factory
@@ -1372,5 +1373,5 @@ Everything in this document exists to reach that moment.
 
 *FORGE — Making It Real · Master Roadmap v3.0*
 *Layers: Substrate → Toolkit → Factory → Self-improvement*
-*Layer 1: v0.1.0 shipped (32/36 tracks, 89%) · Phase 2: 8/37 issues (22%) · Next: session adapters/events → AgentResult/reliability contract → verification*
-*Last updated: 2026-04-10*
+*Layer 1: v0.1.0 shipped (32/36 tracks, 89%) · Phase 2: 9/39 issues (23%) · Next: session adapters/events → AgentResult/reliability contract → verification*
+*Last updated: 2026-04-11*

--- a/scripts/check-forge-examples.sh
+++ b/scripts/check-forge-examples.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Fast mock-only validation for checked-in FORGE examples.
+set -euo pipefail
+
+export FORGE_MOCK=1
+export FORGE_LOG_LEVEL="${FORGE_LOG_LEVEL:-quiet}"
+
+cargo test --test example_validation_tests "$@" -- --show-output

--- a/tests/example_validation_tests.rs
+++ b/tests/example_validation_tests.rs
@@ -1,0 +1,380 @@
+// FORGE checked-in example validation — issue #231.
+// Keeps the examples corpus classified, parser/checker-clean where expected,
+// and runnable in CI only through mock-safe examples.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use forge::checker;
+use forge::checker::boundary_checker;
+use forge::compose::{self, SourceFile};
+use forge::diagnostic::{Diagnostic, DiagnosticKind};
+use forge::llm::providers::mock::MockProvider;
+use forge::llm::registry::ProviderRegistry;
+use forge::manifest::ProjectManifest;
+use forge::resolver::{CapabilityRegistry, CheckContext};
+use forge::runtime::command_manager::CommandManager;
+use forge::runtime::executor::TaskExecutor;
+use forge::runtime::skill_loader::SkillLoader;
+use forge::runtime::skill_registry::SkillRegistry;
+use forge::types::CapabilitySignature;
+
+#[derive(Debug, serde::Deserialize)]
+struct ValidationManifest {
+    cases: Vec<ValidationCase>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ValidationCase {
+    name: String,
+    paths: Vec<String>,
+    check: CheckMode,
+    #[serde(default)]
+    run: RunMode,
+    #[serde(default)]
+    merge: bool,
+    #[serde(default)]
+    expect: Vec<String>,
+    manifest: Option<String>,
+    config: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CheckMode {
+    Ok,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RunMode {
+    #[default]
+    None,
+    Mock,
+    LiveOnly,
+}
+
+struct CheckOutcome {
+    diagnostics: Vec<Diagnostic>,
+    programs: Vec<forge::ast::Program>,
+}
+
+#[test]
+fn example_manifest_covers_every_forge_example() {
+    let root = repo_root();
+    let manifest = load_manifest(&root);
+    let discovered = discover_forge_examples(&root);
+    let classified = classified_paths(&manifest);
+
+    let missing: Vec<_> = discovered.difference(&classified).cloned().collect();
+    let stale: Vec<_> = classified.difference(&discovered).cloned().collect();
+    let duplicates = duplicate_paths(&manifest);
+
+    assert!(
+        missing.is_empty() && stale.is_empty() && duplicates.is_empty(),
+        "example validation manifest coverage mismatch\nmissing: {missing:?}\nstale: {stale:?}\nduplicates: {duplicates:?}"
+    );
+}
+
+#[tokio::test]
+async fn example_validation_manifest_passes() {
+    let root = repo_root();
+    let manifest = load_manifest(&root);
+    let mut checked_ok = 0;
+    let mut checked_error = 0;
+    let mut warnings = 0;
+    let mut mock_runs = 0;
+    let mut live_skips = 0;
+
+    for case in &manifest.cases {
+        let outcome = check_case(&root, case);
+        let errors = diagnostics_of_kind(&outcome.diagnostics, DiagnosticKind::Error);
+        let case_warnings = diagnostics_of_kind(&outcome.diagnostics, DiagnosticKind::Warning);
+        warnings += case_warnings.len();
+
+        match case.check {
+            CheckMode::Ok => {
+                checked_ok += 1;
+                assert!(
+                    errors.is_empty(),
+                    "case `{}` expected no checker errors, got: {:?}",
+                    case.name,
+                    errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+                );
+            }
+            CheckMode::Error => {
+                checked_error += 1;
+                assert!(
+                    !errors.is_empty(),
+                    "case `{}` expected checker errors but passed",
+                    case.name
+                );
+                assert_expected_diagnostics(case, &outcome.diagnostics);
+            }
+        }
+
+        match case.run {
+            RunMode::None => {}
+            RunMode::Mock => {
+                assert!(
+                    errors.is_empty(),
+                    "case `{}` cannot be mock-run because check errors were present",
+                    case.name
+                );
+                run_mock_case(&outcome.programs, case).await;
+                mock_runs += 1;
+            }
+            RunMode::LiveOnly => {
+                live_skips += 1;
+                eprintln!("SKIP live-only runtime case: {}", case.name);
+            }
+        }
+    }
+
+    eprintln!(
+        "FORGE example validation summary: {checked_ok} ok cases, {checked_error} expected-error cases, {warnings} warnings, {mock_runs} mock runs, {live_skips} live-only runtime skips"
+    );
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn load_manifest(root: &Path) -> ValidationManifest {
+    let path = root.join("examples/validation.toml");
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read {}: {e}", path.display()));
+    toml::from_str(&source).unwrap_or_else(|e| panic!("invalid {}: {e}", path.display()))
+}
+
+fn discover_forge_examples(root: &Path) -> BTreeSet<String> {
+    let mut paths = BTreeSet::new();
+    collect_forge_files(&root.join("examples"), root, &mut paths);
+    collect_forge_files(&root.join("workflows"), root, &mut paths);
+    paths
+}
+
+fn collect_forge_files(dir: &Path, root: &Path, out: &mut BTreeSet<String>) {
+    let entries =
+        std::fs::read_dir(dir).unwrap_or_else(|e| panic!("could not read {}: {e}", dir.display()));
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_forge_files(&path, root, out);
+        } else if path.extension().is_some_and(|ext| ext == "forge")
+            && !path.components().any(|c| c.as_os_str() == "static")
+        {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            out.insert(rel);
+        }
+    }
+}
+
+fn classified_paths(manifest: &ValidationManifest) -> BTreeSet<String> {
+    manifest
+        .cases
+        .iter()
+        .flat_map(|case| case.paths.iter().cloned())
+        .collect()
+}
+
+fn duplicate_paths(manifest: &ValidationManifest) -> Vec<String> {
+    let mut counts = BTreeMap::new();
+    for path in manifest.cases.iter().flat_map(|case| case.paths.iter()) {
+        *counts.entry(path.clone()).or_insert(0usize) += 1;
+    }
+    counts
+        .into_iter()
+        .filter_map(|(path, count)| (count > 1).then_some(path))
+        .collect()
+}
+
+fn check_case(root: &Path, case: &ValidationCase) -> CheckOutcome {
+    let source_files = parse_case_sources(root, case);
+    let skill_sigs = skill_signatures(root, case);
+    let mut diagnostics = Vec::new();
+
+    if !case.merge {
+        let mut programs = Vec::new();
+        for source_file in &source_files {
+            diagnostics.extend(check_program(
+                &source_file.program,
+                &source_file.path,
+                &skill_sigs,
+            ));
+            diagnostics.extend(boundary_checker::check(&[(
+                &source_file.program,
+                source_file.path.as_str(),
+            )]));
+            programs.push(source_file.program.clone());
+        }
+        return CheckOutcome {
+            diagnostics,
+            programs,
+        };
+    }
+
+    let composed = compose::merge_programs(&source_files).unwrap_or_else(|errs| {
+        panic!(
+            "case `{}` failed composition: {:?}",
+            case.name,
+            errs.iter().map(ToString::to_string).collect::<Vec<_>>()
+        )
+    });
+
+    let filename = case.paths.join("+");
+    diagnostics.extend(check_program(&composed.program, &filename, &skill_sigs));
+
+    let boundary_refs: Vec<_> = source_files
+        .iter()
+        .map(|sf| (&sf.program, sf.path.as_str()))
+        .collect();
+    diagnostics.extend(boundary_checker::check(&boundary_refs));
+
+    CheckOutcome {
+        diagnostics,
+        programs: vec![composed.program],
+    }
+}
+
+fn check_program(
+    program: &forge::ast::Program,
+    filename: &str,
+    skill_sigs: &HashMap<String, CapabilitySignature>,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let ctx = if skill_sigs.is_empty() {
+        CheckContext::new(filename)
+    } else {
+        CheckContext::with_skills(filename, skill_sigs.clone())
+    };
+
+    if let Err(errors) = ctx.check(program) {
+        let registry = if skill_sigs.is_empty() {
+            CapabilityRegistry::builtin()
+        } else {
+            CapabilityRegistry::with_skills(skill_sigs.clone())
+        };
+        diagnostics.extend(errors.iter().map(|e| e.to_diagnostic(filename, &registry)));
+    }
+
+    diagnostics.extend(checker::check_all(program, filename));
+    diagnostics
+}
+
+fn parse_case_sources(root: &Path, case: &ValidationCase) -> Vec<SourceFile> {
+    case.paths
+        .iter()
+        .map(|rel| {
+            let path = root.join(rel);
+            let source = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("case `{}` could not read {}: {e}", case.name, rel));
+            let program = forge::parser::parse(&source).unwrap_or_else(|e| {
+                panic!("case `{}` parse failed for {}: {:?}", case.name, rel, e)
+            });
+            SourceFile {
+                path: rel.clone(),
+                source,
+                program,
+            }
+        })
+        .collect()
+}
+
+fn skill_signatures(root: &Path, case: &ValidationCase) -> HashMap<String, CapabilitySignature> {
+    let mut registry = SkillRegistry::new();
+
+    if let Some(manifest_path) = &case.manifest {
+        let path = root.join(manifest_path);
+        let manifest = ProjectManifest::load(&path).unwrap_or_else(|e| {
+            panic!("case `{}` could not load {}: {e}", case.name, manifest_path)
+        });
+        let base = path.parent().unwrap_or(root);
+        for (_, skill_path) in manifest.resolve_skills(base, &[]).unwrap_or_else(|e| {
+            panic!(
+                "case `{}` could not resolve manifest skills: {e}",
+                case.name
+            )
+        }) {
+            let skill = SkillLoader::parse_skill_md(&skill_path).unwrap_or_else(|e| {
+                panic!(
+                    "case `{}` could not parse {}: {e}",
+                    case.name,
+                    skill_path.display()
+                )
+            });
+            registry.register(skill);
+        }
+    }
+
+    if let Some(config_path) = &case.config {
+        let path = root.join(config_path);
+        let config = forge::config::ForgeConfig::load(&path)
+            .unwrap_or_else(|e| panic!("case `{}` could not load {}: {e}", case.name, config_path));
+        if let Some(skills) = config.skills {
+            let dirs: Vec<PathBuf> = skills
+                .skill_dirs_or_default()
+                .into_iter()
+                .map(|dir| {
+                    if dir.is_absolute() {
+                        dir
+                    } else {
+                        root.join(dir)
+                    }
+                })
+                .collect();
+            for skill in SkillLoader::load_from_dirs(&dirs) {
+                registry.register(skill);
+            }
+        }
+    }
+
+    registry.capability_signatures()
+}
+
+fn diagnostics_of_kind(diags: &[Diagnostic], kind: DiagnosticKind) -> Vec<&Diagnostic> {
+    diags
+        .iter()
+        .filter(|d| std::mem::discriminant(&d.kind) == std::mem::discriminant(&kind))
+        .collect()
+}
+
+fn assert_expected_diagnostics(case: &ValidationCase, diagnostics: &[Diagnostic]) {
+    let messages = diagnostics
+        .iter()
+        .map(|d| d.message.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    for expected in &case.expect {
+        assert!(
+            messages.contains(expected),
+            "case `{}` expected diagnostic text `{}` in {:?}",
+            case.name,
+            expected,
+            messages
+        );
+    }
+}
+
+async fn run_mock_case(programs: &[forge::ast::Program], case: &ValidationCase) {
+    for program in programs {
+        let mut providers = ProviderRegistry::new("mock");
+        providers.register(
+            "mock",
+            Arc::new(MockProvider::new("mock").with_default("mock response")),
+        );
+        let executor = TaskExecutor::new(program.clone(), Arc::new(providers), None)
+            .with_config(forge::config::ForgeConfig::default_mock_config())
+            .with_command_manager(Arc::new(Mutex::new(CommandManager::new())));
+        executor
+            .run()
+            .await
+            .unwrap_or_else(|e| panic!("case `{}` failed mock runtime: {e}", case.name));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `examples/validation.toml` to classify every checked-in `.forge` example under `examples/` and `workflows/`.
- Adds `tests/example_validation_tests.rs` to enforce manifest coverage, parser/checker expectations, expected diagnostic text, mock-only runtime runs, and live-only skip accounting.
- Adds `scripts/check-forge-examples.sh` as the local/CI entrypoint with `FORGE_MOCK=1` and documents it in `docs/training-development-workflow.md`.
- Updates `CHANGELOG.md` and `roadmap.md` for #231.

## Acceptance Criteria
- [x] Every checked-in `.forge` example under `examples/` and `workflows/` is classified in a repo-tracked manifest.
- [x] Required PR validation uses parser/checker APIs and `FORGE_MOCK=1`; no real providers, live sessions, credentials, or external side effects.
- [x] Expected-error examples assert diagnostic text.
- [x] Live/external examples are visibly skipped and counted.
- [x] Gate stays under 10 seconds warm; observed about 0.12s warm for `example_validation_tests`.
- [x] Local docs/script entrypoint added.
- [x] `CHANGELOG.md` updated.

## Verification
- [x] `bash scripts/check-forge-examples.sh` passed: 19 ok cases, 6 expected-error cases, 14 warnings, 3 mock runs, 2 live-only runtime skips.
- [x] `cargo fmt --check` passed.
- [x] `cargo test` passed.
- [x] `cargo clippy --all-targets -- -D warnings` passed.
- [x] Real-world validation policy: live/external examples are classified as `live_only`; required validation uses only mock-safe runtime execution.

## Known Gaps
- No real LLM/session execution is included in required CI by design; those examples are manifest-classified and counted as live-only skips.

Closes #231