### PR TITLE
feat(checker): pure-FORGE client boundary cap set

### DIFF
--- a/src/checker/boundary_checker.rs
+++ b/src/checker/boundary_checker.rs
@@ -311,6 +311,17 @@ fn check_refs_in_stmt(
             }
         }
         Stmt::Emit(name, args) => {
+            if boundary == BoundaryKind::Client {
+                diagnostics.push(
+                    Diagnostic::error(
+                        file,
+                        format!("emit `{}` is not allowed in client boundary", name.node),
+                        name.span.start..name.span.end,
+                        "the event bus is a server-runtime construct; a one-shot client has no bus to emit onto",
+                    )
+                    .with_help("call a server endpoint (via web.post) that emits the event server-side"),
+                );
+            }
             check_name_ref(
                 &name.node,
                 name.span.start,
@@ -396,6 +407,17 @@ fn check_refs_in_stmt(
             }
         }
         Stmt::Spawn(s) => {
+            if boundary == BoundaryKind::Client {
+                diagnostics.push(
+                    Diagnostic::error(
+                        file,
+                        format!("spawn `{}` is not allowed in client boundary", s.template.node),
+                        s.template.span.start..s.template.span.end,
+                        "spawn requires a supervising runtime that outlives a single request; a client is a one-shot process",
+                    )
+                    .with_help("call a server endpoint that performs the spawn, or move this code to `#! boundary: server`"),
+                );
+            }
             if let Some(ref alias) = s.alias {
                 check_refs_in_expr(alias, boundary, registry, file, diagnostics);
             }
@@ -559,31 +581,43 @@ fn check_refs_in_expr(
             check_refs_in_expr(a, boundary, registry, file, diagnostics);
         }
         Expr::MethodCall(inner, method, args) => {
-            // Boundary enforcement: web.fetch and web.post are server-only
             if let Expr::Ident(ref ns) = inner.node {
+                // web.fetch / web.post: allowed in server AND client (HTTP egress is a
+                // legitimate client capability); rejected in shared (shared is types/pure).
                 if ns == "web"
                     && (method.node == "fetch" || method.node == "post")
-                    && boundary != BoundaryKind::Server
+                    && boundary == BoundaryKind::Shared
                 {
-                    let boundary_name = match boundary {
-                        BoundaryKind::Client => "client",
-                        BoundaryKind::Shared => "shared",
-                        _ => unreachable!(),
-                    };
                     diagnostics.push(
                         Diagnostic::error(
                             file,
-                            format!(
-                                "web.{}() is not allowed in {} boundary",
-                                method.node, boundary_name
-                            ),
+                            format!("web.{}() is not allowed in shared boundary", method.node),
                             inner.span.start..method.span.end,
                             format!(
-                                "web.{}() can only be used in server boundary files",
+                                "web.{}() makes HTTP requests and must live in server or client boundary files",
                                 method.node
                             ),
                         )
-                        .with_help("move this code to a file with `#! boundary: server`"),
+                        .with_help("move this code to a file with `#! boundary: server` or `#! boundary: client`"),
+                    );
+                }
+                // data.store / data.get: durable storage is a server-lifecycle concept
+                // and is not available in a one-shot client process.
+                if ns == "data"
+                    && (method.node == "store"
+                        || method.node == "get"
+                        || method.node == "list"
+                        || method.node == "delete")
+                    && boundary == BoundaryKind::Client
+                {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            file,
+                            format!("data.{}() is not allowed in client boundary", method.node),
+                            inner.span.start..method.span.end,
+                            "durable storage is a server capability; a client has no storage runtime",
+                        )
+                        .with_help("call a server endpoint that reads or writes the data, or move this code to `#! boundary: server`"),
                     );
                 }
             }

--- a/tests/boundary_client_web_tests.rs
+++ b/tests/boundary_client_web_tests.rs
@@ -1,0 +1,246 @@
+// Tests for boundary client cap set — issue #250 (part of epic #249).
+//
+// A boundary: client program must be able to do HTTP egress (web.fetch/web.post)
+// and read env vars (env.get — see #251), but must be locked out of the
+// server-lifecycle capabilities: spawn, emit, data.*, endpoint, search.
+
+use forge::checker::boundary_checker;
+use forge::diagnostic::DiagnosticKind;
+
+fn errors_for(src: &str) -> Vec<String> {
+    let program = forge::parser::parse(src).expect("parse should succeed");
+    let diags = boundary_checker::check(&[(&program, "test.forge")]);
+    diags
+        .into_iter()
+        .filter(|d| matches!(d.kind, DiagnosticKind::Error))
+        .map(|d| d.message)
+        .collect()
+}
+
+// ── web.fetch / web.post: allowed in client boundary (the core of #250) ────
+
+#[test]
+fn client_boundary_allows_web_post() {
+    let src = r#"#! boundary: client
+
+use
+  web.post
+
+task call_server
+  needs question: Text
+  gives Text
+  do
+    response = web.post("http://localhost:3000/api/ask", question)
+    give response
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.is_empty(),
+        "client boundary should allow web.post, got errors: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn client_boundary_allows_web_fetch() {
+    let src = r#"#! boundary: client
+
+use
+  web.fetch
+
+task call_server
+  gives Text
+  do
+    response = web.fetch("http://localhost:3000/api/status")
+    give response
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.is_empty(),
+        "client boundary should allow web.fetch, got errors: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn server_boundary_still_allows_web_post() {
+    let src = r#"#! boundary: server
+
+use
+  web.post
+
+task call_other
+  gives Text
+  do
+    response = web.post("http://other-service/api", "payload")
+    give response
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.is_empty(),
+        "server boundary should still allow web.post, got errors: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn shared_boundary_rejects_web_post() {
+    let src = r#"#! boundary: shared
+
+use
+  web.post
+
+task call_something
+  gives Text
+  do
+    response = web.post("http://x/y", "z")
+    give response
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("web.post") && e.contains("shared")),
+        "shared boundary should reject web.post, got errors: {:?}",
+        errs
+    );
+}
+
+// ── data.store / data.get: rejected in client boundary ─────────────────────
+
+#[test]
+fn client_boundary_rejects_data_store() {
+    let src = r#"#! boundary: client
+
+use
+  data.store
+
+task persist
+  needs key: Text, value: Text
+  gives Text
+  do
+    data.store(key, value)
+    give "stored"
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("data.store") && e.contains("client")),
+        "client boundary should reject data.store, got errors: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn client_boundary_rejects_data_get() {
+    let src = r#"#! boundary: client
+
+use
+  data.get
+
+task read
+  needs key: Text
+  gives Text
+  do
+    value = data.get(key)
+    give value
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("data.get") && e.contains("client")),
+        "client boundary should reject data.get, got errors: {:?}",
+        errs
+    );
+}
+
+// ── endpoints: rejected in client (unchanged from prior behavior) ─────────
+
+#[test]
+fn client_boundary_rejects_endpoint() {
+    let src = r#"#! boundary: client
+
+endpoint health() -> Text
+  give "ok"
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("endpoint") && e.contains("client")),
+        "client boundary should reject endpoint decls, got errors: {:?}",
+        errs
+    );
+}
+
+// ── spawn: rejected in client boundary ────────────────────────────────────
+
+#[test]
+fn client_boundary_rejects_spawn() {
+    let src = r#"#! boundary: client
+
+agent specialist
+  on start
+    say "ready"
+
+agent client_agent
+  on invoke
+    child = spawn specialist as "child_{1}"
+    say "spawned"
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("spawn") && e.contains("client")),
+        "client boundary should reject spawn, got errors: {:?}",
+        errs
+    );
+}
+
+// ── emit: rejected in client boundary ─────────────────────────────────────
+
+#[test]
+fn client_boundary_rejects_emit() {
+    let src = r#"#! boundary: client
+
+event Insight
+  topic: Text
+
+agent client_agent
+  on invoke
+    emit Insight(topic: "test")
+    say "emitted"
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("emit") && e.contains("client")),
+        "client boundary should reject emit, got errors: {:?}",
+        errs
+    );
+}
+
+// ── Combined: a realistic pure-FORGE client agent should pass cleanly ─────
+
+#[test]
+fn realistic_client_agent_compiles_cleanly() {
+    let src = r#"#! boundary: client
+
+use
+  web.post
+  web.fetch
+
+agent forge_sensei_client
+  on status
+    response = web.fetch("http://127.0.0.1:3000/api/status")
+    say response
+
+  on query(question: Text)
+    response = web.post("http://127.0.0.1:3000/api/ask", question)
+    say response
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.is_empty(),
+        "realistic client agent should have no errors, got: {:?}",
+        errs
+    );
+}

