### PR TITLE
feat: add deterministic skill executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible provider now sends tool definitions and parses `tool_calls` response fields (#198)
 
 ### Changed
+- Skill capabilities can now opt into deterministic command execution metadata, letting simple `skill.*` operations bypass the LLM-mediated SKILL.md loop while keeping agentic fallback behavior (#237)
 - Bumped `redb` from v2 to v4 and MSRV from 1.85 to 1.89 (#235)
 
 ### Added

--- a/docs/forge-reference.md
+++ b/docs/forge-reference.md
@@ -2505,6 +2505,24 @@ repo_check = {}
 
 Then a FORGE file can use `skill.repo_check` and call declared capabilities. Skill calls are side-effecting and rejected inside `pure`.
 
+Typed skill capabilities may optionally declare deterministic execution metadata in `SKILL.md`. When present, the runtime expands capability arguments into a structured `argv` command and executes it directly; when absent, the existing LLM-mediated SKILL.md agentic loop remains the fallback. Deterministic skill executors do not make LLM requests and have zero token cost, but they still return skill confidence rather than deterministic confidence because they perform external side effects.
+
+```yaml
+capabilities:
+  - name: add_reaction
+    inputs: [Text, Text, Text]
+    output: Text
+    params: [channel, timestamp, emoji]
+    executor:
+      kind: command
+      argv: [curl, -s, -X, POST, "https://slack.com/api/reactions.add", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "timestamp={timestamp}", --data-urlencode, "name={emoji}"]
+      result:
+        success_path: ok
+        error_path: error
+```
+
+Use `{param}` placeholders for capability arguments and `{env:NAME}` for environment variables. Use `{{` and `}}` for literal braces inside argv templates.
+
 ---
 
 ## 22. Templates and Raw Interpolation

--- a/roadmap.md
+++ b/roadmap.md
@@ -76,7 +76,7 @@ Everything in this document exists to reach that moment.
 | P2.M4 — Session Adapters + Events | Agent adapters, polling, and event integration | #191, #192 | Open |
 | P2.M5 — Verification + Contradictions | Verification engine and contradiction/warden integration | #204, #205 | Open |
 | P2.M6 — Sandbox | `sandbox` isolation: spawn modifier + worktree | #194 ✅ | Done |
-| P2.M7 — Skills Foundation | Pluggable skill architecture, capability types, CLI delegation research | #163 ✅ #164 ✅ #165 | In Progress |
+| P2.M7 — Skills Foundation | Pluggable skill architecture, capability types, CLI delegation research, deterministic execution | #163 ✅ #164 ✅ #165 ✅ #237 ✅ | Done |
 | P2.M8 — CLI Skills | GitHub, Slack, Claude Code, Codex/Ollama SKILL.md files | #176-#179 | Open |
 | P2.M9 — Orchestration | Slack Monitor, Inbound Triager, approval gate | #180-#182 | Open |
 | P2.M10 — Dev System | ProjectAgent, Executor, FORGE + forge-wiki two-project proof | #183-#185 | Open |
@@ -694,6 +694,7 @@ Worktree isolation for safe agent execution:
 | #163 | Pluggable skill architecture — project-level declarations | Done |
 | #164 | Skill capability type system — rich signatures | Done |
 | #165 | Explore agent-to-CLI delegation patterns (Claude Code, Codex) | Done |
+| #237 | Hybrid deterministic skill execution for simple capabilities | Done |
 
 ### P2.M8: CLI Skills (SKILL.md)
 
@@ -940,7 +941,7 @@ P2.M3  Result+Contract ░░░░░░░░░░░░░░░░░░░
 P2.M4  Adapters+Events ░░░░░░░░░░░░░░░░░░░░  0/2  (  0%)
 P2.M5  Verify+Contra   ██████████░░░░░░░░░░  1/2  ( 50%)
 P2.M6  Sandbox         ████████████████████  1/1  (100%)
-P2.M7  Skills          █████████████░░░░░░░  2/3  ( 67%)
+P2.M7  Skills          ████████████████████  4/4  (100%)
 P2.M8  CLI Skills      ░░░░░░░░░░░░░░░░░░░░  0/4  (  0%)
 P2.M9  Orchestration   ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
 P2.M10 Dev System      ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
@@ -948,7 +949,7 @@ P2.M11 Knowledge       ░░░░░░░░░░░░░░░░░░░
 P2.M12 Toolkit         ░░░░░░░░░░░░░░░░░░░░  0/8  (  0%)
 P2.M13 Polish          █████░░░░░░░░░░░░░░░  1/4  ( 25%)
 ─────────────────────────────────────────────────────────
-Phase 2 Overall         █████░░░░░░░░░░░░░░░  9/39 ( 23%)
+Phase 2 Overall         █████░░░░░░░░░░░░░░░  10/40 ( 25%)
 ```
 
 ---
@@ -1373,5 +1374,5 @@ Everything in this document exists to reach that moment.
 
 *FORGE — Making It Real · Master Roadmap v3.0*
 *Layers: Substrate → Toolkit → Factory → Self-improvement*
-*Layer 1: v0.1.0 shipped (32/36 tracks, 89%) · Phase 2: 9/39 issues (23%) · Next: session adapters/events → AgentResult/reliability contract → verification*
+*Layer 1: v0.1.0 shipped (32/36 tracks, 89%) · Phase 2: 10/40 issues (25%) · Next: session adapters/events → AgentResult/reliability contract → verification*
 *Last updated: 2026-04-11*

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -8,24 +8,63 @@ capabilities:
   - name: send_message
     inputs: [Text, Text]
     output: Text
+    params: [channel, text]
+    executor:
+      kind: command
+      argv: [curl, -s, -X, POST, "https://slack.com/api/chat.postMessage", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "text={text}"]
+      result:
+        success_path: ok
+        error_path: error
+        json_path: ts
   - name: send_rich_message
     inputs: [Text, Text]
     output: Text
   - name: reply_thread
     inputs: [Text, Text, Text]
     output: Text
+    params: [channel, thread_ts, text]
+    executor:
+      kind: command
+      argv: [curl, -s, -X, POST, "https://slack.com/api/chat.postMessage", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "thread_ts={thread_ts}", --data-urlencode, "text={text}"]
+      result:
+        success_path: ok
+        error_path: error
+        json_path: ts
   - name: add_reaction
     inputs: [Text, Text, Text]
     output: Text
+    params: [channel, timestamp, emoji]
+    executor:
+      kind: command
+      argv: [curl, -s, -X, POST, "https://slack.com/api/reactions.add", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "timestamp={timestamp}", --data-urlencode, "name={emoji}"]
+      result:
+        success_path: ok
+        error_path: error
   - name: list_channels
     inputs: [Text]
     output: Text
   - name: read_history
     inputs: [Text, Text, Text]
     output: Text
+    params: [channel, oldest, limit]
+    executor:
+      kind: command
+      argv: [curl, -s, -G, "https://slack.com/api/conversations.history", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "oldest={oldest}", --data-urlencode, "limit={limit}"]
+      result:
+        success_path: ok
+        error_path: error
+        json_path: messages
   - name: read_thread
     inputs: [Text, Text]
     output: Text
+    params: [channel, thread_ts]
+    executor:
+      kind: command
+      argv: [curl, -s, -G, "https://slack.com/api/conversations.replies", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "ts={thread_ts}"]
+      result:
+        success_path: ok
+        error_path: error
+        json_path: messages
   - name: detect_mentions
     inputs: [Text, Text]
     output: Text
@@ -35,15 +74,44 @@ capabilities:
   - name: edit_message
     inputs: [Text, Text, Text]
     output: Text
+    params: [channel, timestamp, text]
+    executor:
+      kind: command
+      argv: [curl, -s, -X, POST, "https://slack.com/api/chat.update", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "ts={timestamp}", --data-urlencode, "text={text}"]
+      result:
+        success_path: ok
+        error_path: error
   - name: delete_message
     inputs: [Text, Text]
     output: Text
+    params: [channel, timestamp]
+    executor:
+      kind: command
+      argv: [curl, -s, -X, POST, "https://slack.com/api/chat.delete", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "ts={timestamp}"]
+      result:
+        success_path: ok
+        error_path: error
   - name: pin_message
     inputs: [Text, Text]
     output: Text
+    params: [channel, timestamp]
+    executor:
+      kind: command
+      argv: [curl, -s, -X, POST, "https://slack.com/api/pins.add", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "channel={channel}", --data-urlencode, "timestamp={timestamp}"]
+      result:
+        success_path: ok
+        error_path: error
   - name: member_info
     inputs: [Text]
     output: Text
+    params: [user_id]
+    executor:
+      kind: command
+      argv: [curl, -s, -G, "https://slack.com/api/users.info", -H, "Authorization: Bearer {env:SLACK_BOT_TOKEN}", --data-urlencode, "user={user_id}"]
+      result:
+        success_path: ok
+        error_path: error
+        json_path: user
 ---
 
 # Slack Skill

--- a/src/runtime/skill.rs
+++ b/src/runtime/skill.rs
@@ -7,6 +7,27 @@ use crate::types::CapabilitySignature;
 pub struct SkillCapability {
     pub name: String,
     pub signature: CapabilitySignature,
+    pub executor: Option<SkillCapabilityExecutor>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillCapabilityExecutor {
+    pub params: Vec<String>,
+    pub kind: SkillExecutorKind,
+    pub argv: Vec<String>,
+    pub result: Option<SkillExecutorResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillExecutorKind {
+    Command,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillExecutorResult {
+    pub json_path: Option<String>,
+    pub success_path: Option<String>,
+    pub error_path: Option<String>,
 }
 
 /// Metadata about a skill, loaded from SKILL.md frontmatter or config.

--- a/src/runtime/skill_executor.rs
+++ b/src/runtime/skill_executor.rs
@@ -9,8 +9,10 @@ use std::time::Duration;
 
 use crate::llm::registry::ProviderRegistry;
 use crate::llm::{CompletionRequest, ToolDefinition};
-use crate::runtime::confidence::ConfidentValue;
-use crate::runtime::skill::{LoadedSkill, SkillError};
+use crate::runtime::confidence::{ConfidentValue, Value};
+use crate::runtime::skill::{
+    LoadedSkill, SkillCapabilityExecutor, SkillError, SkillExecutorKind, SkillExecutorResult,
+};
 use crate::runtime::skill_registry::SharedSkillRegistry;
 use crate::tracer::LLMResponseInfo;
 use crate::tracer::Tracer;
@@ -97,6 +99,18 @@ impl SkillExecutor {
         method: &str,
         args: &HashMap<String, ConfidentValue>,
     ) -> Result<ConfidentValue, SkillError> {
+        if let Some(executor) = skill
+            .manifest
+            .capabilities
+            .iter()
+            .find(|cap| cap.name == method)
+            .and_then(|cap| cap.executor.as_ref())
+        {
+            return self
+                .execute_deterministic(skill, method, executor, args)
+                .await;
+        }
+
         let system_prompt = format!(
             "You are executing a skill. Follow these instructions exactly.\n\n{}\n\n\
              Respond with the final result as plain text when done. \
@@ -144,6 +158,61 @@ impl SkillExecutor {
                 name: skill.manifest.name.clone(),
                 timeout_secs: skill.manifest.timeout_secs,
             }),
+        }
+    }
+
+    async fn execute_deterministic(
+        &self,
+        skill: &LoadedSkill,
+        method: &str,
+        executor: &SkillCapabilityExecutor,
+        args: &HashMap<String, ConfidentValue>,
+    ) -> Result<ConfidentValue, SkillError> {
+        match executor.kind {
+            SkillExecutorKind::Command => {
+                let argv = expand_argv(&executor.argv, &executor.params, args)?;
+                let (program, program_args) =
+                    argv.split_first()
+                        .ok_or_else(|| SkillError::ExecutionFailed {
+                            name: format!("{}.{}", skill.manifest.name, method),
+                            reason: "executor argv must not be empty".to_string(),
+                        })?;
+
+                let output = tokio::time::timeout(
+                    Duration::from_secs(skill.manifest.timeout_secs),
+                    tokio::process::Command::new(program)
+                        .args(program_args)
+                        .output(),
+                )
+                .await
+                .map_err(|_| SkillError::Timeout {
+                    name: skill.manifest.name.clone(),
+                    timeout_secs: skill.manifest.timeout_secs,
+                })?
+                .map_err(|e| SkillError::ExecutionFailed {
+                    name: format!("{}.{}", skill.manifest.name, method),
+                    reason: e.to_string(),
+                })?;
+
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                if !output.status.success() {
+                    return Err(SkillError::ExecutionFailed {
+                        name: format!("{}.{}", skill.manifest.name, method),
+                        reason: if stderr.is_empty() { stdout } else { stderr },
+                    });
+                }
+
+                let text = apply_result_mapping(
+                    executor.result.as_ref(),
+                    &stdout,
+                    &format!("{}.{}", skill.manifest.name, method),
+                )?;
+                Ok(ConfidentValue::from_skill(
+                    Value::Text(text),
+                    skill.manifest.default_confidence,
+                ))
+            }
         }
     }
 
@@ -395,5 +464,143 @@ impl SkillExecutor {
         }
 
         tools
+    }
+}
+
+fn expand_argv(
+    argv: &[String],
+    params: &[String],
+    args: &HashMap<String, ConfidentValue>,
+) -> Result<Vec<String>, SkillError> {
+    argv.iter()
+        .map(|arg| expand_template(arg, params, args))
+        .collect()
+}
+
+fn expand_template(
+    template: &str,
+    params: &[String],
+    args: &HashMap<String, ConfidentValue>,
+) -> Result<String, SkillError> {
+    let mut output = String::new();
+    let mut rest = template;
+
+    while let Some(start) = rest.find(['{', '}']) {
+        output.push_str(&rest[..start]);
+        if rest[start..].starts_with("{{") {
+            output.push('{');
+            rest = &rest[start + 2..];
+            continue;
+        }
+        if rest[start..].starts_with("}}") {
+            output.push('}');
+            rest = &rest[start + 2..];
+            continue;
+        }
+        if rest[start..].starts_with('}') {
+            output.push('}');
+            rest = &rest[start + 1..];
+            continue;
+        }
+
+        let after_start = &rest[start + 1..];
+        let Some(end) = after_start.find('}') else {
+            output.push_str(&rest[start..]);
+            return Ok(output);
+        };
+        let key = &after_start[..end];
+        output.push_str(&lookup_template_value(key, params, args)?);
+        rest = &after_start[end + 1..];
+    }
+    output.push_str(rest);
+    Ok(output)
+}
+
+fn lookup_template_value(
+    key: &str,
+    params: &[String],
+    args: &HashMap<String, ConfidentValue>,
+) -> Result<String, SkillError> {
+    if let Some(env_name) = key.strip_prefix("env:") {
+        return std::env::var(env_name).map_err(|_| SkillError::ExecutionFailed {
+            name: "deterministic_skill".to_string(),
+            reason: format!("missing environment variable '{}'", env_name),
+        });
+    }
+
+    if let Some(value) = args.get(key) {
+        return Ok(value.value.to_string());
+    }
+
+    if let Some(index) = params.iter().position(|param| param == key) {
+        if let Some(value) = args.get(&format!("_{}", index)) {
+            return Ok(value.value.to_string());
+        }
+    }
+
+    Err(SkillError::ExecutionFailed {
+        name: "deterministic_skill".to_string(),
+        reason: format!("missing argument '{}'", key),
+    })
+}
+
+fn apply_result_mapping(
+    mapping: Option<&SkillExecutorResult>,
+    stdout: &str,
+    name: &str,
+) -> Result<String, SkillError> {
+    let Some(mapping) = mapping else {
+        return Ok(stdout.trim().to_string());
+    };
+
+    let json: serde_json::Value =
+        serde_json::from_str(stdout).map_err(|e| SkillError::ExecutionFailed {
+            name: name.to_string(),
+            reason: format!("executor output was not valid JSON: {}", e),
+        })?;
+
+    if let Some(success_path) = &mapping.success_path {
+        if extract_json_path(&json, success_path) == Some(&serde_json::Value::Bool(false)) {
+            let reason = mapping
+                .error_path
+                .as_deref()
+                .and_then(|path| extract_json_path(&json, path))
+                .map(json_value_to_text)
+                .unwrap_or_else(|| "operation returned ok=false".to_string());
+            return Err(SkillError::ExecutionFailed {
+                name: name.to_string(),
+                reason,
+            });
+        }
+    }
+
+    if let Some(path) = &mapping.json_path {
+        let Some(value) = extract_json_path(&json, path) else {
+            return Err(SkillError::ExecutionFailed {
+                name: name.to_string(),
+                reason: format!("missing JSON result path '{}'", path),
+            });
+        };
+        return Ok(json_value_to_text(value));
+    }
+
+    Ok(stdout.trim().to_string())
+}
+
+fn extract_json_path<'a>(
+    value: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+fn json_value_to_text(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
     }
 }

--- a/src/runtime/skill_loader.rs
+++ b/src/runtime/skill_loader.rs
@@ -3,7 +3,10 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::runtime::skill::{LoadedSkill, SkillCapability, SkillManifest};
+use crate::runtime::skill::{
+    LoadedSkill, SkillCapability, SkillCapabilityExecutor, SkillExecutorKind, SkillExecutorResult,
+    SkillManifest,
+};
 use crate::types::{CapabilitySignature, ForgeType};
 use serde::Deserialize;
 
@@ -100,6 +103,22 @@ struct SkillCapabilityFrontmatter {
     name: String,
     inputs: Vec<String>,
     output: String,
+    params: Option<Vec<String>>,
+    executor: Option<SkillCapabilityExecutorFrontmatter>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillCapabilityExecutorFrontmatter {
+    kind: String,
+    argv: Vec<String>,
+    result: Option<SkillExecutorResultFrontmatter>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillExecutorResultFrontmatter {
+    json_path: Option<String>,
+    success_path: Option<String>,
+    error_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -126,11 +145,46 @@ impl SkillFrontmatter {
                                     .collect::<Result<Vec<_>, _>>()?,
                                 output: parse_forge_type(&cap.output)?,
                             },
+                            executor: cap.parse_executor()?,
                         })
                     })
                     .collect()
             })
             .unwrap_or_else(|| Ok(Vec::new()))
+    }
+}
+
+impl SkillCapabilityFrontmatter {
+    fn parse_executor(&self) -> Result<Option<SkillCapabilityExecutor>, String> {
+        let Some(executor) = &self.executor else {
+            return Ok(None);
+        };
+        let kind = match executor.kind.as_str() {
+            "command" => SkillExecutorKind::Command,
+            other => {
+                return Err(format!(
+                    "unsupported executor kind '{}' for capability '{}'",
+                    other, self.name
+                ));
+            }
+        };
+        if executor.argv.is_empty() {
+            return Err(format!(
+                "executor argv must not be empty for capability '{}'",
+                self.name
+            ));
+        }
+
+        Ok(Some(SkillCapabilityExecutor {
+            params: self.params.clone().unwrap_or_default(),
+            kind,
+            argv: executor.argv.clone(),
+            result: executor.result.as_ref().map(|result| SkillExecutorResult {
+                json_path: result.json_path.clone(),
+                success_path: result.success_path.clone(),
+                error_path: result.error_path.clone(),
+            }),
+        }))
     }
 }
 
@@ -276,5 +330,34 @@ Body.
         assert_eq!(caps[0].name, "create_issue");
         assert_eq!(caps[0].signature.inputs.len(), 3);
         assert_eq!(caps[1].signature.output, ForgeType::Text);
+    }
+
+    #[test]
+    fn parse_typed_capability_executor() {
+        let content = r#"---
+name: demo
+capabilities:
+  - name: echo
+    inputs: [Text]
+    output: Text
+    params: [text]
+    executor:
+      kind: command
+      argv: [printf, "%s", "{text}"]
+      result:
+        json_path: output
+---
+Body.
+"#;
+        let (fm, _) = split_frontmatter(content).unwrap();
+        let caps = fm.parse_capabilities().unwrap();
+        let executor = caps[0].executor.as_ref().unwrap();
+        assert_eq!(executor.params, vec!["text"]);
+        assert_eq!(executor.kind, SkillExecutorKind::Command);
+        assert_eq!(executor.argv, vec!["printf", "%s", "{text}"]);
+        assert_eq!(
+            executor.result.as_ref().unwrap().json_path.as_deref(),
+            Some("output")
+        );
     }
 }

--- a/tests/skill_e2e_test.rs
+++ b/tests/skill_e2e_test.rs
@@ -14,6 +14,7 @@ use forge::runtime::skill_executor::SkillExecutor;
 use forge::runtime::skill_loader::SkillLoader;
 use forge::runtime::skill_registry::SkillRegistry;
 use forge::tracer::Tracer;
+use forge::types::ConfidenceSource;
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -35,6 +36,58 @@ fn create_temp_skill(name: &str, description: &str, body: &str) -> tempfile::Tem
     )
     .unwrap();
     dir
+}
+
+fn create_deterministic_skill(name: &str, capability: &str, body: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let skill_dir = dir.path().join(name);
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    let mut file = std::fs::File::create(skill_dir.join("SKILL.md")).unwrap();
+    write!(
+        file,
+        r#"---
+name: {name}
+description: Deterministic test skill
+timeout: 30
+capabilities:
+  - name: {capability}
+    inputs: [Text]
+    output: Text
+    params: [text]
+    executor:
+      kind: command
+      argv: [printf, "%s", '{{{{"ok":true,"output":"{{text}}"}}}}']
+      result:
+        success_path: ok
+        error_path: error
+        json_path: output
+---
+
+{body}
+"#
+    )
+    .unwrap();
+    dir
+}
+
+fn executor_for_dir(
+    dir: &tempfile::TempDir,
+    mock: MockProvider,
+    tracer: Option<Tracer>,
+) -> SkillExecutor {
+    let skills = SkillLoader::load_from_dirs(&[dir.path().to_path_buf()]);
+    let mut registry = SkillRegistry::new();
+    for skill in skills {
+        registry.register(skill);
+    }
+    let shared_registry = Arc::new(Mutex::new(registry));
+    let mut executor = SkillExecutor::new(mock_registry(mock), shared_registry);
+    executor.max_turns = 5;
+    executor.default_timeout = Duration::from_secs(10);
+    if let Some(tracer) = tracer {
+        executor = executor.with_tracer(Arc::new(tracer));
+    }
+    executor
 }
 
 // ── E2E: full skill execution with mock tool-use ────────────────
@@ -110,6 +163,94 @@ async fn skill_e2e_mock_tool_use() {
         cv.confidence <= 0.99,
         "confidence should be capped at 0.99, got: {}",
         cv.confidence
+    );
+}
+
+#[tokio::test]
+async fn deterministic_skill_executor_skips_llm_and_maps_result() {
+    let dir = create_deterministic_skill(
+        "det-test",
+        "echo",
+        "This body should not be sent to the LLM for deterministic execution.",
+    );
+    let tracer = Tracer::with_capture();
+    let executor = executor_for_dir(
+        &dir,
+        MockProvider::new("mock").with_default("LLM_SHOULD_NOT_RUN"),
+        Some(tracer.clone()),
+    );
+    let mut args = HashMap::new();
+    args.insert(
+        "_0".to_string(),
+        forge::runtime::confidence::ConfidentValue::deterministic(
+            forge::runtime::confidence::Value::Text("hello from argv".to_string()),
+        ),
+    );
+
+    let result = executor.execute("det-test", "echo", &args).await.unwrap();
+
+    assert_eq!(result.value.to_string(), "hello from argv");
+    assert!(matches!(
+        result.source,
+        ConfidenceSource::SkillInvocation(conf) if (conf - 0.85).abs() < f32::EPSILON
+    ));
+    let events = tracer.captured_events();
+    assert!(events.contains(&"skill_call".to_string()));
+    assert!(events.contains(&"skill_return".to_string()));
+    assert!(!events.contains(&"llm_request".to_string()));
+    assert!(!events.contains(&"llm_response".to_string()));
+}
+
+#[tokio::test]
+async fn deterministic_skill_executor_does_not_use_shell_interpolation() {
+    let dir = create_deterministic_skill("det-test", "echo", "No LLM fallback.");
+    let executor = executor_for_dir(&dir, MockProvider::new("mock"), None);
+    let mut args = HashMap::new();
+    args.insert(
+        "_0".to_string(),
+        forge::runtime::confidence::ConfidentValue::deterministic(
+            forge::runtime::confidence::Value::Text("hello; exit 7".to_string()),
+        ),
+    );
+
+    let result = executor.execute("det-test", "echo", &args).await.unwrap();
+
+    assert_eq!(result.value.to_string(), "hello; exit 7");
+}
+
+#[tokio::test]
+async fn deterministic_skill_executor_reports_missing_env_placeholders() {
+    let dir = tempfile::tempdir().unwrap();
+    let skill_dir = dir.path().join("env-test");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        r#"---
+name: env-test
+capabilities:
+  - name: echo
+    inputs: [Text]
+    output: Text
+    params: [text]
+    executor:
+      kind: command
+      argv: [printf, "%s", "{env:FORGE_TEST_MISSING_ENV_237}"]
+---
+Body.
+"#,
+    )
+    .unwrap();
+    let executor = executor_for_dir(&dir, MockProvider::new("mock"), None);
+
+    let err = executor
+        .execute("env-test", "echo", &HashMap::new())
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("missing environment variable 'FORGE_TEST_MISSING_ENV_237'"),
+        "unexpected error: {err}"
     );
 }
 

--- a/tests/skill_integration_tests.rs
+++ b/tests/skill_integration_tests.rs
@@ -206,6 +206,49 @@ fn skill_loader_parses_github_skill() {
 }
 
 #[test]
+fn skill_loader_parses_slack_deterministic_executors() {
+    let skill = SkillLoader::parse_skill_md(Path::new("skills/slack/SKILL.md")).unwrap();
+    assert_eq!(skill.manifest.name, "slack");
+    assert_eq!(skill.manifest.capabilities.len(), 13);
+
+    let deterministic: Vec<&str> = skill
+        .manifest
+        .capabilities
+        .iter()
+        .filter(|cap| cap.executor.is_some())
+        .map(|cap| cap.name.as_str())
+        .collect();
+    for expected in [
+        "send_message",
+        "reply_thread",
+        "add_reaction",
+        "read_history",
+        "read_thread",
+        "edit_message",
+        "delete_message",
+        "pin_message",
+        "member_info",
+    ] {
+        assert!(
+            deterministic.contains(&expected),
+            "missing deterministic executor for {}",
+            expected
+        );
+    }
+
+    let detect_mentions = skill
+        .manifest
+        .capabilities
+        .iter()
+        .find(|cap| cap.name == "detect_mentions")
+        .unwrap();
+    assert!(
+        detect_mentions.executor.is_none(),
+        "composite capability should keep the agentic fallback"
+    );
+}
+
+#[test]
 fn github_skill_registers_all_capabilities() {
     let skill = SkillLoader::parse_skill_md(Path::new("skills/github/SKILL.md")).unwrap();
     let mut registry = SkillRegistry::new();


### PR DESCRIPTION
## Summary

Adds a hybrid skill execution path for #237: typed SKILL.md capabilities can now opt into deterministic command execution metadata, while capabilities without metadata continue through the existing LLM-mediated agentic skill loop.

Key changes:
- Adds capability-level `params` and `executor` metadata parsing for SKILL.md.
- Executes deterministic command `argv` directly with `tokio::process::Command`, not `sh -c`.
- Supports `{param}` and `{env:NAME}` placeholders, plus `{{` / `}}` for literal braces.
- Supports JSON result mapping with success/error paths.
- Updates Slack single-step Web API operations to use deterministic curl argv metadata; composite capabilities such as `detect_mentions` remain agentic.
- Updates docs, changelog, and roadmap.

## Acceptance Criteria

- [x] Typed SKILL.md capabilities can optionally declare deterministic execution metadata while existing SKILL.md files continue to load unchanged.
- [x] Deterministic capabilities execute without an LLM request and without shell interpolation through `sh -c`.
- [x] Deterministic capability calls still return `ConfidentValue::from_skill(...)`, not deterministic confidence 1.0.
- [x] Deterministic capability calls emit `skill_call` and `skill_return` trace events, but no `llm_request`/`llm_response` events.
- [x] Deterministic capability calls have zero token cost.
- [x] The existing agentic SKILL.md loop remains the fallback for capabilities without deterministic metadata.
- [x] Slack single-step operations such as `add_reaction`, `reply_thread`, `read_history`, and `read_thread` use deterministic metadata.
- [x] Tests cover loader parsing, deterministic execution, error handling, trace/cost behavior, and agentic fallback compatibility.
- [x] Documentation and changelog describe the hybrid model.

## Verification

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] Manifest smoke validation: `cargo run -- run --manifest /tmp/forge-237-skill-smoke.N5Dl3A/forge.project.toml`
- [x] Trace smoke validation: `FORGE_TRACE=1 cargo run -- run --manifest /tmp/forge-237-skill-smoke.N5Dl3A/forge.project.toml` showed `skill_call` and `skill_return` with no LLM trace events.

## Known Gaps

- Live Slack API validation was not run because this architecture change does not include a safe target channel/message tuple for posting or reacting in Slack. The Slack metadata is covered by loader tests, and the deterministic runtime path is covered by unit/integration tests plus manifest smoke validation.
