### PR TITLE
feat(workflows): client preflight + check command (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `proc.exit(code)` runtime primitive: one-shot CLI handlers can signal a non-zero exit, translated by the generated dispatch into `std::process::exit(code)` without the error-formatting path (#258)
+- forge-sensei client `check` command: reports `server ok` and exit 0 when `/api/status` is reachable, prints a clear unreachable message with start instructions and exits 1 otherwise (#258)
+- forge-sensei client handlers now exit 1 when the server is unreachable (query/review/status/ingest/etc.), so shell scripts and CI can rely on the exit code (#258)
 - forge-sensei native boundary split: shared/server/client FORGE projects now build separate server and pure HTTP client binaries, with client-safe API endpoints for sensei commands (#256)
 - forge-sensei `/api/self-assess` endpoint: triggers built-in curriculum evaluation and persists mastery internally via `data.store` — no external assess.sh/cron needed (#247)
 - forge-sensei status endpoints (`/api/status`, `/status` HTML) now reflect persisted mastery state instead of hardcoded 0 (#247)
@@ -23,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example toolkit agent (`examples/agents/toolkit_demo.forge`) demonstrating spawn→recall→emit→absorb pattern (#167)
 
 ### Fixed
+- forge-sensei client handlers (query/review/ingest/deep-dive/update-mastery) now form-encode their POST bodies (e.g. `question=...`) so the server can bind the parameters instead of failing with `undefined variable` (#258)
 - `install-sensei.sh` default config now points to vLLM on `192.168.10.195:8000` instead of stale Ollama localhost defaults; server wrapper uses `--config` flag for unambiguous config resolution (#247)
 - Multi-file project builds (`forge build`) no longer fail on cross-file lifecycle references; checker now validates the merged program (#167)
 - Quiz tutor example now runs cleanly with `FORGE_MOCK=1 forge run examples/agents/quiz_tutor.forge`, and mock-runnable examples reject checker warnings in the validation gate (#231)

--- a/src/build.rs
+++ b/src/build.rs
@@ -664,6 +664,10 @@ async fn dispatch(
     match agent.dispatch(event, params).await {{
         Ok(Some(val)) => println!("{{}}", val.value),
         Ok(None) => {{}},
+        // Raised by the `exit(code)` capability (issue #258). Bypass the
+        // error-formatting path — the handler has already emitted any
+        // user-facing message via `say`.
+        Err(forge::runtime::executor::RuntimeError::Exit(code)) => std::process::exit(code),
         Err(e) => {{
             eprintln!("error: {{}}", e);
             std::process::exit(1);

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -190,6 +190,18 @@ impl CapabilityRegistry {
                 output: ForgeType::Text,
             },
         );
+        // proc.exit(code) -> never returns — signal process exit with the given code.
+        // Raises RuntimeError::Exit which the generated CLI dispatch translates to
+        // std::process::exit(code). Used by one-shot clients to propagate a
+        // failure exit code when a remote dependency is unreachable.
+        // See issue #258 (part of epic #249).
+        caps.insert(
+            "proc.exit".into(),
+            CapabilitySignature {
+                inputs: vec![ForgeType::Number],
+                output: ForgeType::Unit,
+            },
+        );
         caps.insert(
             "data.store".into(),
             CapabilitySignature {

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -60,6 +60,14 @@ pub enum RuntimeError {
     // Control flow — not a real error, used to signal graceful agent retirement
     #[error("retire signal (internal)")]
     RetireSignal,
+
+    // Control flow — raised by the `exit(code)` capability in one-shot CLI clients
+    // to propagate a process exit code. See issue #258 (part of epic #249).
+    // The generated CLI dispatch (src/build.rs) catches this and calls
+    // std::process::exit(code) without printing — the handler has already
+    // emitted any user-facing message via `say`.
+    #[error("")]
+    Exit(i32),
 }
 
 /// Result from executing an endpoint, including optional response metadata.
@@ -1872,6 +1880,27 @@ impl TaskExecutor {
                                 .unwrap_or_default();
                             let value = std::env::var(&name).unwrap_or_else(|_| default.clone());
                             return Ok(ConfidentValue::deterministic(Value::Text(value)));
+                        }
+                    }
+
+                    // proc.exit(code) — signal process exit. See issue #258.
+                    // Raises RuntimeError::Exit, which the generated CLI dispatch
+                    // (src/build.rs) translates to std::process::exit(code). Non-CLI
+                    // contexts propagate the error like any other uncaught signal.
+                    if let Expr::Ident(ref ns) = obj_expr.node {
+                        if ns == "proc" && method.node == "exit" {
+                            let mut arg_vals = Vec::new();
+                            for arg in args {
+                                arg_vals.push(self.eval_expr(&arg.node.value, env).await?);
+                            }
+                            let code = match arg_vals.first().map(|v| &v.value) {
+                                Some(Value::Number(n)) => {
+                                    // Clamp to conventional Unix exit-code range.
+                                    (n.trunc() as i64).clamp(0, 255) as i32
+                                }
+                                _ => 1,
+                            };
+                            return Err(RuntimeError::Exit(code));
                         }
                     }
 

--- a/tests/exit_primitive_tests.rs
+++ b/tests/exit_primitive_tests.rs
@@ -1,0 +1,109 @@
+// Tests for proc.exit runtime primitive — issue #258 (part of epic #249).
+//
+// proc.exit(code) raises RuntimeError::Exit(code), which the generated CLI
+// dispatch (src/build.rs) translates to std::process::exit(code). In non-CLI
+// contexts, it surfaces as an uncaught exit signal.
+
+use forge::checker::boundary_checker;
+use forge::diagnostic::DiagnosticKind;
+use forge::runtime::executor::RuntimeError;
+
+fn errors_for(src: &str) -> Vec<String> {
+    let program = forge::parser::parse(src).expect("parse should succeed");
+    let diags = boundary_checker::check(&[(&program, "test.forge")]);
+    diags
+        .into_iter()
+        .filter(|d| matches!(d.kind, DiagnosticKind::Error))
+        .map(|d| d.message)
+        .collect()
+}
+
+// ── Boundary acceptance ────────────────────────────────────────────────────
+
+#[test]
+fn proc_exit_is_allowed_in_client_boundary() {
+    let src = r#"#! boundary: client
+
+use
+  web.fetch
+  env.get
+  proc.exit
+
+agent tiny_client
+  on check
+    base = env.get("SERVER", "http://127.0.0.1:3000")
+    response = try web.fetch("{base}/api/status") or ""
+    if response == ""
+      say "unreachable"
+      proc.exit(1)
+    say "ok"
+"#;
+    let errs = errors_for(src);
+    assert!(
+        errs.is_empty(),
+        "proc.exit should be allowed in client boundary, got errors: {:?}",
+        errs
+    );
+}
+
+// ── Runtime behaviour ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn proc_exit_raises_exit_error_with_code() {
+    use std::sync::Arc;
+
+    let src = r#"fn main
+  proc.exit(42)
+"#;
+    let program = forge::parser::parse(src).expect("parse should succeed");
+    let config = forge::config::ForgeConfig::default_mock_config();
+    let registry =
+        Arc::new(forge::llm::registry::ProviderRegistry::from_config(config).expect("registry"));
+    let executor = forge::runtime::executor::TaskExecutor::new(program, registry, None);
+    let result = executor.run().await;
+    match result {
+        Err(RuntimeError::Exit(code)) => assert_eq!(code, 42),
+        other => panic!("expected RuntimeError::Exit(42), got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn proc_exit_zero_raises_exit_error() {
+    use std::sync::Arc;
+
+    let src = r#"fn main
+  proc.exit(0)
+"#;
+    let program = forge::parser::parse(src).expect("parse should succeed");
+    let config = forge::config::ForgeConfig::default_mock_config();
+    let registry =
+        Arc::new(forge::llm::registry::ProviderRegistry::from_config(config).expect("registry"));
+    let executor = forge::runtime::executor::TaskExecutor::new(program, registry, None);
+    let result = executor.run().await;
+    match result {
+        Err(RuntimeError::Exit(code)) => assert_eq!(code, 0),
+        other => panic!("expected RuntimeError::Exit(0), got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn proc_exit_clamps_out_of_range_codes() {
+    use std::sync::Arc;
+
+    let src = r#"fn main
+  proc.exit(999)
+"#;
+    let program = forge::parser::parse(src).expect("parse should succeed");
+    let config = forge::config::ForgeConfig::default_mock_config();
+    let registry =
+        Arc::new(forge::llm::registry::ProviderRegistry::from_config(config).expect("registry"));
+    let executor = forge::runtime::executor::TaskExecutor::new(program, registry, None);
+    let result = executor.run().await;
+    match result {
+        Err(RuntimeError::Exit(code)) => assert_eq!(code, 255),
+        other => panic!(
+            "expected RuntimeError::Exit(255) (clamped), got {:?}",
+            other
+        ),
+    }
+}

--- a/workflows/forge-sensei/client/client.forge
+++ b/workflows/forge-sensei/client/client.forge
@@ -4,52 +4,94 @@ use
   web.fetch
   web.post
   env.get
+  proc.exit
 
 agent forge_sensei_client
+  on check
+    base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
+    response = try web.fetch("{base}/api/status") or ""
+    if response == ""
+      say "server unreachable at {base}"
+      say "start with: forge-sensei-server service start"
+      proc.exit(1)
+    say "server ok at {base}"
+
   on status
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
-    response = try web.fetch("{base}/api/status") or "server unreachable at {base}"
+    response = try web.fetch("{base}/api/status") or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response
 
   on query(question: Text)
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
-    response = try web.post("{base}/api/ask", question) or "server unreachable at {base}"
+    payload = "question={question}"
+    response = try web.post("{base}/api/ask", payload) or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response
 
   on review(code: Text)
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
-    response = try web.post("{base}/api/review", code) or "server unreachable at {base}"
+    payload = "code={code}"
+    response = try web.post("{base}/api/review", payload) or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response
 
   on ingest(document_path: Text)
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
-    response = try web.post("{base}/api/ingest", document_path) or "server unreachable at {base}"
+    payload = "document_path={document_path}"
+    response = try web.post("{base}/api/ingest", payload) or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response
 
   on ingest_fact(category: Text, fact: Text)
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
     payload = "category={category}&fact={fact}"
-    response = try web.post("{base}/api/ingest-fact", payload) or "server unreachable at {base}"
+    response = try web.post("{base}/api/ingest-fact", payload) or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response
 
   on learn_from_session(question: Text, resolution: Text)
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
     payload = "question={question}&resolution={resolution}"
-    response = try web.post("{base}/api/learn-from-session", payload) or "server unreachable at {base}"
+    response = try web.post("{base}/api/learn-from-session", payload) or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response
 
   on deep_dive(topic: Text)
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
-    response = try web.post("{base}/api/deep-dive", topic) or "server unreachable at {base}"
+    payload = "topic={topic}"
+    response = try web.post("{base}/api/deep-dive", payload) or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response
 
   on assess_detailed(test_input: Text, expected: Text)
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
     payload = "test_input={test_input}&expected={expected}"
-    response = try web.post("{base}/api/assess-detailed", payload) or "server unreachable at {base}"
+    response = try web.post("{base}/api/assess-detailed", payload) or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response
 
   on update_mastery(score: Number)
     base = env.get("FORGE_SENSEI_SERVER", "http://127.0.0.1:3000")
-    response = try web.post("{base}/api/update-mastery", "{score}") or "server unreachable at {base}"
+    payload = "score={score}"
+    response = try web.post("{base}/api/update-mastery", payload) or ""
+    if response == ""
+      say "server unreachable at {base}"
+      proc.exit(1)
     say response


### PR DESCRIPTION
## Summary

Adds `proc.exit(code)` runtime primitive and wires it into the forge-sensei pure-FORGE client so one-shot invocations propagate failure exit codes. Closes step 9 of epic #249.

- `forge-sensei check` → exit 0 `server ok` when `/api/status` reachable, exit 1 with start instructions otherwise
- All client handlers (`query`, `status`, `review`, etc.) → exit 1 with `server unreachable at {base}` when down
- Also fixes a pre-existing body-encoding bug (raw text vs. form-encoded) that made AC #2 unverifiable

## Acceptance criteria (#258)

- [x] Server down + `forge-sensei query "x"` → clear error + exit 1, no hang
- [x] Server up + `forge-sensei query "x"` → normal response, exit 0
- [x] `forge-sensei check` returns 0 reachable, 1 otherwise

## Implementation notes

- `proc.exit` follows the #251 `env.get` precedent — pure capability addition (resolver + executor + one dispatch branch), no grammar changes
- Semantics: raises `RuntimeError::Exit(code)` (a new control-flow variant next to `GiveSignal` / `RetireSignal`), caught by generated `dispatch()` and passed to `std::process::exit` without printing `error: ...` — the handler has already `say`-d its user-facing message
- Client pattern is deliberate: `try web.post(...) or ""` → `if response == ""` → `say` + `proc.exit(1)`. Verbose but honest — we keep `try/or` as a value-producing expression and use an explicit empty-string sentinel rather than adding a second failure primitive

## Out of scope

- Server-boundary rejection of `proc.exit` (could foot-gun a server that calls it) — future concern
- A `fail "msg"` statement form — `say` + `proc.exit` covers the AC with no grammar work
- `ingest(document_path)` / `batch_assess` client commands — still deferred from #256

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings`
- [x] `cargo test --test exit_primitive_tests` — 4 new tests pass (client-boundary acceptance, exit-error propagation with code, clamp-to-255)
- [x] Full e2e against running server: `check` / `query` / down + check / down + query all show correct messages and exit codes
- [ ] CI green on `development`

Part of #249.