### PR TITLE
feat(sensei): split client and server boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- forge-sensei native boundary split: shared/server/client FORGE projects now build separate server and pure HTTP client binaries, with client-safe API endpoints for sensei commands (#256)
 - forge-sensei `/api/self-assess` endpoint: triggers built-in curriculum evaluation and persists mastery internally via `data.store` — no external assess.sh/cron needed (#247)
 - forge-sensei status endpoints (`/api/status`, `/status` HTML) now reflect persisted mastery state instead of hardcoded 0 (#247)
 - Half-open circuit breaker recovery: warden no longer terminates on trip — enters cooldown → probe → resume cycle, making servers self-healing when providers recover (#247)

--- a/docs/forge-sensei.md
+++ b/docs/forge-sensei.md
@@ -12,9 +12,9 @@ forge-sensei is structured as a multi-file FORGE project in `workflows/forge-sen
 
 ```
 workflows/forge-sensei/
-  core.forge    — Types, events, states, pure functions, tasks, flows, contract
-  agent.forge   — Sensei agent, specialist agent, warden
-  web.forge     — HTTP endpoints for web UI
+  shared/       — Shared types, events, and lifecycle states
+  server/       — Tasks, flows, agents, warden, endpoints, and system wiring
+  client/       — Pure-FORGE HTTP client agent
 ```
 
 The component stack follows FORGE's natural declaration order:
@@ -773,10 +773,11 @@ bash scripts/build-sensei.sh
 #   bin/forge-sensei-server
 ```
 
-The CLI build uses the agent entry from `forge.project.toml`. The server build composes the web entry with the shared core and agent sources:
+The client and server builds use separate `forge.project.toml` manifests:
 
 ```bash
-forge build workflows/forge-sensei/ --entry web.forge --source core.forge --source agent.forge -o bin/forge-sensei-server
+forge build workflows/forge-sensei/client -o bin/forge-sensei
+forge build workflows/forge-sensei/server -o bin/forge-sensei-server
 ```
 
 ### Pre-train
@@ -839,7 +840,7 @@ bin/forge-sensei deep-dive "SYNTAX"
 ### Serve
 
 ```bash
-forge serve workflows/forge-sensei/ --watch
+forge serve workflows/forge-sensei/server/web.forge --source workflows/forge-sensei/shared/types.forge --source workflows/forge-sensei/shared/events.forge --source workflows/forge-sensei/shared/states.forge --source workflows/forge-sensei/server/tasks.forge --source workflows/forge-sensei/server/flows.forge --source workflows/forge-sensei/server/agent.forge --watch
 # Web UI at http://localhost:3030
 ```
 

--- a/examples/validation.toml
+++ b/examples/validation.toml
@@ -222,10 +222,20 @@ check = "ok"
 [[cases]]
 name = "forge-sensei multi-file workflow"
 paths = [
-  "workflows/forge-sensei/core.forge",
-  "workflows/forge-sensei/agent.forge",
-  "workflows/forge-sensei/web.forge",
+  "workflows/forge-sensei/shared/types.forge",
+  "workflows/forge-sensei/shared/events.forge",
+  "workflows/forge-sensei/shared/states.forge",
+  "workflows/forge-sensei/server/tasks.forge",
+  "workflows/forge-sensei/server/flows.forge",
+  "workflows/forge-sensei/server/agent.forge",
+  "workflows/forge-sensei/server/web.forge",
 ]
 check = "ok"
 manifest = "workflows/forge-sensei/forge.project.toml"
 merge = true
+
+[[cases]]
+name = "forge-sensei client workflow"
+paths = ["workflows/forge-sensei/client/client.forge"]
+check = "ok"
+manifest = "workflows/forge-sensei/client/forge.project.toml"

--- a/roadmap.md
+++ b/roadmap.md
@@ -728,6 +728,7 @@ Worktree isolation for safe agent execution:
 | #166 | forge-sensei code-generation curriculum | Open |
 | #167 | Toolkit agent knowledge transfer infrastructure | Open |
 | #240 | forge-sensei server/client deployment path | In Progress |
+| #256 | Split sensei into shared/server/client FORGE sources | In Progress |
 
 ### P2.M12: Toolkit Agents
 
@@ -946,7 +947,7 @@ P2.M7  Skills          ███████████████████
 P2.M8  CLI Skills      ░░░░░░░░░░░░░░░░░░░░  0/4  (  0%)
 P2.M9  Orchestration   ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
 P2.M10 Dev System      ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)
-P2.M11 Knowledge       ██████████░░░░░░░░░░  1/2  ( 50%)  #166 curriculum done
+P2.M11 Knowledge       ██████████░░░░░░░░░░  1/3  ( 33%)  #166 curriculum done; #256 in progress
 P2.M12 Toolkit         ░░░░░░░░░░░░░░░░░░░░  0/8  (  0%)
 P2.M13 Polish          █████░░░░░░░░░░░░░░░  1/4  ( 25%)
 ─────────────────────────────────────────────────────────

--- a/scripts/build-sensei.sh
+++ b/scripts/build-sensei.sh
@@ -3,12 +3,9 @@
 set -euo pipefail
 
 FORGE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-# Multi-file project: use directory with forge.project.toml
-SENSEI_SOURCE="$FORGE_ROOT/workflows/forge-sensei"
-# Fallback to single-file if directory doesn't exist
-if [ ! -d "$SENSEI_SOURCE" ]; then
-  SENSEI_SOURCE="$FORGE_ROOT/workflows/forge-sensei.forge"
-fi
+SENSEI_ROOT="$FORGE_ROOT/workflows/forge-sensei"
+SENSEI_CLIENT_SOURCE="$SENSEI_ROOT/client"
+SENSEI_SERVER_SOURCE="$SENSEI_ROOT/server"
 SENSEI_BIN="$FORGE_ROOT/bin/forge-sensei"
 SENSEI_SERVER_BIN="$FORGE_ROOT/bin/forge-sensei-server"
 HASH_FILE="$FORGE_ROOT/bin/.sensei-build-hash"
@@ -20,11 +17,7 @@ if ! command -v cargo &>/dev/null; then
 fi
 
 # ── Skip-if-unchanged ────────────────────────────────────────
-if [ -d "$SENSEI_SOURCE" ]; then
-  CURRENT_HASH=$(find "$SENSEI_SOURCE" -name '*.forge' -o -name '*.toml' | sort | xargs cat | shasum -a 256 | cut -d' ' -f1)
-else
-  CURRENT_HASH=$(shasum -a 256 "$SENSEI_SOURCE" | cut -d' ' -f1)
-fi
+CURRENT_HASH=$(find "$SENSEI_ROOT" \( -name '*.forge' -o -name '*.toml' \) -type f | sort | xargs cat | shasum -a 256 | cut -d' ' -f1)
 if [ -f "$HASH_FILE" ] && [ -x "$SENSEI_BIN" ] && [ -x "$SENSEI_SERVER_BIN" ]; then
   CACHED_HASH=$(cat "$HASH_FILE")
   if [ "$CURRENT_HASH" = "$CACHED_HASH" ]; then
@@ -39,26 +32,23 @@ echo "Building forge-sensei..."
 START=$SECONDS
 
 cargo run --manifest-path "$FORGE_ROOT/Cargo.toml" -- build \
-  "$SENSEI_SOURCE" \
-  -o "$SENSEI_BIN"
+  "$SENSEI_SERVER_SOURCE" \
+  -o "$SENSEI_SERVER_BIN"
 
 cargo run --manifest-path "$FORGE_ROOT/Cargo.toml" -- build \
-  "$SENSEI_SOURCE" \
-  --entry web.forge \
-  --source core.forge \
-  --source agent.forge \
-  -o "$SENSEI_SERVER_BIN"
+  "$SENSEI_CLIENT_SOURCE" \
+  -o "$SENSEI_BIN"
 
 ELAPSED=$((SECONDS - START))
 echo "$CURRENT_HASH" > "$HASH_FILE"
 
 # ── Smoke test ────────────────────────────────────────────────
-if "$SENSEI_BIN" status &>/dev/null; then
+if "$SENSEI_BIN" --help &>/dev/null; then
   echo ""
   echo "Binaries ready: bin/forge-sensei, bin/forge-sensei-server (${ELAPSED}s)"
   echo "Run: bin/forge-sensei --help"
 else
   echo ""
   echo "Binaries ready: bin/forge-sensei, bin/forge-sensei-server (${ELAPSED}s)"
-  echo "Note: smoke test returned non-zero (may need pretrain first)"
+  echo "Note: CLI help smoke test returned non-zero"
 fi

--- a/scripts/install-sensei.sh
+++ b/scripts/install-sensei.sh
@@ -30,15 +30,12 @@ mkdir -p "$INSTALL_DIR" "$BIN_DIR"
 
 echo "Building forge-sensei CLI..."
 cargo run --manifest-path "$FORGE_ROOT/Cargo.toml" -- build \
-  "$FORGE_ROOT/workflows/forge-sensei" \
+  "$FORGE_ROOT/workflows/forge-sensei/client" \
   -o "$INSTALL_DIR/forge-sensei-bin"
 
 echo "Building forge-sensei server..."
 cargo run --manifest-path "$FORGE_ROOT/Cargo.toml" -- build \
-  "$FORGE_ROOT/workflows/forge-sensei" \
-  --entry web.forge \
-  --source core.forge \
-  --source agent.forge \
+  "$FORGE_ROOT/workflows/forge-sensei/server" \
   -o "$INSTALL_DIR/forge-sensei-server-bin"
 
 echo "  CLI binary:    $INSTALL_DIR/forge-sensei-bin"
@@ -67,7 +64,8 @@ if [ "$1" = "status" ] && [ -f "$SENSEI_DIR/knowledge.json" ]; then
   fi
 fi
 
-FORGE_CONFIG="${FORGE_CONFIG:-$SENSEI_DIR/config.toml}" \
+FORGE_SENSEI_SERVER="${FORGE_SENSEI_SERVER:-http://127.0.0.1:3000}" \
+  FORGE_CONFIG="${FORGE_CONFIG:-$SENSEI_DIR/config.toml}" \
   exec "$SENSEI_DIR/forge-sensei-bin" "$@"
 WRAPPER
 chmod +x "$BIN_DIR/forge-sensei"
@@ -77,7 +75,8 @@ cat > "$BIN_DIR/forge-sensei-server" <<'WRAPPER'
 # forge-sensei-server wrapper — runs the long-lived HTTP daemon.
 SENSEI_DIR="$HOME/.forge/sensei"
 cd "$SENSEI_DIR"
-exec "$SENSEI_DIR/forge-sensei-server-bin" --config "$SENSEI_DIR/config.toml" "$@"
+FORGE_CONFIG="${FORGE_CONFIG:-$SENSEI_DIR/config.toml}" \
+  exec "$SENSEI_DIR/forge-sensei-server-bin" "$@"
 WRAPPER
 chmod +x "$BIN_DIR/forge-sensei-server"
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -316,6 +316,10 @@ serde_json = "1"
                         .clone()
                         .unwrap_or_else(|| "0.1.0".to_string()),
                     handlers,
+                    client_boundary: program
+                        .boundary
+                        .as_ref()
+                        .is_some_and(|b| b.node.kind.node == crate::ast::BoundaryKind::Client),
                 });
             }
         }
