### PR TITLE
feat: toolkit agent knowledge transfer infrastructure (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Toolkit agent knowledge transfer infrastructure: forge-sensei subscribes to `LearnedInsight` events from toolkit and specialist agents, closing the feedback loop so spawned agents' learnings compound in sensei's knowledge store (#167)
+- `--version` flag for all FORGE agent binaries built with `forge build`, sourced from `forge.project.toml` version field (#167)
+- Knowledge transfer integration tests: export-by-category with confidence cap, AgentTransfer source tagging, full seed→export→cap→merge→recall cycle (#167)
+- Conformance tests for `subscribe` with compound `or` filter and spawn-with-knowledge runtime execution (#167)
+- Example toolkit agent (`examples/agents/toolkit_demo.forge`) demonstrating spawn→recall→emit→absorb pattern (#167)
+
 ### Fixed
+- Multi-file project builds (`forge build`) no longer fail on cross-file lifecycle references; checker now validates the merged program (#167)
 - Quiz tutor example now runs cleanly with `FORGE_MOCK=1 forge run examples/agents/quiz_tutor.forge`, and mock-runnable examples reject checker warnings in the validation gate (#231)
 - FORGE reference, training workflow doc, and local examples now cover implemented command/session/AgentResult/verification/knowledge/skill surfaces (#229)
 - Anthropic provider now sends tool definitions and parses `tool_use` response blocks, enabling skill executor agentic loop (#198)

--- a/conformance/checker/sensei_subscribe_learned_insight.json
+++ b/conformance/checker/sensei_subscribe_learned_insight.json
@@ -1,0 +1,10 @@
+{
+  "name": "sensei_subscribe_learned_insight",
+  "category": "checker",
+  "subcategory": "events",
+  "description": "Agent subscribing to LearnedInsight with compound or-filter compiles cleanly",
+  "input": "event LearnedInsight\n  category: Text\n  content: Text\n  source: Text\n  confidence: Number\n\nexportable agent sensei\n  knowledge store: \".forge-knowledge/test\"\n    max_entries: 100\n    retention: 30d\n  subscribe LearnedInsight where source == \"toolkit\" or source == \"specialist\"\n\n  on start\n    say \"Ready\"\n\n  on LearnedInsight(category: Text, content: Text, source: Text, confidence: Number)\n    learn \"{content}\" category: category\n    say \"Absorbed from {source}\"\n",
+  "expected": {
+    "outcome": "compile_ok"
+  }
+}

--- a/conformance/runtime/knowledge_transfer_spawn.json
+++ b/conformance/runtime/knowledge_transfer_spawn.json
@@ -1,0 +1,10 @@
+{
+  "name": "knowledge_transfer_spawn",
+  "category": "runtime",
+  "description": "Spawn agent with knowledge filter and confidence cap compiles and runs",
+  "input": "event LearnedInsight\n  category: Text\n  content: Text\n  source: Text\n  confidence: Number\n\nagent worker\n  memory\n    topic: Text\n  knowledge store: \".forge-knowledge/test-worker\"\n    max_entries: 100\n    retention: 30d\n\n  on start\n    say \"Worker started for {memory.topic}\"\n    emit LearnedInsight(category: memory.topic, content: \"worker learned something\", source: \"toolkit\", confidence: 0.8)\n\n  if stuck for 2 turns\n    escalate to human\n\nexportable agent parent\n  knowledge store: \".forge-knowledge/test-parent\"\n    max_entries: 100\n    retention: 30d\n  subscribe LearnedInsight where source == \"toolkit\"\n\n  on start\n    learn \"FORGE tasks use task keyword\" category: \"TASKS\"\n    child = spawn worker as \"worker_1\"\n      with knowledge where category == \"TASKS\"\n      with confidence_cap: 0.8\n      with memory topic: \"TASKS\"\n    say \"Spawned worker\"\n\n  on LearnedInsight(category: Text, content: Text, source: Text, confidence: Number)\n    learn \"{content}\" category: category\n    say \"Absorbed [{category}]\"\n\nfn main\n  say \"done\"\n",
+  "mock_responses": [],
+  "expected": {
+    "outcome": "run_ok"
+  }
+}

--- a/examples/agents/toolkit_demo.forge
+++ b/examples/agents/toolkit_demo.forge
@@ -1,0 +1,68 @@
+use
+  llm.reason
+
+# Types and Events
+
+event LearnedInsight
+  category: Text
+  content: Text
+  source: Text
+  confidence: Number
+
+# Toolkit Agent: spawned with filtered knowledge
+#
+# Demonstrates the spawn, recall, generate, learn, feedback
+# cycle defined in issue #167.
+
+agent task_generator
+  memory
+    topic: Text
+  knowledge store: ".forge-knowledge/toolkit-demo-worker"
+    max_entries: 1000
+    retention: 30d
+
+  on start
+    say "Worker started for [{memory.topic}]"
+
+  on generate(spec: Text)
+    prior = recall "{memory.topic} {spec}"
+    when prior.sure -> emit LearnedInsight(category: memory.topic, content: "Found pattern", source: "toolkit", confidence: 0.8)
+    when prior.unsure -> emit LearnedInsight(category: "ERRORS", content: "Low confidence", source: "toolkit", confidence: 0.3)
+    else -> emit LearnedInsight(category: "ERRORS", content: "No knowledge", source: "toolkit", confidence: 0.2)
+
+  if stuck for 2 turns
+    escalate to human
+
+# Parent Agent: seeds knowledge, spawns toolkit, absorbs insights
+
+exportable agent toolkit_demo
+  memory
+    insights_received: Number
+  knowledge store: ".forge-knowledge/toolkit-demo-parent"
+    max_entries: 5000
+    retention: 90d
+  subscribe LearnedInsight where source == "toolkit"
+
+  on start
+    memory.insights_received = 0
+    learn "FORGE tasks use task name needs params gives ReturnType do body" category: "TASKS"
+    learn "FORGE flows use flow name with stage declarations" category: "FLOWS"
+    say "Toolkit demo parent ready."
+
+  on spawn_generator(topic: Text)
+    child = spawn task_generator as "gen_{topic}"
+      with knowledge where category == topic
+      with confidence_cap: 0.8
+      with memory topic: topic
+    say "Spawned task_generator for [{topic}]"
+
+  on LearnedInsight(category: Text, content: Text, source: Text, confidence: Number)
+    learn "{content}" category: category
+    memory.insights_received = memory.insights_received + 1
+    say "Parent absorbed insight [{category}] from {source}"
+
+  on status
+    give "Insights received: {memory.insights_received}"
+
+  if stuck for 3 turns
+    escalate to human

--- a/examples/validation.toml
+++ b/examples/validation.toml
@@ -14,6 +14,7 @@ paths = [
   "examples/agents/fact_check_pool.forge",
   "examples/agents/learning_agent.forge",
   "examples/agents/support_bot.forge",
+  "examples/agents/toolkit_demo.forge",
 ]
 check = "ok"
 

--- a/scripts/pretrain-toolkit.sh
+++ b/scripts/pretrain-toolkit.sh
@@ -44,7 +44,7 @@ fi
 
 # ── Counters ─────────────────────────────────────────────────
 COUNT=0
-TOTAL=63
+TOTAL=64
 FAILED=0
 FAIL_LOG=()
 PHASE_START=$SECONDS
@@ -1110,6 +1110,23 @@ Key rules:
   - The spawned agent type must be declared in the same program
   - Specialists subscribe to events filtered by their topic
 Related: see specialist agent pattern for the spawned agent's implementation
+FACT
+)"
+
+ingest_fact "AGENTS" "$(cat <<'FACT'
+FORGE toolkit agent knowledge feedback pattern. Toolkit agents emit LearnedInsight events on success or failure. The parent subscribes and absorbs insights into its own knowledge store.
+Pattern (child emits):
+  emit LearnedInsight(category: "ERRORS", content: "what was learned", source: "toolkit", confidence: 0.5)
+Pattern (parent subscribes):
+  subscribe LearnedInsight where source == "toolkit"
+  on LearnedInsight(category: Text, content: Text, source: Text, confidence: Number)
+    learn "{content}" category: category
+Key rules:
+  - Toolkit agents use source: "toolkit" to distinguish from other LearnedInsight sources
+  - Parent subscribes with a filter to avoid feedback loops (not re-ingesting its own emissions)
+  - confidence_cap on spawn already limits transferred knowledge confidence (Principle I — Honesty)
+  - LearnedInsight events flow through the event bus; the parent must have a matching handler
+Related: see spawn with knowledge transfer pattern for how knowledge is initially seeded into toolkit agents
 FACT
 )"
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -89,28 +89,48 @@ impl BuildPipeline {
             });
         }
 
-        // Step 3: Per-file validation
+        // Step 3: Cross-file boundary check (on pre-merge programs)
         let mut diagnostics = Vec::new();
-        for sf in &source_files {
-            let ctx = crate::resolver::CheckContext::new(&sf.path);
-            if let Err(errors) = ctx.check(&sf.program) {
-                let registry = crate::resolver::CapabilityRegistry::builtin();
-                diagnostics.extend(errors.iter().map(|e| e.to_diagnostic(&sf.path, &registry)));
-            }
-            diagnostics.extend(crate::checker::check_all(&sf.program, &sf.path));
-        }
-
-        // Step 4: Cross-file boundary check (on pre-merge programs)
         let boundary_refs: Vec<_> = source_files
             .iter()
             .map(|sf| (&sf.program, sf.path.as_str()))
             .collect();
         diagnostics.extend(crate::checker::boundary_checker::check(&boundary_refs));
 
+        // Step 4: Merge programs (before full validation, so cross-file
+        // references like lifecycle states resolve correctly)
+        let composed = compose::merge_programs(&source_files).map_err(|errs| {
+            anyhow::anyhow!(
+                "composition failed:\n{}",
+                errs.iter()
+                    .map(|e| format!("  {}", e))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        })?;
+
+        // Step 5: Validate the merged program
+        let merged_fname = source_files
+            .first()
+            .map(|sf| sf.path.clone())
+            .unwrap_or_default();
+        let ctx = crate::resolver::CheckContext::new(&merged_fname);
+        if let Err(errors) = ctx.check(&composed.program) {
+            let registry = crate::resolver::CapabilityRegistry::builtin();
+            diagnostics.extend(
+                errors
+                    .iter()
+                    .map(|e| e.to_diagnostic(&merged_fname, &registry)),
+            );
+        }
+        diagnostics.extend(crate::checker::check_all(&composed.program, &merged_fname));
+
         // Render all diagnostics, but only fail on errors
         if !diagnostics.is_empty() {
             for diag in &diagnostics {
                 if let Some(sf) = source_files.iter().find(|sf| sf.path == diag.file) {
+                    diag.render(&sf.source);
+                } else if let Some(sf) = source_files.first() {
                     diag.render(&sf.source);
                 }
             }
@@ -122,17 +142,6 @@ impl BuildPipeline {
                 anyhow::bail!("validation failed with {} error(s)", error_count);
             }
         }
-
-        // Step 5: Merge programs
-        let composed = compose::merge_programs(&source_files).map_err(|errs| {
-            anyhow::anyhow!(
-                "composition failed:\n{}",
-                errs.iter()
-                    .map(|e| format!("  {}", e))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            )
-        })?;
 
         // Step 6: Detect program kind
         let kind = compose::detect_kind(&composed.program).ok_or_else(|| {
@@ -298,6 +307,12 @@ dirs = "6"
 
                 return Ok(AgentInfo {
                     name: agent.name.node.clone(),
+                    version: self
+                        .manifest
+                        .project
+                        .version
+                        .clone()
+                        .unwrap_or_else(|| "0.1.0".to_string()),
                     handlers,
                 });
             }
@@ -369,6 +384,7 @@ dirs = "6"
 
 struct AgentInfo {
     name: String,
+    version: String,
     handlers: Vec<HandlerInfo>,
 }
 
@@ -597,7 +613,7 @@ const SOURCES: &[(&str, &str)] = &[
 {config}
 
 #[derive(Parser)]
-#[command(name = "{agent_name}", about = "FORGE agent: {agent_name}")]
+#[command(name = "{agent_name}", about = "FORGE agent: {agent_name}", version = "{agent_version}")]
 struct Cli {{
     #[command(subcommand)]
     command: Command,
@@ -777,6 +793,7 @@ async fn main() -> anyhow::Result<()> {{
         sources = sources_array,
         config = config_code,
         agent_name = agent.name,
+        agent_version = agent.version,
         variants = variants.join("\n"),
         match_arms = match_arms.join("\n"),
     )

--- a/tests/knowledge_transfer_tests.rs
+++ b/tests/knowledge_transfer_tests.rs
@@ -1,0 +1,194 @@
+// FORGE knowledge transfer integration tests (issue #167)
+// Tests the toolkit agent knowledge transfer pipeline:
+//   parent export_by_category → confidence cap → merge_imported → child recall
+
+use tempfile::TempDir;
+
+use forge::runtime::knowledge_store::{KnowledgeEntry, KnowledgeSource, KnowledgeStore};
+
+// ── Helper ──────────────────────────────────────────────────
+
+fn make_entry(content: &str, confidence: f32, category: &str) -> KnowledgeEntry {
+    KnowledgeEntry {
+        id: uuid::Uuid::new_v4().to_string(),
+        content: content.to_string(),
+        source: KnowledgeSource::Direct,
+        confidence,
+        category: Some(category.to_string()),
+        created_at: chrono::Utc::now(),
+        last_accessed: chrono::Utc::now(),
+        access_count: 0,
+        success_associations: 0,
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+#[test]
+fn export_by_category_with_confidence_cap() {
+    let tmp = TempDir::new().unwrap();
+    let store_path = tmp.path().join("parent").to_string_lossy().to_string();
+
+    let mut parent = KnowledgeStore::new(&store_path, Some(100), None);
+    parent.learn_direct_categorized("FORGE tasks use task keyword", "TASKS");
+    parent.learn_direct_categorized("FORGE flows use flow keyword", "FLOWS");
+    parent.learn_direct_categorized("FORGE agents use agent keyword", "AGENTS");
+    parent.learn_direct_categorized("Another TASKS fact about gives clause", "TASKS");
+
+    // Export only TASKS category
+    let mut transferred = parent.export_by_category("TASKS");
+    assert_eq!(transferred.len(), 2);
+
+    // Apply confidence cap (mirrors executor.rs logic)
+    let cap = 0.8;
+    for entry in &mut transferred {
+        entry.confidence = entry.confidence.min(cap);
+        entry.source = KnowledgeSource::AgentTransfer {
+            source_agent: "parent".to_string(),
+        };
+    }
+
+    // All entries should be capped
+    assert!(transferred.iter().all(|e| e.confidence <= cap));
+
+    // Merge into child store
+    let child_path = tmp.path().join("child").to_string_lossy().to_string();
+    let mut child = KnowledgeStore::new(&child_path, Some(100), None);
+    let added = child.merge_imported(transferred);
+    assert_eq!(added, 2);
+    assert_eq!(child.entry_count(), 2);
+
+    // Child should be able to recall TASKS knowledge
+    let result = child.recall("FORGE tasks", 1000);
+    assert!(
+        result.confidence > 0.0,
+        "child should recall transferred knowledge"
+    );
+    let text = format!("{}", result.value);
+    assert!(
+        text.contains("task"),
+        "recalled text should contain task content"
+    );
+}
+
+#[test]
+fn merge_preserves_category_and_agent_transfer_source() {
+    let tmp = TempDir::new().unwrap();
+
+    // Create entries tagged as AgentTransfer
+    let mut entries = vec![
+        make_entry("FORGE task declaration pattern", 0.8, "TASKS"),
+        make_entry("FORGE flow pipeline stages", 0.7, "FLOWS"),
+    ];
+    for entry in &mut entries {
+        entry.source = KnowledgeSource::AgentTransfer {
+            source_agent: "forge_sensei".to_string(),
+        };
+    }
+
+    let store_path = tmp.path().join("child").to_string_lossy().to_string();
+    let mut store = KnowledgeStore::new(&store_path, Some(100), None);
+    store.merge_imported(entries);
+
+    // Verify category preserved
+    let tasks = store.export_by_category("TASKS");
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].category.as_deref(), Some("TASKS"));
+
+    // Verify source preserved
+    match &tasks[0].source {
+        KnowledgeSource::AgentTransfer { source_agent } => {
+            assert_eq!(source_agent, "forge_sensei");
+        }
+        other => panic!("expected AgentTransfer source, got {:?}", other),
+    }
+
+    let flows = store.export_by_category("FLOWS");
+    assert_eq!(flows.len(), 1);
+}
+
+#[test]
+fn full_transfer_cycle_seed_export_cap_merge_recall() {
+    let tmp = TempDir::new().unwrap();
+
+    // 1. Parent seeds categorized knowledge
+    let parent_path = tmp.path().join("parent").to_string_lossy().to_string();
+    let mut parent = KnowledgeStore::new(&parent_path, Some(1000), None);
+
+    parent.learn_direct_categorized(
+        "FORGE basic task declaration pattern. A task is the primary compute unit. Syntax: task name needs params gives ReturnType do body",
+        "TASKS",
+    );
+    parent.learn_direct_categorized(
+        "FORGE task with reason primitive. Tasks can call reason for LLM inference: result = reason \"prompt\"",
+        "TASKS",
+    );
+    parent.learn_direct_categorized(
+        "FORGE flow declaration pattern. Flows are multi-stage pipelines: flow name needs params gives ReturnType with stage declarations",
+        "FLOWS",
+    );
+    parent.learn_direct_categorized(
+        "FORGE agent handler pattern. Agents respond to events via on handlers: on event_name(params) body",
+        "AGENTS",
+    );
+
+    // 2. Export TASKS only (simulates spawn with knowledge where category == "TASKS")
+    let mut transferred = parent.export_by_category("TASKS");
+    assert_eq!(
+        transferred.len(),
+        2,
+        "should export exactly 2 TASKS entries"
+    );
+
+    // 3. Apply confidence cap (simulates confidence_cap: 0.8)
+    for entry in &mut transferred {
+        entry.confidence = entry.confidence.min(0.8);
+        entry.source = KnowledgeSource::AgentTransfer {
+            source_agent: "forge_sensei".to_string(),
+        };
+    }
+
+    // 4. Merge into child's knowledge store
+    let child_path = tmp.path().join("child").to_string_lossy().to_string();
+    let mut child = KnowledgeStore::new(&child_path, Some(1000), None);
+    let added = child.merge_imported(transferred);
+    assert_eq!(added, 2);
+
+    // 5. Child recalls TASKS knowledge
+    let result = child.recall("FORGE task declaration needs gives", 2000);
+    assert!(
+        result.confidence > 0.0,
+        "child should find relevant TASKS knowledge"
+    );
+    let text = format!("{}", result.value);
+    assert!(
+        text.contains("task") && text.contains("compute unit"),
+        "recall should return task declaration pattern, got: {}",
+        text
+    );
+
+    // 6. Verify FLOWS and AGENTS were NOT transferred
+    let flows = child.export_by_category("FLOWS");
+    assert!(flows.is_empty(), "FLOWS should not be in child store");
+    let agents = child.export_by_category("AGENTS");
+    assert!(agents.is_empty(), "AGENTS should not be in child store");
+
+    // 7. Simulate child learning (feedback loop)
+    child.learn_direct_categorized(
+        "Generated task pattern: task greet needs name: Text gives Text do give \"Hello {name}\"",
+        "TASKS",
+    );
+    assert_eq!(child.entry_count(), 3);
+
+    // 8. Export child's learned insight back (simulates LearnedInsight → parent absorbs)
+    let feedback = child.export_filtered(|e| e.content.contains("Generated task pattern"));
+    assert_eq!(feedback.len(), 1);
+
+    let before = parent.entry_count();
+    parent.merge_imported(feedback);
+    assert_eq!(
+        parent.entry_count(),
+        before + 1,
+        "parent should absorb child's learned insight"
+    );
+}

--- a/workflows/forge-sensei/agent.forge
+++ b/workflows/forge-sensei/agent.forge
@@ -17,6 +17,7 @@ exportable agent forge_sensei
     max_entries: 50000
     retention: 365d
   timer self_assess: 6h
+  subscribe LearnedInsight where source == "toolkit" or source == "specialist"
 
   on start
     memory.current_level = "novice"
@@ -57,6 +58,13 @@ exportable agent forge_sensei
     learn "{lesson}"
     emit LearnedInsight(category: "interactions", content: lesson, source: "session", confidence: 0.8)
     say "Learned from session."
+
+  # ── Absorb: incorporate toolkit agent insights ─────────────
+
+  on LearnedInsight(category: Text, content: Text, source: Text, confidence: Number)
+    learn "{content}" category: category
+    memory.interaction_count = memory.interaction_count + 1
+    say "Sensei absorbed insight from {source}: [{category}]"
 
   # ── Deep Dive: spawn specialist for focused domain learning ──
 

--- a/workflows/forge-sensei/forge.project.toml
+++ b/workflows/forge-sensei/forge.project.toml
@@ -1,6 +1,6 @@
 [project]
 name = "forge-sensei"
-version = "0.2.0"
+version = "0.2.1"
 description = "FORGE language learning agent — CLI + web interface"
 
 [build]


### PR DESCRIPTION
## Summary

- forge-sensei now subscribes to `LearnedInsight` events from toolkit and specialist agents, absorbing their insights into its knowledge store
- Each generation of spawned toolkit agents benefits from prior runs' learnings (compounding knowledge loop)
- All FORGE agent binaries now support `--version` flag, sourced from `forge.project.toml`
- Fixed multi-file build pipeline that was failing on cross-file lifecycle references

## Changes

- `workflows/forge-sensei/agent.forge` — subscribe + handler for LearnedInsight
- `examples/agents/toolkit_demo.forge` — new example demonstrating spawn→recall→emit→absorb
- `tests/knowledge_transfer_tests.rs` — 3 integration tests for the transfer pipeline
- `conformance/` — 2 new tests (checker + runtime)
- `src/build.rs` — validate merged program instead of per-file; add --version to agent CLI
- `scripts/pretrain-toolkit.sh` — new knowledge feedback pattern fact
- `workflows/forge-sensei/forge.project.toml` — bump to v0.2.1

## Test plan

- [x] 96 conformance tests pass (including 2 new)
- [x] 3 new knowledge_transfer_tests pass (export/cap/merge/recall cycle)
- [x] Example validation tests pass (toolkit_demo.forge)
- [x] Event bus tests pass (13 tests)
- [x] forge-sensei binary builds and smoke tests 5/5
- [x] `forge-sensei --version` prints `0.2.1`
- [x] Live query test: sensei answers and learns (96→98 entries)

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)