--- a/tests/boundary_tests.rs
+++ b/tests/boundary_tests.rs
@@ -452,7 +452,9 @@ task noop
 // ── HTTP client boundary enforcement (issue #51) ────────────
 
 #[test]
-fn web_fetch_in_client_boundary_is_error() {
+fn web_fetch_in_client_boundary_is_ok() {
+    // Updated for #250: web.fetch is a legitimate client capability for pure-FORGE
+    // HTTP clients talking to a server. Only shared boundary still rejects it.
     let source = "\
 #! boundary: client
 
@@ -462,13 +464,16 @@ fn main
 ";
     let diags = check_boundary(&[(source, "client.forge")]);
     let errs = errors(&diags);
-    assert_eq!(errs.len(), 1);
-    assert!(errs[0].message.contains("web.fetch()"));
-    assert!(errs[0].message.contains("client"));
+    assert!(
+        errs.is_empty(),
+        "web.fetch should be allowed in client boundary (#250), got: {:?}",
+        errs
+    );
 }
 
 #[test]
-fn web_post_in_client_boundary_is_error() {
+fn web_post_in_client_boundary_is_ok() {
+    // Updated for #250: see above.
     let source = "\
 #! boundary: client
 
@@ -478,9 +483,29 @@ fn main
 ";
     let diags = check_boundary(&[(source, "client.forge")]);
     let errs = errors(&diags);
+    assert!(
+        errs.is_empty(),
+        "web.post should be allowed in client boundary (#250), got: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn web_fetch_in_shared_boundary_is_error() {
+    // Added for #250: shared is the one boundary where web.* is not allowed
+    // (shared is for types + pure code that both sides import).
+    let source = "\
+#! boundary: shared
+
+fn main
+  page = web.fetch(\"https://example.com\")
+  give page
+";
+    let diags = check_boundary(&[(source, "shared.forge")]);
+    let errs = errors(&diags);
     assert_eq!(errs.len(), 1);
-    assert!(errs[0].message.contains("web.post()"));
-    assert!(errs[0].message.contains("client"));
+    assert!(errs[0].message.contains("web.fetch()"));
+    assert!(errs[0].message.contains("shared"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Fixes #250.
- Allows `web.fetch` and `web.post` in `#! boundary: client` while keeping them rejected in shared boundary.
- Rejects client-boundary `data.*`, `spawn`, and `emit` with actionable guidance.
- Adds `tests/boundary_client_web_tests.rs` and updates existing boundary expectations.

## Acceptance Criteria
- [x] `boundary: client` program with `web.post` in a task -> checker OK.
- [x] `boundary: client` with `endpoint` -> checker rejects.
- [x] `boundary: client` with `data.store` -> checker rejects.
- [x] `boundary: client` with `spawn specialist as "x"` -> checker rejects with supervising-runtime guidance.
- [x] All existing tests pass.
- [x] New test file `tests/boundary_client_web_tests.rs`.

## Verification
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `bash scripts/check-forge-examples.sh`
- `bash scripts/check-principles.sh`
- `git diff --check`

## Stack
- Base PR: #260
- Next PR: #251 / env.get

## Known Gaps
- None.