### PR TITLE
fix: sensei operational readiness — lifecycle + mastery gates (#240)

### DIFF
--- a/scripts/install-sensei.sh
+++ b/scripts/install-sensei.sh
@@ -68,7 +68,7 @@ if [ "$1" = "status" ] && [ -f "$SENSEI_DIR/knowledge.json" ]; then
   fi
 fi
 
-FORGE_APP_CONFIG="$SENSEI_DIR/config.toml" \
+FORGE_CONFIG="${FORGE_CONFIG:-$SENSEI_DIR/config.toml}" \
   exec "$SENSEI_DIR/forge-sensei-bin" "$@"
 WRAPPER
 chmod +x "$BIN_DIR/forge-sensei"

--- a/scripts/pretrain-sensei.sh
+++ b/scripts/pretrain-sensei.sh
@@ -2,6 +2,7 @@
 # pretrain-sensei.sh — Bulk pre-training pipeline for forge-sensei
 # Usage: bash scripts/pretrain-sensei.sh [--force] [--dry-run]
 set -euo pipefail
+shopt -s globstar nullglob
 
 FORGE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SENSEI_BIN="${SENSEI_BIN:-$HOME/.forge/bin/forge-sensei}"
@@ -43,8 +44,7 @@ collect() { [ -f "$1" ] && FILES+=("$1"); }
 for f in docs/forge-reference.md forge-principles.md README.md roadmap.md providers.md CONTRIBUTING.md; do
   collect "$FORGE_ROOT/$f"
 done
-for f in "$FORGE_ROOT"/examples/*.forge; do collect "$f"; done
-for f in "$FORGE_ROOT"/examples/tictactoe/*.forge; do collect "$f"; done
+for f in "$FORGE_ROOT"/examples/**/*.forge; do collect "$f"; done
 for f in "$FORGE_ROOT"/workflows/*.forge; do
   [ "$(basename "$f")" = "forge-sensei.forge" ] && continue
   collect "$f"
@@ -146,7 +146,7 @@ phase_time
 
 # ── Phase 2: Example Programs ────────────────────────────────
 echo "Phase 2: Example programs..."
-for f in "$FORGE_ROOT"/examples/*.forge "$FORGE_ROOT"/examples/tictactoe/*.forge; do
+for f in "$FORGE_ROOT"/examples/**/*.forge; do
   [ -f "$f" ] && ingest "$f"
 done
 phase_time

--- a/scripts/sensei-e2e-test.sh
+++ b/scripts/sensei-e2e-test.sh
@@ -339,6 +339,38 @@ run_test "smoke-test-script" bash "$FORGE_ROOT/scripts/sensei-smoke-test.sh"
 run_test "cache-stats" bash "$FORGE_ROOT/scripts/sensei-cache.sh" stats
 echo ""
 
+# ── Category 10: Mastery Progression ────────────────────────
+echo "=== Category 10: Mastery Progression ==="
+
+# Save current state so we can restore after testing
+MASTERY_BACKUP=$(cat "$HOME/.forge/sensei/state.json" 2>/dev/null || echo '{}')
+
+# Reset to novice (clear redb lifecycle + memory state)
+bash "$FORGE_ROOT/scripts/sensei-cache.sh" reset >/dev/null 2>&1 || true
+
+# Verify status shows novice after reset
+check_contains "mastery-reset-novice" "novice" "$SENSEI_BIN" status
+
+# Verify review gate rejects at novice
+check_contains "review-gate-novice" "novice|apprentice|assessment" "$SENSEI_BIN" review "pure x gives Number do give 1"
+
+# Verify deep_dive gate rejects at novice
+check_contains "deepdive-gate-novice" "journeyman|level|assessment" "$SENSEI_BIN" deep-dive "SYNTAX"
+
+# Run assessment to advance (uses iterative update-mastery)
+run_test "mastery-assessment" bash "$HOME/.claude/skills/forge-sensei/assess.sh" --json
+
+# Verify status shows advanced level (not novice)
+check_not_contains "mastery-post-assess" "novice" "$SENSEI_BIN" status
+
+# Verify persistence: re-check status still shows advanced
+check_not_contains "mastery-persists" "novice" "$SENSEI_BIN" status
+
+# Verify review gate passes after advancement
+run_test "review-gate-post-assess" "$SENSEI_BIN" review "pure add needs a: Number gives Number do give a + 1"
+
+echo ""
+
 # ── Summary ───────────────────────────────────────────────────
 echo "============================================"
 echo " E2E Results: $PASSED passed, $FAILED failed, $TOTAL total"

--- a/workflows/forge-sensei/agent.forge
+++ b/workflows/forge-sensei/agent.forge
@@ -20,9 +20,10 @@ exportable agent forge_sensei
   subscribe LearnedInsight where source == "toolkit" or source == "specialist"
 
   on start
-    memory.current_level = "novice"
+    if memory.current_level == ""
+      memory.current_level = "novice"
     start self_assess
-    say "forge-sensei initialized. Level: novice. Ready to learn and teach FORGE."
+    say "forge-sensei initialized. Level: {memory.current_level}. Ready to learn and teach FORGE."
 
   # ── Pre-training: bulk document ingestion ───────────────────
 
@@ -85,7 +86,6 @@ exportable agent forge_sensei
   # ── Assess: objective self-evaluation ───────────────────────
 
   on assess_detailed(test_input: Text, expected: Text)
-    requires lifecycle == apprentice or lifecycle == journeyman or lifecycle == expert on fail: give AssessmentResult(passed: false, prediction: "", expected: expected, gap_topic: "Must reach apprentice level first")
     memory.interaction_count = memory.interaction_count + 1
     categories = categorize_for_recall("{test_input} expects {expected}")
     prior = recall "{categories} {test_input}"
@@ -111,12 +111,12 @@ exportable agent forge_sensei
     score = compute_mastery_score(passed, total)
     memory.last_assessment_score = score
     level = determine_level(score)
-    if score >= 90 and lifecycle != expert
-      transition to expert
-    if score >= 70 and lifecycle == apprentice
-      transition to journeyman
     if score >= 40 and lifecycle == novice
       transition to apprentice
+    if score >= 70 and lifecycle == apprentice
+      transition to journeyman
+    if score >= 90 and lifecycle == journeyman
+      transition to expert
     emit AssessmentCompleted(level: level, score: score, passed: passed, total: total, failures: gaps)
     give AssessmentResult(passed: score >= 40, prediction: "{passed}/{total}", expected: ">=40%", gap_topic: gaps)
 


### PR DESCRIPTION
## Summary
- Fix 4 bugs preventing forge-sensei from working end-to-end: assess_detailed chicken-and-egg gate, illegal FSM transitions in batch_assess, on start memory reset, and wrapper config env var
- Fix pretrain-sensei.sh glob patterns to find examples in subdirectories
- Add Category 10 mastery progression E2E tests
- Verified: 96/96 conformance tests pass, expert level reached, review + deep_dive gates work, 465 knowledge entries populated

## What was broken
1. `assess_detailed` required apprentice+ but assessment is how you reach apprentice
2. `batch_assess` tried `novice→expert` (illegal — FSM only allows single-step edges)
3. `on start` unconditionally set `memory.current_level = "novice"`, stomping persisted state
4. Wrapper used `FORGE_APP_CONFIG` but the built binary reads `FORGE_CONFIG`

## Test plan
- [x] `cargo test` — 330 tests pass, no regressions
- [x] `bash scripts/build-sensei.sh` — binary builds
- [x] `bash scripts/pretrain-toolkit.sh --force` — 64/64 patterns ingested
- [x] `bash scripts/pretrain-sensei.sh --force` — 182/182 items ingested (465 total entries)
- [x] `bash ~/.claude/skills/forge-sensei/assess.sh` — 96/96 (100%), expert level reached
- [x] `forge-sensei status` — shows expert, persists across restarts
- [x] `forge-sensei review "..."` — works at expert (apprentice+ gate passes)
- [x] `forge-sensei deep-dive "TASKS"` — gate passes at expert (spawn needs daemon mode)
- [ ] `bash scripts/sensei-e2e-test.sh` — Category 10 mastery progression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)