### PR TITLE
feat(runtime): agent lifecycle events on tracer broadcast (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Agent lifecycle events on the tracer broadcast: `AgentStarted`, `HandlerStarted`, `HandlerCompleted` (status: `success` | `timeout` | `error` | `blocked_by_requires`, with `duration_ms` and `confidence`), and `AgentShutdown` (reason: `retire` | `channel_closed` | `error`). Automatically surfaces on `/__forge/events` SSE and the cost-aggregator channel so Observer and internal agents can see the runtime run itself (#255)
 - `proc.exit(code)` runtime primitive: one-shot CLI handlers can signal a non-zero exit, translated by the generated dispatch into `std::process::exit(code)` without the error-formatting path (#258)
 - forge-sensei client `check` command: reports `server ok` and exit 0 when `/api/status` is reachable, prints a clear unreachable message with start instructions and exits 1 otherwise (#258)
 - forge-sensei client handlers now exit 1 when the server is unreachable (query/review/status/ingest/etc.), so shell scripts and CI can rely on the exit code (#258)

--- a/src/runtime/agent.rs
+++ b/src/runtime/agent.rs
@@ -508,9 +508,24 @@ impl AgentProcess {
                 .eval_expr(&req.node.condition, &mut env)
                 .await?;
             if !truthy(&cond_val) {
+                if let Some(t) = self.executor.tracer() {
+                    t.handler_completed(
+                        &self.decl.name.node,
+                        event,
+                        "blocked_by_requires",
+                        0,
+                        None,
+                    );
+                }
                 return self.apply_fail_policy(&req.node.on_fail, &mut env).await;
             }
         }
+
+        // Emit HandlerStarted after requires pass (issue #255)
+        if let Some(t) = self.executor.tracer() {
+            t.handler_started(&self.decl.name.node, event);
+        }
+        let handler_started_at = std::time::Instant::now();
 
         // Execute handler body with timeout detection
         let handler_timeout = std::time::Duration::from_secs(60);
@@ -518,13 +533,33 @@ impl AgentProcess {
         let result = match tokio::time::timeout(handler_timeout, exec_future).await {
             Ok(Ok(_)) => None,
             Ok(Err(RuntimeError::GiveSignal(val, ..))) => Some(val),
-            Ok(Err(e)) => return Err(e),
+            Ok(Err(e)) => {
+                if let Some(t) = self.executor.tracer() {
+                    t.handler_completed(
+                        &self.decl.name.node,
+                        event,
+                        "error",
+                        handler_started_at.elapsed().as_millis() as u64,
+                        None,
+                    );
+                }
+                return Err(e);
+            }
             Err(_elapsed) => {
                 // Handler timed out — signal warden
                 if let Some(ref tx) = self.warden_tx {
                     let _ = tx.try_send(AgentSignal::Timeout {
                         agent_name: self.decl.name.node.clone(),
                     });
+                }
+                if let Some(t) = self.executor.tracer() {
+                    t.handler_completed(
+                        &self.decl.name.node,
+                        event,
+                        "timeout",
+                        handler_started_at.elapsed().as_millis() as u64,
+                        None,
+                    );
                 }
                 return Err(RuntimeError::Unsupported(format!(
                     "agent '{}' handler '{}' timed out after {}s",
@@ -534,6 +569,18 @@ impl AgentProcess {
                 )));
             }
         };
+
+        // Emit HandlerCompleted for success path (issue #255)
+        if let Some(t) = self.executor.tracer() {
+            let confidence = result.as_ref().map(|v| v.confidence);
+            t.handler_completed(
+                &self.decl.name.node,
+                event,
+                "success",
+                handler_started_at.elapsed().as_millis() as u64,
+                confidence,
+            );
+        }
 
         // Record turn for stuck detection
         let response_text = result
@@ -639,6 +686,11 @@ impl AgentProcess {
     /// events, dispatch to handlers, and drain emitted events back through the bus.
     /// Returns when all event channels are closed.
     pub async fn run(&mut self) -> Result<(), RuntimeError> {
+        // Emit AgentStarted lifecycle event (issue #255)
+        if let Some(t) = self.executor.tracer() {
+            t.agent_started(&self.decl.name.node, std::process::id());
+        }
+
         // Merge all receivers into a single stream via a helper channel
         let (merge_tx, mut merge_rx) = mpsc::channel::<(Option<Spanned<Expr>>, EventPayload)>(64);
 
@@ -658,6 +710,7 @@ impl AgentProcess {
         // Drop our copy so merge_rx closes when all forwarders finish
         drop(merge_tx);
 
+        let shutdown_reason: &'static str;
         loop {
             tokio::select! {
                 msg = merge_rx.recv() => {
@@ -677,21 +730,40 @@ impl AgentProcess {
 
                                 match self.dispatch(&event_name, params).await {
                                     Ok(_) => {}
-                                    Err(RuntimeError::RetireSignal) => break,
-                                    Err(e) => return Err(e),
+                                    Err(RuntimeError::RetireSignal) => {
+                                        shutdown_reason = "retire";
+                                        break;
+                                    }
+                                    Err(e) => {
+                                        if let Some(t) = self.executor.tracer() {
+                                            t.agent_shutdown(&self.decl.name.node, "error");
+                                        }
+                                        return Err(e);
+                                    }
                                 }
                                 self.drain_event_sink().await?;
                             }
                         }
-                        None => break, // All event channels closed
+                        None => {
+                            shutdown_reason = "channel_closed";
+                            break;
+                        }
                     }
                 }
                 fired = self.timer_rx.recv() => {
                     if let Some(timer_event) = fired {
                         match self.handle_timer_fired(timer_event).await {
                             Ok(()) => {}
-                            Err(RuntimeError::RetireSignal) => break,
-                            Err(e) => return Err(e),
+                            Err(RuntimeError::RetireSignal) => {
+                                shutdown_reason = "retire";
+                                break;
+                            }
+                            Err(e) => {
+                                if let Some(t) = self.executor.tracer() {
+                                    t.agent_shutdown(&self.decl.name.node, "error");
+                                }
+                                return Err(e);
+                            }
                         }
                         self.drain_event_sink().await?;
                     }
@@ -715,6 +787,11 @@ impl AgentProcess {
         // Cleanup worktree on agent exit (issue #194)
         if let Some(ref branch) = self.worktree_branch {
             let _ = crate::runtime::sandbox::remove_worktree(branch);
+        }
+
+        // Emit AgentShutdown lifecycle event (issue #255)
+        if let Some(t) = self.executor.tracer() {
+            t.agent_shutdown(&self.decl.name.node, shutdown_reason);
         }
 
         Ok(())

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -70,6 +70,13 @@ impl Tracer {
         })
     }
 
+    /// Return captured (name, payload) pairs in order — for tests.
+    pub fn captured_log(&self) -> Vec<(String, serde_json::Value)> {
+        self.captured
+            .as_ref()
+            .map_or_else(Vec::new, |buf| buf.lock().unwrap().clone())
+    }
+
     fn ts_ms(&self) -> u64 {
         self.start.elapsed().as_millis() as u64
     }
@@ -542,6 +549,58 @@ impl Tracer {
                 "response": response,
                 "scope": scope,
                 "retry_count": retry_count,
+            }),
+        );
+    }
+
+    // ── Agent lifecycle tracing (issue #255) ───────────────────────────────
+
+    pub fn agent_started(&self, agent: &str, pid: u32) {
+        self.emit(
+            "AgentStarted",
+            serde_json::json!({
+                "agent": agent,
+                "pid": pid,
+            }),
+        );
+    }
+
+    pub fn handler_started(&self, agent: &str, handler: &str) {
+        self.emit(
+            "HandlerStarted",
+            serde_json::json!({
+                "agent": agent,
+                "handler": handler,
+            }),
+        );
+    }
+
+    pub fn handler_completed(
+        &self,
+        agent: &str,
+        handler: &str,
+        status: &str,
+        duration_ms: u64,
+        confidence: Option<f32>,
+    ) {
+        self.emit(
+            "HandlerCompleted",
+            serde_json::json!({
+                "agent": agent,
+                "handler": handler,
+                "status": status,
+                "duration_ms": duration_ms,
+                "confidence": confidence,
+            }),
+        );
+    }
+
+    pub fn agent_shutdown(&self, agent: &str, reason: &str) {
+        self.emit(
+            "AgentShutdown",
+            serde_json::json!({
+                "agent": agent,
+                "reason": reason,
             }),
         );
     }

--- a/tests/lifecycle_events_tests.rs
+++ b/tests/lifecycle_events_tests.rs
@@ -1,0 +1,189 @@
+// FORGE lifecycle event tests — issue #255
+//
+// Verifies that AgentStarted / HandlerStarted / HandlerCompleted / AgentShutdown
+// are emitted by AgentProcess and captured by the tracer.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use forge::ast::*;
+use forge::llm::providers::mock::MockProvider;
+use forge::llm::registry::ProviderRegistry;
+use forge::runtime::agent::AgentProcess;
+use forge::runtime::event_bus::{EventBus, EventPayload};
+use forge::tracer::Tracer;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn spanned<T>(node: T) -> Spanned<T> {
+    Spanned::new(node, Span { start: 0, end: 0 })
+}
+
+fn empty_program() -> Program {
+    Program {
+        boundary: None,
+        items: vec![],
+    }
+}
+
+fn mock_registry() -> Arc<ProviderRegistry> {
+    let mock = MockProvider::new("mock").with_default("mock response");
+    let mut reg = ProviderRegistry::new("mock");
+    reg.register("mock", Arc::new(mock));
+    Arc::new(reg)
+}
+
+fn payload(name: &str, source: &str) -> EventPayload {
+    EventPayload {
+        event_name: name.to_string(),
+        args: vec![],
+        source_agent: source.to_string(),
+        fields: HashMap::new(),
+    }
+}
+
+/// Minimal agent with a `give "ok"` handler for `Ping`.
+fn ping_agent(name: &str) -> AgentDecl {
+    AgentDecl {
+        exportable: false,
+        name: spanned(name.into()),
+        lifecycle: None,
+        memory: vec![],
+        memory_persistent: false,
+        knowledge: None,
+        timers: vec![],
+        subscriptions: vec![spanned(SubscribeDecl {
+            event_name: spanned("Ping".into()),
+            filter: None,
+        })],
+        handlers: vec![spanned(OnHandler {
+            event: spanned("Ping".into()),
+            params: vec![],
+            payload_type: None,
+            requires: vec![],
+            body: vec![spanned(Stmt::Give(
+                spanned(Expr::Template(vec![spanned(TemplatePart::Text(
+                    "ok".into(),
+                ))])),
+                vec![],
+            ))],
+        })],
+        warden_override: Vec::new(),
+        stuck_policy: None,
+    }
+}
+
+/// Agent whose `Ping` handler has an always-false requires guard with Silent fail.
+fn ping_agent_with_failing_requires(name: &str) -> AgentDecl {
+    let mut decl = ping_agent(name);
+    decl.handlers[0].node.requires = vec![spanned(RequiresClause {
+        condition: spanned(Expr::BoolLit(false)),
+        on_fail: Some(spanned(FailPolicy::Silent)),
+    })];
+    decl
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn emits_agent_started_handler_pair_and_shutdown_on_success() {
+    let tracer = Tracer::with_capture();
+    let bus = EventBus::new_shared(None);
+
+    let mut agent = AgentProcess::new(
+        ping_agent("pinger"),
+        None,
+        mock_registry(),
+        Some(tracer.clone()),
+        empty_program(),
+        None,
+        None,
+    )
+    .with_event_bus(bus.clone())
+    .await;
+
+    // Publish one Ping then close the bus so run() returns.
+    {
+        let bus_guard = bus.read().await;
+        bus_guard.publish(&payload("Ping", "external"));
+    }
+    bus.write().await.close();
+
+    agent.run().await.expect("agent run");
+
+    let log = tracer.captured_log();
+    let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+
+    // Lifecycle skeleton appears in this order.
+    let started_pos = names
+        .iter()
+        .position(|n| *n == "AgentStarted")
+        .expect("AgentStarted missing");
+    let handler_started_pos = names
+        .iter()
+        .position(|n| *n == "HandlerStarted")
+        .expect("HandlerStarted missing");
+    let handler_done_pos = names
+        .iter()
+        .position(|n| *n == "HandlerCompleted")
+        .expect("HandlerCompleted missing");
+    let shutdown_pos = names
+        .iter()
+        .position(|n| *n == "AgentShutdown")
+        .expect("AgentShutdown missing");
+
+    assert!(started_pos < handler_started_pos);
+    assert!(handler_started_pos < handler_done_pos);
+    assert!(handler_done_pos < shutdown_pos);
+
+    // Inspect HandlerCompleted payload: success + duration + confidence present.
+    let (_, completed) = &log[handler_done_pos];
+    assert_eq!(completed["event"], "HandlerCompleted");
+    assert_eq!(completed["agent"], "pinger");
+    assert_eq!(completed["handler"], "Ping");
+    assert_eq!(completed["status"], "success");
+    assert!(completed["duration_ms"].is_u64());
+    assert!(completed["confidence"].is_number());
+
+    // AgentStarted carries agent name and a pid.
+    let (_, started) = &log[started_pos];
+    assert_eq!(started["agent"], "pinger");
+    assert!(started["pid"].is_u64());
+
+    // AgentShutdown reason reflects the channel-closed exit path.
+    let (_, shutdown) = &log[shutdown_pos];
+    assert_eq!(shutdown["agent"], "pinger");
+    assert_eq!(shutdown["reason"], "channel_closed");
+}
+
+#[tokio::test]
+async fn blocked_by_requires_emits_handler_completed_without_started() {
+    let tracer = Tracer::with_capture();
+    let agent = AgentProcess::new(
+        ping_agent_with_failing_requires("guarded"),
+        None,
+        mock_registry(),
+        Some(tracer.clone()),
+        empty_program(),
+        None,
+        None,
+    );
+
+    // Direct dispatch: requires guard fails, silent fail policy returns Ok(None).
+    let out = agent.dispatch("Ping", HashMap::new()).await.unwrap();
+    assert!(out.is_none());
+
+    let log = tracer.captured_log();
+    let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+
+    assert!(
+        !names.contains(&"HandlerStarted"),
+        "HandlerStarted must not fire when requires blocks dispatch"
+    );
+    let completed = log
+        .iter()
+        .find(|(n, _)| n == "HandlerCompleted")
+        .expect("HandlerCompleted missing");
+    assert_eq!(completed.1["status"], "blocked_by_requires");
+    assert_eq!(completed.1["duration_ms"], 0);
+}


### PR DESCRIPTION
## Summary
- Emits `AgentStarted`, `HandlerStarted`, `HandlerCompleted`, and `AgentShutdown` from `AgentProcess` — visible on `/__forge/events` SSE and the cost-aggregator broadcast without any wiring changes.
- `HandlerCompleted` carries `status` (`success` | `timeout` | `error` | `blocked_by_requires`), `duration_ms`, and `confidence`. `AgentShutdown` carries `reason` (`retire` | `channel_closed` | `error`).
- Emissions go through the existing `Tracer` pipe alongside `llm_response`, `flow_start`, etc., matching the established observability pattern. (The issue text says "EventBus" but the SSE and cost-aggregator consumers actually read the tracer broadcast — same end result, no new wiring.)

Closes #255. Step 6 of #249.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — full suite, 1189+ tests, 0 failures
- [x] New `tests/lifecycle_events_tests.rs` — asserts event ordering on the happy path and the `blocked_by_requires` path
- [ ] Manual: `forge serve` an agent, `curl -N /__forge/events`, trigger a handler, observe all four events; Ctrl-C and see `AgentShutdown { reason: "channel_closed" }`

## Changelog entry
Under `## [Unreleased] -> Added`:

> Agent lifecycle events on the tracer broadcast: `AgentStarted`, `HandlerStarted`, `HandlerCompleted` (status: `success` | `timeout` | `error` | `blocked_by_requires`, with `duration_ms` and `confidence`), and `AgentShutdown` (reason: `retire` | `channel_closed` | `error`). Automatically surfaces on `/__forge/events` SSE and the cost-aggregator channel so Observer and internal agents can see the runtime run itself (#255)

🤖 Generated with [Claude Code](https://claude.com/claude-code)