### PR TITLE
Make quiz tutor mock-runnable on development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Quiz tutor example now runs cleanly with `FORGE_MOCK=1 forge run examples/agents/quiz_tutor.forge`, and mock-runnable examples reject checker warnings in the validation gate (#231)
 - FORGE reference, training workflow doc, and local examples now cover implemented command/session/AgentResult/verification/knowledge/skill surfaces (#229)
 - Anthropic provider now sends tool definitions and parses `tool_use` response blocks, enabling skill executor agentic loop (#198)
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)

--- a/examples/agents/quiz_tutor.forge
+++ b/examples/agents/quiz_tutor.forge
@@ -16,9 +16,7 @@ event SessionSummary
 # ── Lifecycle ─────────────────────────────────────────────────
 
 states TutorPhase
-  beginner -> intermediate when score >= 3
-  intermediate -> advanced when score >= 7
-  advanced -> advanced
+  active -> active
 
 # ── Quiz generation tasks ─────────────────────────────────────
 
@@ -56,7 +54,7 @@ task pick_topic
 
 # ── The tutor agent ───────────────────────────────────────────
 #
-# Demonstrates: memory, lifecycle, handlers, requires guards,
+# Demonstrates: memory, lifecycle guard, handlers, requires guards,
 # stuck detection, timers, event emission, escalation.
 
 agent forge_tutor
@@ -84,7 +82,7 @@ agent forge_tutor
 
   on answer(student_answer: Text)
     requires memory.questions_asked > 0 on fail: give "No active question. Send 'start' first."
-    requires lifecycle == beginner or lifecycle == intermediate on fail: silent
+    requires lifecycle == active on fail: silent
     verdict = check_answer(memory.current_question, student_answer)
     grade = classify verdict into ["correct", "partial", "wrong"]
     when grade.sure -> say "Graded with confidence."
@@ -105,13 +103,11 @@ agent forge_tutor
       emit TopicCompleted(topic: memory.current_topic, score: memory.score)
       memory.streak = 0
       say "Topic mastered!"
-    if memory.score >= 7 and lifecycle == intermediate
+    if memory.score >= 7 and memory.level == "intermediate"
       memory.level = "advanced"
-      transition to advanced
       say "Level up: ADVANCED!"
-    if memory.score >= 3 and lifecycle == beginner
+    if memory.score >= 3 and memory.level == "beginner"
       memory.level = "intermediate"
-      transition to intermediate
       say "Level up: INTERMEDIATE!"
     topic = pick_topic(memory.level, memory.current_topic)
     memory.current_topic = topic
@@ -155,3 +151,12 @@ agent forge_tutor
     say "Hint: {hint_text}"
     say "FORGE is built around honesty (confidence), composition, and supervision."
     say "Send 'skip' to move to a new question."
+
+fn main
+  topic = pick_topic("beginner", "")
+  question = generate_question(topic, "beginner")
+  hint_text = generate_hint(question, topic)
+  say "FORGE Quiz Tutor demo"
+  say "Topic: {topic}"
+  say "Question: {question}"
+  say "Hint: {hint_text}"

--- a/examples/validation.toml
+++ b/examples/validation.toml
@@ -13,10 +13,15 @@ paths = [
   "examples/agents/debate.forge",
   "examples/agents/fact_check_pool.forge",
   "examples/agents/learning_agent.forge",
-  "examples/agents/quiz_tutor.forge",
   "examples/agents/support_bot.forge",
 ]
 check = "ok"
+
+[[cases]]
+name = "mock-runnable quiz tutor agent"
+paths = ["examples/agents/quiz_tutor.forge"]
+check = "ok"
+run = "mock"
 
 [[cases]]
 name = "hello world"

--- a/tests/example_validation_tests.rs
+++ b/tests/example_validation_tests.rs
@@ -123,6 +123,12 @@ async fn example_validation_manifest_passes() {
                     "case `{}` cannot be mock-run because check errors were present",
                     case.name
                 );
+                assert!(
+                    case_warnings.is_empty(),
+                    "case `{}` is mock-runnable but has checker warnings: {:?}",
+                    case.name,
+                    case_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+                );
                 run_mock_case(&outcome.programs, case).await;
                 mock_runs += 1;
             }


### PR DESCRIPTION
## Summary
- Fixes `examples/agents/quiz_tutor.forge` so `FORGE_MOCK=1 forge run examples/agents/quiz_tutor.forge` runs cleanly on top of current `development`.
- Moves the quiz tutor into a `run = "mock"` validation manifest case.
- Tightens the example validation test so mock-runnable examples fail on checker warnings.

## Context
- #233 was merged into the old stacked branch (`feature/231-mock-example-ci`), not into `development`, so the fix was not present after pulling `development`.
- This PR cherry-picks only the follow-up fix onto current `origin/development`.

## Verification
- [x] `bash scripts/check-forge-examples.sh` passed: 20 ok cases, 6 expected-error cases, 13 warnings, 4 mock runs, 2 live-only runtime skips.
- [x] `FORGE_MOCK=1 cargo run -- run examples/agents/quiz_tutor.forge` passed.
- [x] `cargo fmt --check` passed.
- [x] `cargo clippy --all-targets -- -D warnings` passed.

Refs #231