### PR TITLE
feat(runtime): env.get primitive

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -180,6 +180,16 @@ impl CapabilityRegistry {
                 output: ForgeType::Text,
             },
         );
+        // env.get(name, default) -> Text — read an environment variable at runtime,
+        // with fallback. Allowed in all boundaries (server, client, shared).
+        // See issue #251 (part of epic #249).
+        caps.insert(
+            "env.get".into(),
+            CapabilitySignature {
+                inputs: vec![ForgeType::Text, ForgeType::Text],
+                output: ForgeType::Text,
+            },
+        );
         caps.insert(
             "data.store".into(),
             CapabilitySignature {

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -1854,6 +1854,27 @@ impl TaskExecutor {
                         }
                     }
 
+                    // env.get(name, default) — read an environment variable with fallback.
+                    // See issue #251 (part of epic #249).
+                    if let Expr::Ident(ref ns) = obj_expr.node {
+                        if ns == "env" && method.node == "get" {
+                            let mut arg_vals = Vec::new();
+                            for arg in args {
+                                arg_vals.push(self.eval_expr(&arg.node.value, env).await?);
+                            }
+                            let name = arg_vals
+                                .first()
+                                .map(|v| format!("{}", v.value))
+                                .unwrap_or_default();
+                            let default = arg_vals
+                                .get(1)
+                                .map(|v| format!("{}", v.value))
+                                .unwrap_or_default();
+                            let value = std::env::var(&name).unwrap_or_else(|_| default.clone());
+                            return Ok(ConfidentValue::deterministic(Value::Text(value)));
+                        }
+                    }
+
                     // web.fetch() / web.post() — built-in HTTP client capabilities
                     if let Expr::Ident(ref ns) = obj_expr.node {
                         if ns == "web" {

--- a/tests/env_primitive_tests.rs
+++ b/tests/env_primitive_tests.rs
@@ -1,0 +1,122 @@
+// Tests for env.get runtime primitive — issue #251 (part of epic #249).
+//
+// env.get(name, default) reads an environment variable at runtime, falling back
+// to `default` if unset. Usable in all boundaries (server, client, shared).
+
+use forge::checker::boundary_checker;
+use forge::diagnostic::DiagnosticKind;
+
+fn errors_for(src: &str) -> Vec<String> {
+    let program = forge::parser::parse(src).expect("parse should succeed");
+    let diags = boundary_checker::check(&[(&program, "test.forge")]);
+    diags
+        .into_iter()
+        .filter(|d| matches!(d.kind, DiagnosticKind::Error))
+        .map(|d| d.message)
+        .collect()
+}
+
+// ── Boundary acceptance ────────────────────────────────────────────────────
+
+#[test]
+fn env_get_is_allowed_in_client_boundary() {
+    let src = r#"#! boundary: client
+
+use
+  env.get
+
+task resolve_server
+  gives Text
+  do
+    url = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    give url
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.is_empty(),
+        "env.get should be allowed in client boundary, got errors: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn env_get_is_allowed_in_server_boundary() {
+    let src = r#"#! boundary: server
+
+use
+  env.get
+
+task resolve_home
+  gives Text
+  do
+    home = env.get("HOME", "/tmp")
+    give home
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.is_empty(),
+        "env.get should be allowed in server boundary, got errors: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn env_get_is_allowed_in_shared_boundary() {
+    let src = r#"#! boundary: shared
+
+use
+  env.get
+
+task resolve_log_level
+  gives Text
+  do
+    level = env.get("FORGE_LOG_LEVEL", "info")
+    give level
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.is_empty(),
+        "env.get should be allowed in shared boundary, got errors: {:?}",
+        errs
+    );
+}
+
+// ── Runtime behaviour ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn env_get_returns_set_value() {
+    use std::sync::Arc;
+    std::env::set_var("FORGE_TEST_ENV_VALUE", "hello-from-env");
+
+    let src = r#"fn main
+  value = env.get("FORGE_TEST_ENV_VALUE", "default")
+  give value
+"#;
+    let program = forge::parser::parse(src).expect("parse should succeed");
+    let config = forge::config::ForgeConfig::default_mock_config();
+    let registry =
+        Arc::new(forge::llm::registry::ProviderRegistry::from_config(config).expect("registry"));
+    let executor = forge::runtime::executor::TaskExecutor::new(program, registry, None);
+    let result = executor.run().await.expect("run should succeed");
+    assert_eq!(format!("{}", result.value), "hello-from-env");
+
+    std::env::remove_var("FORGE_TEST_ENV_VALUE");
+}
+
+#[tokio::test]
+async fn env_get_returns_default_when_unset() {
+    use std::sync::Arc;
+    std::env::remove_var("FORGE_TEST_UNSET_VAR");
+
+    let src = r#"fn main
+  value = env.get("FORGE_TEST_UNSET_VAR", "fallback-value")
+  give value
+"#;
+    let program = forge::parser::parse(src).expect("parse should succeed");
+    let config = forge::config::ForgeConfig::default_mock_config();
+    let registry =
+        Arc::new(forge::llm::registry::ProviderRegistry::from_config(config).expect("registry"));
+    let executor = forge::runtime::executor::TaskExecutor::new(program, registry, None);
+    let result = executor.run().await.expect("run should succeed");
+    assert_eq!(format!("{}", result.value), "fallback-value");
+}


### PR DESCRIPTION
## Summary
- Fixes #251.
- Adds `env.get(name: Text, default: Text) -> Text` to the resolver/runtime.
- Adds boundary/runtime tests for set and unset environment variables across client, server, and shared boundaries.

## Acceptance Criteria
- [x] `env.get("HOME", "/tmp")` returns `$HOME` in a task body.
- [x] `env.get("DOES_NOT_EXIST", "fallback")` returns `"fallback"`.
- [x] Allowed in client, server, and shared boundaries.
- [x] Tests cover both set and unset cases.

## Verification
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `bash scripts/check-forge-examples.sh`
- `bash scripts/check-principles.sh`
- `git diff --check`

## Stack
- Base PR: #261
- Next PR: #256 / forge-sensei split

## Known Gaps
- None.