@@ -388,6 +392,7 @@ struct AgentInfo {
     name: String,
     version: String,
     handlers: Vec<HandlerInfo>,
+    client_boundary: bool,
 }
 
 struct HandlerInfo {
@@ -515,6 +520,14 @@ fn generate_agent_cli_main(
 ) -> String {
     let sources_array = source_entries.join(",\n    ");
     let config_code = config_resolution_code(embed_config);
+    let server_url_code = if agent.client_boundary {
+        "let server_url = None;".to_string()
+    } else {
+        r#"let server_url = cli
+        .server
+        .or_else(|| std::env::var("FORGE_SENSEI_SERVER").ok());"#
+            .to_string()
+    };
 
     // Generate subcommand variants
     let mut variants = Vec::new();
@@ -805,9 +818,7 @@ fn parse_args(s: &str) -> Vec<String> {{
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {{
     let cli = Cli::parse();
-    let server_url = cli
-        .server
-        .or_else(|| std::env::var("FORGE_SENSEI_SERVER").ok());
+    {server_url_code}
     let program = forge::compose::parse_and_merge_sources(SOURCES)
         .map_err(|e| anyhow::anyhow!("{{}}", e))?;
     let config = resolve_config();
@@ -875,6 +886,7 @@ async fn main() -> anyhow::Result<()> {{
 "#,
         sources = sources_array,
         config = config_code,
+        server_url_code = server_url_code,
         agent_name = agent.name,
         agent_version = agent.version,
         variants = variants.join("\n"),

--- a/src/runtime/http_server.rs
+++ b/src/runtime/http_server.rs
@@ -456,6 +456,7 @@ async fn handle_post_endpoint(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
+    let endpoint = executor.endpoints().get(&endpoint_name).cloned();
     let (params, args): (HashMap<String, String>, HashMap<String, ConfidentValue>) =
         if content_type.contains("application/json") {
             // JSON body
@@ -465,6 +466,14 @@ async fn handle_post_endpoint(
                     None => (HashMap::new(), HashMap::new()),
                 },
                 Err(_) => (HashMap::new(), HashMap::new()),
+            }
+        } else if !raw_body.contains('=') {
+            match endpoint.as_ref() {
+                Some(ep) => match raw_body_to_single_param_args(ep, &raw_body) {
+                    Some(args) => (single_param_string_params(ep, &raw_body), args),
+                    None => (HashMap::new(), HashMap::new()),
+                },
+                None => (HashMap::new(), HashMap::new()),
             }
         } else {
             // Form-encoded body (application/x-www-form-urlencoded)
@@ -921,6 +930,45 @@ fn json_value_to_confident(value: &serde_json::Value) -> ConfidentValue {
         serde_json::Value::Object(fields) => Value::Record(json_object_to_args(fields)),
     };
     ConfidentValue::deterministic(converted)
+}
+
+fn single_param_string_params(
+    endpoint: &crate::ast::EndpointDecl,
+    raw_body: &str,
+) -> HashMap<String, String> {
+    endpoint
+        .params
+        .first()
+        .map(|param| HashMap::from([(param.node.name.clone(), raw_body.to_string())]))
+        .unwrap_or_default()
+}
+
+fn raw_body_to_single_param_args(
+    endpoint: &crate::ast::EndpointDecl,
+    raw_body: &str,
+) -> Option<HashMap<String, ConfidentValue>> {
+    if endpoint.params.len() != 1 {
+        return None;
+    }
+
+    let param = endpoint.params.first()?;
+    let value = match &param.node.type_name.node {
+        crate::ast::TypeName::Number => raw_body
+            .trim()
+            .parse::<f64>()
+            .map(Value::Number)
+            .unwrap_or_else(|_| Value::Text(raw_body.to_string())),
+        crate::ast::TypeName::Bool => {
+            let normalized = raw_body.trim();
+            Value::Bool(normalized == "true" || normalized == "1")
+        }
+        _ => Value::Text(raw_body.to_string()),
+    };
+
+    Some(HashMap::from([(
+        param.node.name.clone(),
+        ConfidentValue::deterministic(value),
+    )]))
 }
 
 async fn dispatch_endpoint(

--- a/tests/build_tests.rs
+++ b/tests/build_tests.rs
@@ -119,13 +119,25 @@ fn detect_kind_server() {
 
 #[test]
 fn detect_sensei_cli_and_server_build_shapes() {
-    let core = std::fs::read_to_string("workflows/forge-sensei/core.forge").expect("read core");
-    let agent = std::fs::read_to_string("workflows/forge-sensei/agent.forge").expect("read agent");
-    let web = std::fs::read_to_string("workflows/forge-sensei/web.forge").expect("read web");
+    let types =
+        std::fs::read_to_string("workflows/forge-sensei/shared/types.forge").expect("read types");
+    let events =
+        std::fs::read_to_string("workflows/forge-sensei/shared/events.forge").expect("read events");
+    let states =
+        std::fs::read_to_string("workflows/forge-sensei/shared/states.forge").expect("read states");
+    let tasks =
+        std::fs::read_to_string("workflows/forge-sensei/server/tasks.forge").expect("read tasks");
+    let flows =
+        std::fs::read_to_string("workflows/forge-sensei/server/flows.forge").expect("read flows");
+    let agent =
+        std::fs::read_to_string("workflows/forge-sensei/server/agent.forge").expect("read agent");
+    let web = std::fs::read_to_string("workflows/forge-sensei/server/web.forge").expect("read web");
+    let client =
+        std::fs::read_to_string("workflows/forge-sensei/client/client.forge").expect("read client");
 
     let cli = compose::merge_programs(&[
-        parse_source("core.forge", &core),
-        parse_source("agent.forge", &agent),
+        parse_source("types.forge", &types),
+        parse_source("client.forge", &client),
     ])
     .expect("sensei CLI sources should merge");
     assert_eq!(
@@ -134,9 +146,13 @@ fn detect_sensei_cli_and_server_build_shapes() {
     );
 
     let server = compose::merge_programs(&[
-        parse_source("web.forge", &web),
-        parse_source("core.forge", &core),
+        parse_source("types.forge", &types),
+        parse_source("events.forge", &events),
+        parse_source("states.forge", &states),
+        parse_source("tasks.forge", &tasks),
+        parse_source("flows.forge", &flows),
         parse_source("agent.forge", &agent),
+        parse_source("web.forge", &web),
     ])
     .expect("sensei server sources should merge");
     assert_eq!(

--- a/tests/http_server_tests.rs
+++ b/tests/http_server_tests.rs
@@ -1211,26 +1211,7 @@ async fn multi_file_html_rendering_across_files() {
 
 /// Load and merge the actual forge-sensei source files.
 async fn spawn_sensei_web_server() -> String {
-    let core_source =
-        std::fs::read_to_string("workflows/forge-sensei/core.forge").expect("read core.forge");
-    let web_source =
-        std::fs::read_to_string("workflows/forge-sensei/web.forge").expect("read web.forge");
-
-    let core_program = forge::parser::parse(&core_source).expect("parse core.forge failed");
-    let web_program = forge::parser::parse(&web_source).expect("parse web.forge failed");
-
-    let source_files = vec![
-        forge::compose::SourceFile {
-            path: "core.forge".to_string(),
-            source: core_source,
-            program: core_program,
-        },
-        forge::compose::SourceFile {
-            path: "web.forge".to_string(),
-            source: web_source,
-            program: web_program,
-        },
-    ];
+    let source_files = sensei_server_source_files();
     let composed =
         forge::compose::merge_programs(&source_files).expect("merge sensei files failed");
     let executor = TaskExecutor::new(composed.program, mock_registry(), None);
@@ -1251,6 +1232,30 @@ async fn spawn_sensei_web_server() -> String {
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     format!("http://127.0.0.1:{port}")
+}
+
+fn sensei_server_source_files() -> Vec<forge::compose::SourceFile> {
+    [
+        ("types.forge", "workflows/forge-sensei/shared/types.forge"),
+        ("events.forge", "workflows/forge-sensei/shared/events.forge"),
+        ("states.forge", "workflows/forge-sensei/shared/states.forge"),
+        ("tasks.forge", "workflows/forge-sensei/server/tasks.forge"),
+        ("flows.forge", "workflows/forge-sensei/server/flows.forge"),
+        ("agent.forge", "workflows/forge-sensei/server/agent.forge"),
+        ("web.forge", "workflows/forge-sensei/server/web.forge"),
+    ]
+    .into_iter()
+    .map(|(name, path)| {
+        let source = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("read {path}"));
+        let program =
+            forge::parser::parse(&source).unwrap_or_else(|_| panic!("parse {path} failed"));
+        forge::compose::SourceFile {
+            path: name.to_string(),
+            source,
+            program,
+        }
+    })
+    .collect()
 }
 
 #[tokio::test]
@@ -1434,6 +1439,21 @@ async fn sensei_json_update_mastery_preserves_number_param() {
 }
 
 #[tokio::test]
+async fn sensei_raw_body_update_mastery_preserves_number_param() {
+    let base = spawn_sensei_web_server().await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/api/update-mastery"))
+        .body("75")
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["result"].as_str().unwrap().contains("journeyman"));
+}
+
+#[tokio::test]
 async fn sensei_nonexistent_endpoint_returns_404() {
     let base = spawn_sensei_web_server().await;
     let resp = reqwest::get(format!("{base}/nonexistent"))
@@ -1444,26 +1464,7 @@ async fn sensei_nonexistent_endpoint_returns_404() {
 
 #[tokio::test]
 async fn sensei_all_endpoints_registered() {
-    let core_source =
-        std::fs::read_to_string("workflows/forge-sensei/core.forge").expect("read core.forge");
-    let web_source =
-        std::fs::read_to_string("workflows/forge-sensei/web.forge").expect("read web.forge");
-
-    let core_program = forge::parser::parse(&core_source).expect("parse core.forge failed");
-    let web_program = forge::parser::parse(&web_source).expect("parse web.forge failed");
-
-    let source_files = vec![
-        forge::compose::SourceFile {
-            path: "core.forge".to_string(),
-            source: core_source,
-            program: core_program,
-        },
-        forge::compose::SourceFile {
-            path: "web.forge".to_string(),
-            source: web_source,
-            program: web_program,
-        },
-    ];
+    let source_files = sensei_server_source_files();
     let composed =
         forge::compose::merge_programs(&source_files).expect("merge sensei files failed");
     let executor = TaskExecutor::new(composed.program, mock_registry(), None);
@@ -1502,6 +1503,18 @@ async fn sensei_all_endpoints_registered() {
         "missing api_review endpoint"
     );
     assert!(
+        endpoints.contains_key("api_ingest"),
+        "missing api_ingest endpoint"
+    );
+    assert!(
+        endpoints.contains_key("api_ingest_fact"),
+        "missing api_ingest_fact endpoint"
+    );
+    assert!(
+        endpoints.contains_key("api_learn_from_session"),
+        "missing api_learn_from_session endpoint"
+    );
+    assert!(
         endpoints.contains_key("api_assess_detailed"),
         "missing api_assess_detailed endpoint"
     );
@@ -1521,5 +1534,5 @@ async fn sensei_all_endpoints_registered() {
         endpoints.contains_key("api_self_assess"),
         "missing api_self_assess endpoint (#247)"
     );
-    assert_eq!(endpoints.len(), 15);
+    assert_eq!(endpoints.len(), 18);
 }

--- a/tests/sensei_checker_tests.rs
+++ b/tests/sensei_checker_tests.rs
@@ -1,27 +1,47 @@
 // FORGE forge-sensei checker tests
-// Validates that the checker produces zero errors on the sensei program
+// Validates that the checker produces zero errors on the split sensei program
 // and catches purity violations as expected.
 
-use forge::ast::Program;
 use forge::checker;
 use forge::checker::boundary_checker;
 use forge::diagnostic::{Diagnostic, DiagnosticKind};
 
-fn parse_file(path: &str) -> Program {
-    let source =
-        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("could not read {}: {}", path, e));
-    forge::parser::parse(&source).unwrap_or_else(|e| panic!("parse failed for {}: {:?}", path, e))
+fn sensei_server_sources() -> Vec<forge::compose::SourceFile> {
+    [
+        "workflows/forge-sensei/shared/types.forge",
+        "workflows/forge-sensei/shared/events.forge",
+        "workflows/forge-sensei/shared/states.forge",
+        "workflows/forge-sensei/server/tasks.forge",
+        "workflows/forge-sensei/server/flows.forge",
+        "workflows/forge-sensei/server/agent.forge",
+        "workflows/forge-sensei/server/web.forge",
+    ]
+    .into_iter()
+    .map(|path| {
+        let source = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("could not read {}: {}", path, e));
+        let program = forge::parser::parse(&source)
+            .unwrap_or_else(|e| panic!("parse failed for {}: {:?}", path, e));
+        forge::compose::SourceFile {
+            path: path.to_string(),
+            source,
+            program,
+        }
+    })
+    .collect()
 }
 
-fn check_file(path: &str) -> Vec<Diagnostic> {
-    let program = parse_file(path);
-    let filename = std::path::Path::new(path)
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap();
-    let mut diags = checker::check_all(&program, filename);
-    diags.extend(boundary_checker::check(&[(&program, filename)]));
+fn check_sensei_server() -> Vec<Diagnostic> {
+    let source_files = sensei_server_sources();
+    let refs = source_files
+        .iter()
+        .map(|sf| (&sf.program, sf.path.as_str()))
+        .collect::<Vec<_>>();
+    let composed =
+        forge::compose::merge_programs(&source_files).expect("sensei server files should merge");
+    let mut diags =
+        checker::check_all(&composed.program, "workflows/forge-sensei/server/web.forge");
+    diags.extend(boundary_checker::check(&refs));
     diags
 }
 
@@ -39,11 +59,11 @@ fn warnings(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
         .collect()
 }
 
-// ── Test 1: zero checker errors on forge-sensei.forge ───────────
+// ── Test 1: zero checker errors on split forge-sensei server ─────
 
 #[test]
 fn check_sensei_zero_errors() {
-    let diags = check_file("workflows/forge-sensei.forge");
+    let diags = check_sensei_server();
     let errs = errors(&diags);
     if !errs.is_empty() {
         for e in &errs {
@@ -52,7 +72,7 @@ fn check_sensei_zero_errors() {
     }
     assert!(
         errs.is_empty(),
-        "forge-sensei.forge should produce zero checker errors, found {}",
+        "split forge-sensei server should produce zero checker errors, found {}",
         errs.len()
     );
 }
@@ -61,12 +81,12 @@ fn check_sensei_zero_errors() {
 
 #[test]
 fn check_sensei_warnings_inventory() {
-    let diags = check_file("workflows/forge-sensei.forge");
+    let diags = check_sensei_server();
     let warns = warnings(&diags);
 
     // Print warnings for documentation
     if !warns.is_empty() {
-        eprintln!("--- forge-sensei.forge warnings ({}) ---", warns.len());
+        eprintln!("--- split forge-sensei warnings ({}) ---", warns.len());
         for w in &warns {
             eprintln!("  WARN: {} — {}", w.message, w.label);
         }

--- a/tests/sensei_parser_tests.rs
+++ b/tests/sensei_parser_tests.rs
@@ -1,19 +1,42 @@
 // FORGE forge-sensei parser tests
-// Validates the AST structure of workflows/forge-sensei.forge after parsing.
+// Validates the AST structure of the split workflows/forge-sensei server after parsing.
 
 use forge::ast::{Program, TopLevel};
 
-fn parse_file(path: &str) -> Program {
-    let source =
-        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("could not read {}: {}", path, e));
-    forge::parser::parse(&source).unwrap_or_else(|e| panic!("parse failed for {}: {:?}", path, e))
+fn parse_sensei_server() -> Program {
+    let files = [
+        "workflows/forge-sensei/shared/types.forge",
+        "workflows/forge-sensei/shared/events.forge",
+        "workflows/forge-sensei/shared/states.forge",
+        "workflows/forge-sensei/server/tasks.forge",
+        "workflows/forge-sensei/server/flows.forge",
+        "workflows/forge-sensei/server/agent.forge",
+        "workflows/forge-sensei/server/web.forge",
+    ];
+    let source_files = files
+        .into_iter()
+        .map(|path| {
+            let source = std::fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("could not read {}: {}", path, e));
+            let program = forge::parser::parse(&source)
+                .unwrap_or_else(|e| panic!("parse failed for {}: {:?}", path, e));
+            forge::compose::SourceFile {
+                path: path.to_string(),
+                source,
+                program,
+            }
+        })
+        .collect::<Vec<_>>();
+    forge::compose::merge_programs(&source_files)
+        .expect("sensei server files should merge")
+        .program
 }
 
 // ── Test 1: full program AST structure counts ───────────────────
 
 #[test]
 fn parse_sensei_full_program_ast_structure() {
-    let program = parse_file("workflows/forge-sensei.forge");
+    let program = parse_sensei_server();
 
     let mut types = 0;
     let mut events = 0;
@@ -40,10 +63,7 @@ fn parse_sensei_full_program_ast_structure() {
         }
     }
 
-    assert_eq!(
-        types, 2,
-        "expected 2 type defs (QueryResult, AssessmentResult)"
-    );
+    assert_eq!(types, 4, "expected 4 type defs");
     assert_eq!(
         events, 3,
         "expected 3 events (LearnedInsight, AssessmentCompleted, KnowledgeGapFound)"
@@ -52,8 +72,8 @@ fn parse_sensei_full_program_ast_structure() {
         states, 2,
         "expected 2 states (MasteryLevel, SpecialistPhase)"
     );
-    assert_eq!(pures, 4, "expected 4 pure functions");
-    assert_eq!(tasks, 5, "expected 5 tasks");
+    assert_eq!(pures, 11, "expected 11 pure functions");
+    assert_eq!(tasks, 8, "expected 8 tasks");
     assert_eq!(flows, 2, "expected 2 flows (answer_query, review_code)");
     assert_eq!(contracts, 1, "expected 1 contract (ForgeTutor)");
     assert_eq!(agents, 2, "expected 2 agents (forge_sensei, specialist)");
@@ -64,7 +84,7 @@ fn parse_sensei_full_program_ast_structure() {
 
 #[test]
 fn parse_sensei_agent_handlers_complete() {
-    let program = parse_file("workflows/forge-sensei.forge");
+    let program = parse_sensei_server();
 
     let sensei = program
         .items
@@ -88,6 +108,7 @@ fn parse_sensei_agent_handlers_complete() {
         "query",
         "review",
         "learn_from_session",
+        "LearnedInsight",
         "deep_dive",
         "assess_detailed",
         "batch_assess",
@@ -117,7 +138,7 @@ fn parse_sensei_agent_handlers_complete() {
 
 #[test]
 fn parse_sensei_warden_policies() {
-    let program = parse_file("workflows/forge-sensei.forge");
+    let program = parse_sensei_server();
 
     let warden = program
         .items

--- a/tests/server_resilience_tests.rs
+++ b/tests/server_resilience_tests.rs
@@ -202,9 +202,19 @@ fn circuit_breaker_reset_enables_fresh_start() {
 fn generated_server_code_includes_resilience_flags() {
     // Verify the generated server main template includes the new CLI flags
     // by building the sensei server sources and checking the program structure
-    let core = std::fs::read_to_string("workflows/forge-sensei/core.forge").expect("read core");
-    let agent = std::fs::read_to_string("workflows/forge-sensei/agent.forge").expect("read agent");
-    let web = std::fs::read_to_string("workflows/forge-sensei/web.forge").expect("read web");
+    let types =
+        std::fs::read_to_string("workflows/forge-sensei/shared/types.forge").expect("read types");
+    let events =
+        std::fs::read_to_string("workflows/forge-sensei/shared/events.forge").expect("read events");
+    let states =
+        std::fs::read_to_string("workflows/forge-sensei/shared/states.forge").expect("read states");
+    let tasks =
+        std::fs::read_to_string("workflows/forge-sensei/server/tasks.forge").expect("read tasks");
+    let flows =
+        std::fs::read_to_string("workflows/forge-sensei/server/flows.forge").expect("read flows");
+    let agent =
+        std::fs::read_to_string("workflows/forge-sensei/server/agent.forge").expect("read agent");
+    let web = std::fs::read_to_string("workflows/forge-sensei/server/web.forge").expect("read web");
 
     use forge::compose::{self, SourceFile};
     fn parse_source(name: &str, source: &str) -> SourceFile {
@@ -217,9 +227,13 @@ fn generated_server_code_includes_resilience_flags() {
     }
 
     let composed = compose::merge_programs(&[
-        parse_source("web.forge", &web),
-        parse_source("core.forge", &core),
+        parse_source("types.forge", &types),
+        parse_source("events.forge", &events),
+        parse_source("states.forge", &states),
+        parse_source("tasks.forge", &tasks),
+        parse_source("flows.forge", &flows),
         parse_source("agent.forge", &agent),
+        parse_source("web.forge", &web),
     ])
     .expect("sensei server sources should merge");
 

--- a/workflows/forge-sensei/client/client.forge
+++ b/workflows/forge-sensei/client/client.forge
@@ -1,0 +1,55 @@
+#! boundary: client
+
+use
+  web.fetch
+  web.post
+  env.get
+
+agent forge_sensei_client
+  on status
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    response = try web.fetch("{base}/api/status") or "server unreachable at {base}"
+    say response
+
+  on query(question: Text)
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    response = try web.post("{base}/api/ask", question) or "server unreachable at {base}"
+    say response
+
+  on review(code: Text)
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    response = try web.post("{base}/api/review", code) or "server unreachable at {base}"
+    say response
+
+  on ingest(document_path: Text)
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    response = try web.post("{base}/api/ingest", document_path) or "server unreachable at {base}"
+    say response
+
+  on ingest_fact(category: Text, fact: Text)
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    payload = "category={category}&fact={fact}"
+    response = try web.post("{base}/api/ingest-fact", payload) or "server unreachable at {base}"
+    say response
+
+  on learn_from_session(question: Text, resolution: Text)
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    payload = "question={question}&resolution={resolution}"
+    response = try web.post("{base}/api/learn-from-session", payload) or "server unreachable at {base}"
+    say response
+
+  on deep_dive(topic: Text)
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    response = try web.post("{base}/api/deep-dive", topic) or "server unreachable at {base}"
+    say response
+
+  on assess_detailed(test_input: Text, expected: Text)
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    payload = "test_input={test_input}&expected={expected}"
+    response = try web.post("{base}/api/assess-detailed", payload) or "server unreachable at {base}"
+    say response
+
+  on update_mastery(score: Number)
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    response = try web.post("{base}/api/update-mastery", "{score}") or "server unreachable at {base}"
+    say response

--- a/workflows/forge-sensei/client/forge.project.toml
+++ b/workflows/forge-sensei/client/forge.project.toml
@@ -1,0 +1,11 @@
+[project]
+name = "forge-sensei"
+version = "0.2.1"
+description = "FORGE language learning agent client"
+
+[build]
+entry = "client.forge"
+output = "forge-sensei"
+sources = [
+  "../shared/types.forge",
+]

--- a/workflows/forge-sensei/forge.project.toml
+++ b/workflows/forge-sensei/forge.project.toml
@@ -1,9 +1,16 @@
 [project]
 name = "forge-sensei"
 version = "0.2.1"
-description = "FORGE language learning agent — CLI + web interface"
+description = "FORGE language learning agent server"
 
 [build]
-entry = "agent.forge"
-output = "forge-sensei"
-sources = ["core.forge"]
+entry = "server/web.forge"
+output = "forge-sensei-server"
+sources = [
+  "shared/types.forge",
+  "shared/events.forge",
+  "shared/states.forge",
+  "server/tasks.forge",
+  "server/flows.forge",
+  "server/agent.forge",
+]

--- a/workflows/forge-sensei/server/agent.forge
+++ b/workflows/forge-sensei/server/agent.forge
@@ -1,3 +1,5 @@
+#! boundary: server
+
 # ── The Sensei Agent ──────────────────────────────────────────
 #
 # A self-referential learning agent: written in FORGE to teach FORGE.
@@ -202,7 +204,5 @@ warden sensei_warden
   max_retries 3 per 1h then escalate
 
 # ── Usage ─────────────────────────────────────────────────────
-# Build:  forge build workflows/forge-sensei/ -o bin/forge-sensei
-# Run:    bin/forge-sensei query "how do flows work?"
-# REPL:   bin/forge-sensei repl
-# Help:   bin/forge-sensei --help
+# Build:  forge build workflows/forge-sensei/server -o bin/forge-sensei-server
+# Run:    bin/forge-sensei-server --port 3000

--- a/workflows/forge-sensei/server/flows.forge
+++ b/workflows/forge-sensei/server/flows.forge
@@ -1,0 +1,44 @@
+#! boundary: server
+
+flow answer_query
+  needs question: Text
+  gives QueryResult
+
+  stage categorize
+    categories = question >> categorize_for_recall(_pipe)
+
+  stage retrieve
+    needs categorize.categories
+    prior = recall "{categorize.categories} {question}"
+
+  stage respond
+    needs retrieve.prior, categorize.categories
+    prior = retrieve.prior
+    response = answer_forge_question(question, prior)
+    when prior.sure -> give QueryResult(answer: response, confidence_tier: "sure", sources_used: 1)
+    when prior.unsure -> give QueryResult(answer: response, confidence_tier: "unsure", sources_used: 1)
+    else -> give QueryResult(answer: response, confidence_tier: "none", sources_used: 0)
+
+flow review_code
+  needs code: Text
+  gives Text
+
+  stage categorize
+    categories = code >> categorize_for_recall(_pipe)
+
+  stage retrieve
+    needs categorize.categories
+    prior = recall "{categorize.categories} FORGE syntax patterns errors"
+
+  stage review
+    needs retrieve.prior
+    prior = retrieve.prior
+    when prior.sure -> give review_forge_code(code, prior)
+    when prior.unsure -> give review_forge_code(code, prior)
+    else -> give review_forge_code(code, "No prior knowledge. Review from first principles.")
+
+contract ForgeTutor
+  can query(question: Text) -> QueryResult
+  can review(code: Text) -> Text
+  can status() -> Text
+  can assess_detailed(test_input: Text, expected: Text) -> AssessmentResult

--- a/workflows/forge-sensei/server/forge.project.toml
+++ b/workflows/forge-sensei/server/forge.project.toml
@@ -1,0 +1,16 @@
+[project]
+name = "forge-sensei-server"
+version = "0.2.1"
+description = "FORGE language learning agent server"
+
+[build]
+entry = "web.forge"
+output = "forge-sensei-server"
+sources = [
+  "../shared/types.forge",
+  "../shared/events.forge",
+  "../shared/states.forge",
+  "tasks.forge",
+  "flows.forge",
+  "agent.forge",
+]

--- a/workflows/forge-sensei/server/tasks.forge
+++ b/workflows/forge-sensei/server/tasks.forge
@@ -1,60 +1,10 @@
+#! boundary: server
+
 use
   llm.reason
   llm.classify
   data.store
   data.get
-
-# ── Types ─────────────────────────────────────────────────────
-
-type QueryResult
-  answer: Text
-  confidence_tier: Text
-  sources_used: Number
-
-type AssessmentResult
-  passed: Bool
-  prediction: Text
-  expected: Text
-  gap_topic: Text
-
-type ApiStatus
-  status: Text
-
-type ApiTextResult
-  result: Text
-
-# ── Events ────────────────────────────────────────────────────
-
-event LearnedInsight
-  category: Text
-  content: Text
-  source: Text
-  confidence: Number
-
-event AssessmentCompleted
-  level: Text
-  score: Number
-  passed: Number
-  total: Number
-  failures: Text
-
-event KnowledgeGapFound
-  category: Text
-  question: Text
-
-# ── Lifecycle ─────────────────────────────────────────────────
-
-states MasteryLevel
-  novice -> apprentice when conformance_score >= 40
-  apprentice -> journeyman when conformance_score >= 70
-  journeyman -> expert when conformance_score >= 90
-  expert -> expert
-
-states SpecialistPhase
-  learning -> ready when absorbed_count >= 5
-  ready -> ready
-
-# ── Pure Functions ────────────────────────────────────────────
 
 pure compute_mastery_score
   needs passed: Number, total: Number
@@ -95,8 +45,6 @@ pure check_prediction
     if predicted.contains(expected)
       give true
     give false
-
-# ── Tasks ─────────────────────────────────────────────────────
 
 task answer_forge_question
   needs question: Text, context: Text
@@ -143,11 +91,6 @@ task categorize_for_recall
     when result.unsure -> give result
     else -> give "GENERAL"
 
-# ── Shared tasks for reading mastery state from data.store ──────
-# The agent writes its mastery into data.store on update_mastery.
-# Endpoints read it here so /api/status reflects actual state instead
-# of a hardcoded 0.
-
 task get_mastery_score
   gives Text
   do
@@ -171,50 +114,3 @@ task get_interaction_count
     if raw == ""
       give "0"
     give raw
-
-# ── Flows ─────────────────────────────────────────────────────
-
-flow answer_query
-  needs question: Text
-  gives QueryResult
-
-  stage categorize
-    categories = question >> categorize_for_recall(_pipe)
-
-  stage retrieve
-    needs categorize.categories
-    prior = recall "{categorize.categories} {question}"
-
-  stage respond
-    needs retrieve.prior, categorize.categories
-    prior = retrieve.prior
-    response = answer_forge_question(question, prior)
-    when prior.sure -> give QueryResult(answer: response, confidence_tier: "sure", sources_used: 1)
-    when prior.unsure -> give QueryResult(answer: response, confidence_tier: "unsure", sources_used: 1)
-    else -> give QueryResult(answer: response, confidence_tier: "none", sources_used: 0)
-
-flow review_code
-  needs code: Text
-  gives Text
-
-  stage categorize
-    categories = code >> categorize_for_recall(_pipe)
-
-  stage retrieve
-    needs categorize.categories
-    prior = recall "{categorize.categories} FORGE syntax patterns errors"
-
-  stage review
-    needs retrieve.prior
-    prior = retrieve.prior
-    when prior.sure -> give review_forge_code(code, prior)
-    when prior.unsure -> give review_forge_code(code, prior)
-    else -> give review_forge_code(code, "No prior knowledge. Review from first principles.")
-
-# ── Contract ──────────────────────────────────────────────────
-
-contract ForgeTutor
-  can query(question: Text) -> QueryResult
-  can review(code: Text) -> Text
-  can status() -> Text
-  can assess_detailed(test_input: Text, expected: Text) -> AssessmentResult

--- a/workflows/forge-sensei/server/web.forge
+++ b/workflows/forge-sensei/server/web.forge
@@ -83,6 +83,19 @@ endpoint api_review(code: Text) -> ApiTextResult
   review_result = review_code(code)
   give ApiTextResult(result: review_result)
 
+endpoint api_ingest(document_path: Text) -> ApiTextResult
+  learn from document(document_path)
+  give ApiTextResult(result: "Ingested: {document_path}")
+
+endpoint api_ingest_fact(category: Text, fact: Text) -> ApiTextResult
+  emit LearnedInsight(category: category, content: fact, source: "api", confidence: 1.0)
+  give ApiTextResult(result: "Learned [{category}]")
+
+endpoint api_learn_from_session(question: Text, resolution: Text) -> ApiTextResult
+  lesson = extract_lesson(question, resolution)
+  emit LearnedInsight(category: "interactions", content: lesson, source: "api", confidence: 0.8)
+  give ApiTextResult(result: "Learned from session.")
+
 endpoint api_assess_detailed(test_input: Text, expected: Text) -> AssessmentResult
   categories = categorize_for_recall("{test_input} expects {expected}")
   prediction = predict_outcome(test_input, categories)
@@ -146,5 +159,5 @@ system forge_sensei_server
     sensei: forge_sensei
 
 # ── Usage ─────────────────────────────────────────────────────
-# Dev:    forge serve workflows/forge-sensei/web.forge --watch
-# Build:  forge build workflows/forge-sensei/ --entry web.forge --source core.forge --source agent.forge -o bin/forge-sensei-server
+# Dev:    forge serve workflows/forge-sensei/server/web.forge --source workflows/forge-sensei/shared/types.forge --source workflows/forge-sensei/shared/events.forge --source workflows/forge-sensei/shared/states.forge --source workflows/forge-sensei/server/tasks.forge --source workflows/forge-sensei/server/flows.forge --source workflows/forge-sensei/server/agent.forge --watch
+# Build:  forge build workflows/forge-sensei/server -o bin/forge-sensei-server

--- a/workflows/forge-sensei/shared/events.forge
+++ b/workflows/forge-sensei/shared/events.forge
@@ -1,0 +1,18 @@
+#! boundary: shared
+
+event LearnedInsight
+  category: Text
+  content: Text
+  source: Text
+  confidence: Number
+
+event AssessmentCompleted
+  level: Text
+  score: Number
+  passed: Number
+  total: Number
+  failures: Text
+
+event KnowledgeGapFound
+  category: Text
+  question: Text

--- a/workflows/forge-sensei/shared/states.forge
+++ b/workflows/forge-sensei/shared/states.forge
@@ -1,0 +1,11 @@
+#! boundary: shared
+
+states MasteryLevel
+  novice -> apprentice when conformance_score >= 40
+  apprentice -> journeyman when conformance_score >= 70
+  journeyman -> expert when conformance_score >= 90
+  expert -> expert
+
+states SpecialistPhase
+  learning -> ready when absorbed_count >= 5
+  ready -> ready

--- a/workflows/forge-sensei/shared/types.forge
+++ b/workflows/forge-sensei/shared/types.forge
@@ -1,0 +1,18 @@
+#! boundary: shared
+
+type QueryResult
+  answer: Text
+  confidence_tier: Text
+  sources_used: Number
+
+type AssessmentResult
+  passed: Bool
+  prediction: Text
+  expected: Text
+  gap_topic: Text
+
+type ApiStatus
+  status: Text
+
+type ApiTextResult
+  result: Text


### PR DESCRIPTION
## Summary
- Fixes #256.
- Splits `workflows/forge-sensei` into `shared/`, `server/`, and `client/` FORGE projects.
- Moves server endpoints/persistence/web UI into server boundary files and adds a pure-FORGE client-boundary HTTP wrapper agent.
- Updates build/install scripts, docs, examples validation, roadmap, changelog, and tests for the split layout.
- Adds runtime/build support needed by the generated client/server shape.

## Acceptance Criteria
- [x] `forge build workflows/forge-sensei/server` produces the server binary.
- [x] `forge build workflows/forge-sensei/client` produces the client binary.
- [x] `grep -r` forbidden server primitives in `workflows/forge-sensei/client/` is empty.
- [x] Previously working user commands work end-to-end through the pure-FORGE client (`update-mastery 75`, `status`, `ingest-fact`).
- [x] Shared types/events/states are referenced from both sides through the split layout.

## Verification
- `cargo test` with `ANTHROPIC_API_KEY` set, including live wiki tests.
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `bash scripts/check-forge-examples.sh`
- `bash scripts/check-principles.sh`
- `git diff --check`
- client-boundary forbidden primitive grep
- `cargo run -- build workflows/forge-sensei/server -o /tmp/forge-sensei-server-256`
- `cargo run -- build workflows/forge-sensei/client -o /tmp/forge-sensei-client-256`
- localhost server/client smoke validation for `update-mastery 75`, `status`, and `ingest-fact`

## Stack
- Base PR: #262
- This PR is intentionally stacked because #256 depends on #250 and #251. After lower PRs merge, this can be retargeted to `development`.

## Known Gaps
- None.