### PR TITLE
feat(runtime): cross-platform StartupManager trait (#254)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
+      # StartupManager E2E (#254): exercise the real launchctl/systemd path
+      # on macOS and Linux. Linux needs a user systemd session; if it's not
+      # available in the runner, the test skips itself cleanly.
+      - name: StartupManager E2E (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          loginctl enable-linger "$USER" || true
+          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+          FORGE_SERVICE_E2E=1 cargo test --test startup_manager_tests
+      - name: StartupManager E2E (macOS)
+        if: matrix.os == 'macos-latest'
+        run: FORGE_SERVICE_E2E=1 cargo test --test startup_manager_tests
 
   msrv:
     name: MSRV (1.89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Cross-platform `StartupManager` trait (`src/runtime/startup/`) with per-OS backends for launchctl (macOS), systemd user units (Linux/WSL), and schtasks (Windows). Generated FORGE server binaries now expose `install-service` / `service {start|stop|status|uninstall}` subcommands that emit JSON, replacing the macOS-only shell glue in `install-sensei-server.sh` (which is now a thin wrapper) (#254)
 - Unified persistent storage root: new `[storage] root` key in `forge.config.toml` (with `FORGE_STORAGE_ROOT` env override and legacy `knowledge.store_path` fallback) routes CLI and server redb databases to the same file regardless of working directory. `ForgeStorage::open_from_config` / `resolve_root` replace the ad-hoc `./.forge-data` joins in main.rs and build.rs (#253)
 - Agent lifecycle events on the tracer broadcast: `AgentStarted`, `HandlerStarted`, `HandlerCompleted` (status: `success` | `timeout` | `error` | `blocked_by_requires`, with `duration_ms` and `confidence`), and `AgentShutdown` (reason: `retire` | `channel_closed` | `error`). Automatically surfaces on `/__forge/events` SSE and the cost-aggregator channel so Observer and internal agents can see the runtime run itself (#255)
 - `proc.exit(code)` runtime primitive: one-shot CLI handlers can signal a non-zero exit, translated by the generated dispatch into `std::process::exit(code)` without the error-formatting path (#258)

--- a/scripts/install-sensei-server.sh
+++ b/scripts/install-sensei-server.sh
@@ -1,84 +1,42 @@
 #!/usr/bin/env bash
-# install-sensei-server.sh — Install/start the macOS LaunchAgent for forge-sensei-server.
+# install-sensei-server.sh — Thin wrapper around the cross-platform
+# StartupManager built into forge-sensei-server (issue #254).
+# Retained for backward compatibility with existing docs and tooling.
 set -euo pipefail
 
 LABEL="com.ncmlabs.forge-sensei"
-PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 BIN="$HOME/.forge/bin/forge-sensei-server"
-CONFIG="$HOME/.forge/sensei/config.toml"
-LOG_DIR="$HOME/.forge/sensei/logs"
 
 usage() {
   echo "Usage: $0 {install|start|stop|restart|status|uninstall}"
 }
 
 cmd="${1:-install}"
-mkdir -p "$(dirname "$PLIST")" "$LOG_DIR"
+
+if [ ! -x "$BIN" ]; then
+  echo "Error: $BIN not found. Run: bash scripts/install-sensei.sh --skip-pretrain"
+  exit 1
+fi
 
 case "$cmd" in
   install)
-    if [ ! -x "$BIN" ]; then
-      echo "Error: $BIN not found. Run: bash scripts/install-sensei.sh --skip-pretrain"
-      exit 1
-    fi
-    cat > "$PLIST" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>$LABEL</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>$BIN</string>
-    <string>--host</string>
-    <string>127.0.0.1</string>
-    <string>--port</string>
-    <string>3000</string>
-  </array>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>FORGE_CONFIG</key>
-    <string>$CONFIG</string>
-  </dict>
-  <key>WorkingDirectory</key>
-  <string>$HOME/.forge/sensei</string>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-  <key>StandardOutPath</key>
-  <string>$LOG_DIR/server.out.log</string>
-  <key>StandardErrorPath</key>
-  <string>$LOG_DIR/server.err.log</string>
-</dict>
-</plist>
-PLIST
-    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
-    launchctl bootstrap "gui/$(id -u)" "$PLIST"
-    launchctl kickstart -k "gui/$(id -u)/$LABEL"
-    echo "Installed and started $LABEL"
+    "$BIN" install-service --label "$LABEL"
     ;;
   start)
-    launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null || true
-    launchctl kickstart -k "gui/$(id -u)/$LABEL"
+    "$BIN" service start --label "$LABEL"
     ;;
   stop)
-    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+    "$BIN" service stop --label "$LABEL"
     ;;
   restart)
-    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
-    launchctl bootstrap "gui/$(id -u)" "$PLIST"
-    launchctl kickstart -k "gui/$(id -u)/$LABEL"
+    "$BIN" service stop --label "$LABEL" || true
+    "$BIN" service start --label "$LABEL"
     ;;
   status)
-    launchctl print "gui/$(id -u)/$LABEL"
+    "$BIN" service status --label "$LABEL"
     ;;
   uninstall)
-    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
-    rm -f "$PLIST"
-    echo "Uninstalled $LABEL"
+    "$BIN" service uninstall --label "$LABEL"
     ;;
   *)
     usage

--- a/src/build.rs
+++ b/src/build.rs
@@ -899,7 +899,7 @@ fn generate_server_main(source_entries: &[String], embed_config: Option<&str>) -
     let config_code = config_resolution_code(embed_config);
 
     format!(
-        r#"use clap::Parser;
+        r#"use clap::{{Parser, Subcommand}};
 use std::sync::Arc;
 
 const SOURCES: &[(&str, &str)] = &[
@@ -924,11 +924,100 @@ struct Cli {{
     /// Clear persisted state (storage, lifecycle) before starting.
     #[arg(long)]
     reset: bool,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}}
+
+#[derive(Subcommand)]
+enum Command {{
+    /// Install this binary as a user service (launchctl/systemd/schtasks).
+    InstallService {{
+        #[arg(long, default_value = "com.ncmlabs.forge-server")]
+        label: String,
+    }},
+    /// Manage an installed service.
+    Service {{
+        #[command(subcommand)]
+        action: ServiceAction,
+    }},
+}}
+
+#[derive(Subcommand)]
+enum ServiceAction {{
+    Start {{ #[arg(long)] label: String }},
+    Stop {{ #[arg(long)] label: String }},
+    Status {{ #[arg(long)] label: String }},
+    Uninstall {{ #[arg(long)] label: String }},
+}}
+
+fn run_service_subcommand(cli: &Cli) -> anyhow::Result<()> {{
+    use forge::runtime::startup::{{self, ServiceConfig}};
+    let mgr = startup::current();
+    match cli.command.as_ref().expect("caller checked is_some") {{
+        Command::InstallService {{ label }} => {{
+            let binary = std::env::current_exe()?;
+            let home = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))?;
+            let log_dir = home.join(".forge/logs");
+            std::fs::create_dir_all(&log_dir).ok();
+            let mut cfg = ServiceConfig::new(label.clone(), binary);
+            cfg.args = vec![
+                "--host".into(), cli.host.clone(),
+                "--port".into(), cli.port.to_string(),
+            ];
+            if let Some(ref c) = cli.config {{
+                cfg.env.push(("FORGE_CONFIG".into(), c.clone()));
+            }}
+            cfg.working_dir = Some(home.clone());
+            cfg.stdout_log = Some(log_dir.join(format!("{{}}.out.log", label)));
+            cfg.stderr_log = Some(log_dir.join(format!("{{}}.err.log", label)));
+            cfg.keep_alive = true;
+            mgr.install(&cfg)?;
+            println!("{{{{\"status\":\"installed\",\"label\":\"{{}}\"}}}}", label);
+            Ok(())
+        }}
+        Command::Service {{ action }} => {{
+            match action {{
+                ServiceAction::Start {{ label }} => {{
+                    mgr.start(label)?;
+                    println!("{{{{\"status\":\"started\",\"label\":\"{{}}\"}}}}", label);
+                }}
+                ServiceAction::Stop {{ label }} => {{
+                    mgr.stop(label)?;
+                    println!("{{{{\"status\":\"stopped\",\"label\":\"{{}}\"}}}}", label);
+                }}
+                ServiceAction::Status {{ label }} => {{
+                    let status = mgr.status(label)?;
+                    let pid = match &status {{
+                        forge::runtime::startup::ServiceStatus::Running {{ pid }} => {{
+                            pid.map(|n| n.to_string()).unwrap_or_else(|| "null".to_string())
+                        }}
+                        _ => "null".to_string(),
+                    }};
+                    println!(
+                        "{{{{\"label\":\"{{}}\",\"state\":\"{{}}\",\"pid\":{{}}}}}}",
+                        label, status.as_str(), pid,
+                    );
+                }}
+                ServiceAction::Uninstall {{ label }} => {{
+                    mgr.uninstall(label)?;
+                    println!("{{{{\"status\":\"uninstalled\",\"label\":\"{{}}\"}}}}", label);
+                }}
+            }}
+            Ok(())
+        }}
+    }}
 }}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {{
     let cli = Cli::parse();
+
+    // Service management subcommands short-circuit the server boot.
+    if cli.command.is_some() {{
+        return run_service_subcommand(&cli);
+    }}
 
     // --config flag overrides all other config resolution
     if let Some(ref config_path) = cli.config {{

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -23,6 +23,7 @@ pub mod skill;
 pub mod skill_executor;
 pub mod skill_loader;
 pub mod skill_registry;
+pub mod startup;
 pub mod state_machine;
 pub mod storage;
 pub mod system;

--- a/src/runtime/startup/linux.rs
+++ b/src/runtime/startup/linux.rs
@@ -81,8 +81,7 @@ impl StartupManager for Systemd {
                     .filter(|p| *p != 0);
                 Ok(ServiceStatus::Running { pid })
             }
-            "inactive" | "failed" | "deactivating" => Ok(ServiceStatus::Stopped),
-            other if other.is_empty() => Ok(ServiceStatus::Stopped),
+            "inactive" | "failed" | "deactivating" | "" => Ok(ServiceStatus::Stopped),
             other => Ok(ServiceStatus::Unknown(other.to_string())),
         }
     }

--- a/src/runtime/startup/linux.rs
+++ b/src/runtime/startup/linux.rs
@@ -1,0 +1,136 @@
+// Linux StartupManager via systemd user units.
+
+use std::process::Command;
+
+use super::{
+    ensure_parent, render_unit, systemd_unit_path, ServiceConfig, ServiceStatus, StartupManager,
+};
+
+pub(crate) struct Systemd;
+
+impl Systemd {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn preflight() -> anyhow::Result<()> {
+        // systemctl must exist; `systemctl --user` needs a user bus, which
+        // typically requires $XDG_RUNTIME_DIR to be set.
+        if which("systemctl").is_none() {
+            anyhow::bail!(
+                "systemctl not found. systemd is required for service management on Linux"
+            );
+        }
+        if std::env::var_os("XDG_RUNTIME_DIR").is_none() {
+            anyhow::bail!(
+                "XDG_RUNTIME_DIR is not set. systemd user session unavailable (common on WSL without systemd)"
+            );
+        }
+        Ok(())
+    }
+}
+
+impl StartupManager for Systemd {
+    fn install(&self, cfg: &ServiceConfig) -> anyhow::Result<()> {
+        Self::preflight()?;
+        let unit_path = systemd_unit_path(&cfg.label)?;
+        ensure_parent(&unit_path)?;
+        std::fs::write(&unit_path, render_unit(cfg))?;
+
+        run_systemctl(["daemon-reload"])?;
+        run_systemctl(["enable", "--now", &format!("{}.service", cfg.label)])?;
+        Ok(())
+    }
+
+    fn start(&self, label: &str) -> anyhow::Result<()> {
+        Self::preflight()?;
+        run_systemctl(["start", &format!("{}.service", label)])
+    }
+
+    fn stop(&self, label: &str) -> anyhow::Result<()> {
+        Self::preflight()?;
+        run_systemctl(["stop", &format!("{}.service", label)])
+    }
+
+    fn status(&self, label: &str) -> anyhow::Result<ServiceStatus> {
+        Self::preflight()?;
+        let unit_path = systemd_unit_path(label)?;
+        if !unit_path.exists() {
+            return Ok(ServiceStatus::NotInstalled);
+        }
+        let out = Command::new("systemctl")
+            .args(["--user", "is-active", &format!("{}.service", label)])
+            .output()?;
+        let state = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        match state.as_str() {
+            "active" | "activating" => {
+                let pid_out = Command::new("systemctl")
+                    .args([
+                        "--user",
+                        "show",
+                        "-p",
+                        "MainPID",
+                        "--value",
+                        &format!("{}.service", label),
+                    ])
+                    .output()?;
+                let pid = String::from_utf8_lossy(&pid_out.stdout)
+                    .trim()
+                    .parse::<u32>()
+                    .ok()
+                    .filter(|p| *p != 0);
+                Ok(ServiceStatus::Running { pid })
+            }
+            "inactive" | "failed" | "deactivating" => Ok(ServiceStatus::Stopped),
+            other if other.is_empty() => Ok(ServiceStatus::Stopped),
+            other => Ok(ServiceStatus::Unknown(other.to_string())),
+        }
+    }
+
+    fn uninstall(&self, label: &str) -> anyhow::Result<()> {
+        Self::preflight()?;
+        let unit_file = format!("{}.service", label);
+        let _ = Command::new("systemctl")
+            .args(["--user", "disable", "--now", &unit_file])
+            .output();
+        let unit_path = systemd_unit_path(label)?;
+        if unit_path.exists() {
+            std::fs::remove_file(&unit_path)?;
+        }
+        let _ = Command::new("systemctl")
+            .args(["--user", "daemon-reload"])
+            .output();
+        Ok(())
+    }
+}
+
+fn run_systemctl<I, S>(args: I) -> anyhow::Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let mut cmd = Command::new("systemctl");
+    cmd.arg("--user");
+    for a in args {
+        cmd.arg(a);
+    }
+    let out = cmd.output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "systemctl --user failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn which(bin: &str) -> Option<std::path::PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(bin);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}

--- a/src/runtime/startup/macos.rs
+++ b/src/runtime/startup/macos.rs
@@ -1,0 +1,132 @@
+// macOS StartupManager via launchctl (user domain).
+
+use std::process::Command;
+
+use super::{
+    ensure_parent, launchagent_plist_path, render_plist, ServiceConfig, ServiceStatus,
+    StartupManager,
+};
+
+pub(crate) struct Launchctl;
+
+impl Launchctl {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn domain() -> String {
+        // Use `gui/$UID` domain so plist is loaded into the user's GUI
+        // session, matching scripts/install-sensei-server.sh.
+        let uid = unsafe { libc_getuid() };
+        format!("gui/{}", uid)
+    }
+
+    fn target(label: &str) -> String {
+        format!("{}/{}", Self::domain(), label)
+    }
+}
+
+impl StartupManager for Launchctl {
+    fn install(&self, cfg: &ServiceConfig) -> anyhow::Result<()> {
+        let plist_path = launchagent_plist_path(&cfg.label)?;
+        ensure_parent(&plist_path)?;
+        std::fs::write(&plist_path, render_plist(cfg))?;
+
+        // Best-effort unload in case of stale registration.
+        let _ = Command::new("launchctl")
+            .args(["bootout", &Self::target(&cfg.label)])
+            .output();
+
+        let out = Command::new("launchctl")
+            .args([
+                "bootstrap",
+                &Self::domain(),
+                &plist_path.display().to_string(),
+            ])
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "launchctl bootstrap failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        let _ = Command::new("launchctl")
+            .args(["kickstart", "-k", &Self::target(&cfg.label)])
+            .output();
+        Ok(())
+    }
+
+    fn start(&self, label: &str) -> anyhow::Result<()> {
+        let plist_path = launchagent_plist_path(label)?;
+        // Bootstrap is a no-op if already loaded.
+        let _ = Command::new("launchctl")
+            .args([
+                "bootstrap",
+                &Self::domain(),
+                &plist_path.display().to_string(),
+            ])
+            .output();
+        let out = Command::new("launchctl")
+            .args(["kickstart", "-k", &Self::target(label)])
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "launchctl kickstart failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    }
+
+    fn stop(&self, label: &str) -> anyhow::Result<()> {
+        let _ = Command::new("launchctl")
+            .args(["bootout", &Self::target(label)])
+            .output();
+        Ok(())
+    }
+
+    fn status(&self, label: &str) -> anyhow::Result<ServiceStatus> {
+        let plist_path = launchagent_plist_path(label)?;
+        if !plist_path.exists() {
+            return Ok(ServiceStatus::NotInstalled);
+        }
+        let out = Command::new("launchctl")
+            .args(["print", &Self::target(label)])
+            .output()?;
+        if !out.status.success() {
+            return Ok(ServiceStatus::Stopped);
+        }
+        let text = String::from_utf8_lossy(&out.stdout);
+        // `launchctl print` emits `pid = <n>` when running.
+        for line in text.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("pid = ") {
+                if let Ok(pid) = rest.trim().parse::<u32>() {
+                    return Ok(ServiceStatus::Running { pid: Some(pid) });
+                }
+            }
+        }
+        // Registered but not running.
+        Ok(ServiceStatus::Stopped)
+    }
+
+    fn uninstall(&self, label: &str) -> anyhow::Result<()> {
+        let _ = Command::new("launchctl")
+            .args(["bootout", &Self::target(label)])
+            .output();
+        let plist_path = launchagent_plist_path(label)?;
+        if plist_path.exists() {
+            std::fs::remove_file(&plist_path)?;
+        }
+        Ok(())
+    }
+}
+
+// Avoid adding a `libc` dep for a single call.
+extern "C" {
+    fn getuid() -> u32;
+}
+#[inline]
+unsafe fn libc_getuid() -> u32 {
+    unsafe { getuid() }
+}

--- a/src/runtime/startup/mod.rs
+++ b/src/runtime/startup/mod.rs
@@ -1,0 +1,420 @@
+// StartupManager — cross-platform service installation (issue #254).
+//
+// Abstracts launchctl (macOS), systemd user units (Linux/WSL), and
+// schtasks (Windows) behind a single trait so generated FORGE server
+// binaries can install themselves as long-running services uniformly.
+
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+pub(crate) mod linux;
+#[cfg(target_os = "macos")]
+pub(crate) mod macos;
+#[cfg(target_os = "windows")]
+pub(crate) mod windows;
+
+/// Input to `StartupManager::install`.
+#[derive(Debug, Clone)]
+pub struct ServiceConfig {
+    /// Reverse-DNS identifier, e.g. `com.ncmlabs.forge-sensei`.
+    pub label: String,
+    pub binary: PathBuf,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub working_dir: Option<PathBuf>,
+    pub stdout_log: Option<PathBuf>,
+    pub stderr_log: Option<PathBuf>,
+    /// Restart on exit (LaunchAgent `KeepAlive`, systemd `Restart=always`).
+    pub keep_alive: bool,
+}
+
+impl ServiceConfig {
+    pub fn new(label: impl Into<String>, binary: impl Into<PathBuf>) -> Self {
+        Self {
+            label: label.into(),
+            binary: binary.into(),
+            args: Vec::new(),
+            env: Vec::new(),
+            working_dir: None,
+            stdout_log: None,
+            stderr_log: None,
+            keep_alive: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServiceStatus {
+    Running { pid: Option<u32> },
+    Stopped,
+    NotInstalled,
+    Unknown(String),
+}
+
+impl ServiceStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ServiceStatus::Running { .. } => "running",
+            ServiceStatus::Stopped => "stopped",
+            ServiceStatus::NotInstalled => "not_installed",
+            ServiceStatus::Unknown(_) => "unknown",
+        }
+    }
+}
+
+pub trait StartupManager {
+    fn install(&self, cfg: &ServiceConfig) -> anyhow::Result<()>;
+    fn start(&self, label: &str) -> anyhow::Result<()>;
+    fn stop(&self, label: &str) -> anyhow::Result<()>;
+    fn status(&self, label: &str) -> anyhow::Result<ServiceStatus>;
+    fn uninstall(&self, label: &str) -> anyhow::Result<()>;
+}
+
+/// Returns the service manager for the current platform.
+pub fn current() -> Box<dyn StartupManager> {
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(macos::Launchctl::new())
+    }
+    #[cfg(target_os = "linux")]
+    {
+        Box::new(linux::Systemd::new())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Box::new(windows::Schtasks::new())
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        Box::new(Unsupported)
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+struct Unsupported;
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+impl StartupManager for Unsupported {
+    fn install(&self, _: &ServiceConfig) -> anyhow::Result<()> {
+        anyhow::bail!("StartupManager not supported on this platform")
+    }
+    fn start(&self, _: &str) -> anyhow::Result<()> {
+        anyhow::bail!("StartupManager not supported on this platform")
+    }
+    fn stop(&self, _: &str) -> anyhow::Result<()> {
+        anyhow::bail!("StartupManager not supported on this platform")
+    }
+    fn status(&self, _: &str) -> anyhow::Result<ServiceStatus> {
+        anyhow::bail!("StartupManager not supported on this platform")
+    }
+    fn uninstall(&self, _: &str) -> anyhow::Result<()> {
+        anyhow::bail!("StartupManager not supported on this platform")
+    }
+}
+
+/// Resolve the home directory or return a clear error.
+pub(crate) fn home_dir() -> anyhow::Result<PathBuf> {
+    dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot resolve home directory"))
+}
+
+/// XML-escape text for plist bodies.
+pub(crate) fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '&' => out.push_str("&amp;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Platform-agnostic helper: format a command-and-args string for display.
+#[allow(dead_code)]
+pub(crate) fn quote_arg(s: &str) -> String {
+    if s.is_empty() || s.chars().any(|c| c.is_whitespace() || c == '"') {
+        let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{}\"", escaped)
+    } else {
+        s.to_string()
+    }
+}
+
+// Pure text renderers — implemented here (not in per-OS modules) so they
+// compile and can be unit-tested on every host. The per-OS modules use
+// these to produce the files they drop on disk.
+
+#[allow(dead_code)]
+pub(crate) fn render_plist(cfg: &ServiceConfig) -> String {
+    use std::fmt::Write;
+    let mut prog_args = String::new();
+    writeln!(
+        prog_args,
+        "    <string>{}</string>",
+        xml_escape(&cfg.binary.display().to_string())
+    )
+    .unwrap();
+    for arg in &cfg.args {
+        writeln!(prog_args, "    <string>{}</string>", xml_escape(arg)).unwrap();
+    }
+
+    let mut env_block = String::new();
+    if !cfg.env.is_empty() {
+        env_block.push_str("  <key>EnvironmentVariables</key>\n  <dict>\n");
+        for (k, v) in &cfg.env {
+            writeln!(
+                env_block,
+                "    <key>{}</key>\n    <string>{}</string>",
+                xml_escape(k),
+                xml_escape(v)
+            )
+            .unwrap();
+        }
+        env_block.push_str("  </dict>\n");
+    }
+
+    let wd_block = cfg
+        .working_dir
+        .as_ref()
+        .map(|p| {
+            format!(
+                "  <key>WorkingDirectory</key>\n  <string>{}</string>\n",
+                xml_escape(&p.display().to_string())
+            )
+        })
+        .unwrap_or_default();
+
+    let stdout_block = cfg
+        .stdout_log
+        .as_ref()
+        .map(|p| {
+            format!(
+                "  <key>StandardOutPath</key>\n  <string>{}</string>\n",
+                xml_escape(&p.display().to_string())
+            )
+        })
+        .unwrap_or_default();
+
+    let stderr_block = cfg
+        .stderr_log
+        .as_ref()
+        .map(|p| {
+            format!(
+                "  <key>StandardErrorPath</key>\n  <string>{}</string>\n",
+                xml_escape(&p.display().to_string())
+            )
+        })
+        .unwrap_or_default();
+
+    let keep_alive = if cfg.keep_alive {
+        "<true/>"
+    } else {
+        "<false/>"
+    };
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{label}</string>
+  <key>ProgramArguments</key>
+  <array>
+{prog_args}  </array>
+{env_block}{wd_block}  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  {keep_alive}
+{stdout_block}{stderr_block}</dict>
+</plist>
+"#,
+        label = xml_escape(&cfg.label),
+        prog_args = prog_args,
+        env_block = env_block,
+        wd_block = wd_block,
+        stdout_block = stdout_block,
+        stderr_block = stderr_block,
+        keep_alive = keep_alive,
+    )
+}
+
+#[allow(dead_code)]
+pub(crate) fn render_unit(cfg: &ServiceConfig) -> String {
+    let mut exec = quote_arg(&cfg.binary.display().to_string());
+    for a in &cfg.args {
+        exec.push(' ');
+        exec.push_str(&quote_arg(a));
+    }
+
+    let mut body = String::new();
+    body.push_str("[Unit]\n");
+    body.push_str(&format!("Description=FORGE service: {}\n", cfg.label));
+    body.push_str("After=network.target\n\n");
+
+    body.push_str("[Service]\n");
+    body.push_str(&format!("ExecStart={}\n", exec));
+    if let Some(wd) = &cfg.working_dir {
+        body.push_str(&format!("WorkingDirectory={}\n", wd.display()));
+    }
+    for (k, v) in &cfg.env {
+        body.push_str(&format!(
+            "Environment=\"{}={}\"\n",
+            k,
+            v.replace('"', "\\\"")
+        ));
+    }
+    if let Some(p) = &cfg.stdout_log {
+        body.push_str(&format!("StandardOutput=append:{}\n", p.display()));
+    }
+    if let Some(p) = &cfg.stderr_log {
+        body.push_str(&format!("StandardError=append:{}\n", p.display()));
+    }
+    if cfg.keep_alive {
+        body.push_str("Restart=always\nRestartSec=3\n");
+    }
+    body.push_str("\n[Install]\nWantedBy=default.target\n");
+    body
+}
+
+#[allow(dead_code)]
+pub(crate) fn render_schtasks_cmd(cfg: &ServiceConfig) -> String {
+    let mut tr = quote_arg(&cfg.binary.display().to_string());
+    for a in &cfg.args {
+        tr.push(' ');
+        tr.push_str(&quote_arg(a));
+    }
+    format!(
+        "schtasks /Create /F /SC ONLOGON /RL HIGHEST /TN {} /TR {}",
+        quote_arg(&cfg.label),
+        quote_arg(&tr)
+    )
+}
+
+/// Default user-unit path for systemd (Linux).
+#[allow(dead_code)]
+pub(crate) fn systemd_unit_path(label: &str) -> anyhow::Result<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(|| home_dir().map(|h| h.join(".config")))?;
+    Ok(base.join("systemd/user").join(format!("{}.service", label)))
+}
+
+/// Default plist path for launchctl (macOS).
+#[allow(dead_code)]
+pub(crate) fn launchagent_plist_path(label: &str) -> anyhow::Result<PathBuf> {
+    Ok(home_dir()?
+        .join("Library/LaunchAgents")
+        .join(format!("{}.plist", label)))
+}
+
+#[allow(dead_code)]
+pub(crate) fn ensure_parent(path: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ServiceConfig {
+        ServiceConfig {
+            label: "com.ncmlabs.forge-sensei".into(),
+            binary: PathBuf::from("/usr/local/bin/forge-sensei-server"),
+            args: vec![
+                "--host".into(),
+                "127.0.0.1".into(),
+                "--port".into(),
+                "3000".into(),
+            ],
+            env: vec![("FORGE_CONFIG".into(), "/tmp/config.toml".into())],
+            working_dir: Some(PathBuf::from("/tmp/wd")),
+            stdout_log: Some(PathBuf::from("/tmp/out.log")),
+            stderr_log: Some(PathBuf::from("/tmp/err.log")),
+            keep_alive: true,
+        }
+    }
+
+    #[test]
+    fn plist_contains_label_and_args() {
+        let s = render_plist(&sample());
+        assert!(s.contains("<string>com.ncmlabs.forge-sensei</string>"));
+        assert!(s.contains("<string>/usr/local/bin/forge-sensei-server</string>"));
+        assert!(s.contains("<string>--host</string>"));
+        assert!(s.contains("<string>127.0.0.1</string>"));
+        assert!(s.contains("<key>FORGE_CONFIG</key>"));
+        assert!(s.contains("<key>WorkingDirectory</key>"));
+        assert!(s.contains("<key>StandardOutPath</key>"));
+        assert!(s.contains("<key>StandardErrorPath</key>"));
+        assert!(s.contains("<key>KeepAlive</key>\n  <true/>"));
+    }
+
+    #[test]
+    fn plist_without_optional_blocks() {
+        let mut cfg = sample();
+        cfg.env.clear();
+        cfg.working_dir = None;
+        cfg.stdout_log = None;
+        cfg.stderr_log = None;
+        cfg.keep_alive = false;
+        let s = render_plist(&cfg);
+        assert!(!s.contains("EnvironmentVariables"));
+        assert!(!s.contains("WorkingDirectory"));
+        assert!(!s.contains("StandardOutPath"));
+        assert!(s.contains("<key>KeepAlive</key>\n  <false/>"));
+    }
+
+    #[test]
+    fn unit_file_has_execstart_and_restart() {
+        let s = render_unit(&sample());
+        assert!(s.contains("[Unit]"));
+        assert!(s.contains("[Service]"));
+        assert!(
+            s.contains("ExecStart=/usr/local/bin/forge-sensei-server --host 127.0.0.1 --port 3000")
+        );
+        assert!(s.contains("Environment=\"FORGE_CONFIG=/tmp/config.toml\""));
+        assert!(s.contains("WorkingDirectory=/tmp/wd"));
+        assert!(s.contains("StandardOutput=append:/tmp/out.log"));
+        assert!(s.contains("StandardError=append:/tmp/err.log"));
+        assert!(s.contains("Restart=always"));
+        assert!(s.contains("WantedBy=default.target"));
+    }
+
+    #[test]
+    fn unit_file_no_restart_when_keepalive_false() {
+        let mut cfg = sample();
+        cfg.keep_alive = false;
+        let s = render_unit(&cfg);
+        assert!(!s.contains("Restart=always"));
+    }
+
+    #[test]
+    fn schtasks_command_quotes_args() {
+        let s = render_schtasks_cmd(&sample());
+        assert!(s.starts_with("schtasks /Create /F /SC ONLOGON /RL HIGHEST"));
+        assert!(s.contains("/TN com.ncmlabs.forge-sensei"));
+        assert!(s.contains("/usr/local/bin/forge-sensei-server"));
+    }
+
+    #[test]
+    fn xml_escape_handles_special_chars() {
+        assert_eq!(xml_escape("a<b&c>\"d'e"), "a&lt;b&amp;c&gt;&quot;d&apos;e");
+    }
+
+    #[test]
+    fn service_status_strings() {
+        assert_eq!(ServiceStatus::Running { pid: Some(42) }.as_str(), "running");
+        assert_eq!(ServiceStatus::Stopped.as_str(), "stopped");
+        assert_eq!(ServiceStatus::NotInstalled.as_str(), "not_installed");
+        assert_eq!(ServiceStatus::Unknown("x".into()).as_str(), "unknown");
+    }
+}

--- a/src/runtime/startup/windows.rs
+++ b/src/runtime/startup/windows.rs
@@ -1,0 +1,91 @@
+// Windows StartupManager via schtasks (scheduled tasks).
+
+use std::process::Command;
+
+use super::{quote_arg, ServiceConfig, ServiceStatus, StartupManager};
+
+pub(crate) struct Schtasks;
+
+impl Schtasks {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl StartupManager for Schtasks {
+    fn install(&self, cfg: &ServiceConfig) -> anyhow::Result<()> {
+        let mut tr = quote_arg(&cfg.binary.display().to_string());
+        for a in &cfg.args {
+            tr.push(' ');
+            tr.push_str(&quote_arg(a));
+        }
+        let out = Command::new("schtasks")
+            .args([
+                "/Create", "/F", "/SC", "ONLOGON", "/RL", "HIGHEST", "/TN", &cfg.label, "/TR", &tr,
+            ])
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "schtasks /Create failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    }
+
+    fn start(&self, label: &str) -> anyhow::Result<()> {
+        let out = Command::new("schtasks")
+            .args(["/Run", "/TN", label])
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "schtasks /Run failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    }
+
+    fn stop(&self, label: &str) -> anyhow::Result<()> {
+        let _ = Command::new("schtasks")
+            .args(["/End", "/TN", label])
+            .output();
+        Ok(())
+    }
+
+    fn status(&self, label: &str) -> anyhow::Result<ServiceStatus> {
+        let out = Command::new("schtasks")
+            .args(["/Query", "/TN", label, "/FO", "CSV", "/NH"])
+            .output()?;
+        if !out.status.success() {
+            return Ok(ServiceStatus::NotInstalled);
+        }
+        let text = String::from_utf8_lossy(&out.stdout);
+        for line in text.lines() {
+            let fields: Vec<&str> = line.split(',').map(|f| f.trim_matches('"')).collect();
+            if fields.len() >= 3 {
+                return Ok(match fields[2] {
+                    "Running" => ServiceStatus::Running { pid: None },
+                    "Ready" | "Queued" | "Disabled" => ServiceStatus::Stopped,
+                    other => ServiceStatus::Unknown(other.to_string()),
+                });
+            }
+        }
+        Ok(ServiceStatus::Unknown("no status row".into()))
+    }
+
+    fn uninstall(&self, label: &str) -> anyhow::Result<()> {
+        let out = Command::new("schtasks")
+            .args(["/Delete", "/F", "/TN", label])
+            .output()?;
+        if !out.status.success() {
+            // Treat "task does not exist" as success.
+            let err = String::from_utf8_lossy(&out.stderr);
+            if err.contains("cannot find") || err.contains("does not exist") {
+                return Ok(());
+            }
+            anyhow::bail!("schtasks /Delete failed: {}", err);
+        }
+        Ok(())
+    }
+}

--- a/tests/startup_manager_tests.rs
+++ b/tests/startup_manager_tests.rs
@@ -1,0 +1,77 @@
+// Integration tests for the StartupManager trait (issue #254).
+//
+// Pure-text renderer tests live in `src/runtime/startup/mod.rs` as lib unit
+// tests — those assert on the generated plist/unit/schtasks strings across
+// all host platforms. This file exercises the real OS-backed manager via
+// `startup::current()`, gated on `FORGE_SERVICE_E2E=1` so normal local
+// `cargo test` runs stay clean.
+
+use forge::runtime::startup::{self, ServiceStatus};
+
+fn e2e_enabled() -> bool {
+    std::env::var("FORGE_SERVICE_E2E").ok().as_deref() == Some("1")
+}
+
+#[test]
+fn current_manager_handles_missing_service() {
+    // Status on a label that was never installed must not panic and must
+    // return NotInstalled (preflight errors on Linux without systemd are
+    // acceptable — treat either as a pass).
+    let mgr = startup::current();
+    let label = format!("com.ncmlabs.forge-test-missing-{}", std::process::id());
+    match mgr.status(&label) {
+        Ok(ServiceStatus::NotInstalled) => {}
+        Ok(other) => panic!("expected NotInstalled, got {:?}", other),
+        Err(_) => {
+            // Acceptable on environments without a user service session.
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[test]
+fn install_status_uninstall_roundtrip() {
+    if !e2e_enabled() {
+        eprintln!("skipping E2E test (set FORGE_SERVICE_E2E=1 to enable)");
+        return;
+    }
+    use forge::runtime::startup::ServiceConfig;
+    use std::path::PathBuf;
+
+    let mgr = startup::current();
+    let label = format!("com.ncmlabs.forge-e2e-{}", std::process::id());
+
+    // Use `sleep` — present on macOS and most Linux distros.
+    let sleep_bin = if PathBuf::from("/bin/sleep").exists() {
+        PathBuf::from("/bin/sleep")
+    } else {
+        PathBuf::from("/usr/bin/sleep")
+    };
+
+    let mut cfg = ServiceConfig::new(label.clone(), sleep_bin);
+    cfg.args = vec!["30".into()];
+    cfg.keep_alive = false;
+
+    // If preflight fails (e.g. CI without systemd-user), skip rather than fail.
+    if let Err(e) = mgr.install(&cfg) {
+        eprintln!("install preflight failed, skipping: {}", e);
+        return;
+    }
+
+    // Status should not be NotInstalled after install.
+    let status = mgr.status(&label).expect("status after install");
+    assert!(
+        !matches!(status, ServiceStatus::NotInstalled),
+        "expected installed, got {:?}",
+        status,
+    );
+
+    mgr.uninstall(&label).expect("uninstall");
+
+    let final_status = mgr.status(&label).expect("status after uninstall");
+    assert_eq!(
+        final_status,
+        ServiceStatus::NotInstalled,
+        "service should be gone after uninstall",
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `src/runtime/startup` with a `StartupManager` trait and per-OS backends: **macOS** (`launchctl` + plist under `~/Library/LaunchAgents/`), **Linux/WSL** (`systemctl --user` + unit under `$XDG_CONFIG_HOME/systemd/user/`), **Windows** (`schtasks` ONLOGON task).
- Generated FORGE server binaries (`generate_server_main` in `src/build.rs`) gain `install-service` and `service {start|stop|status|uninstall}` subcommands. All `service` output is JSON so pure-FORGE clients (post #256) can parse it.
- `scripts/install-sensei-server.sh` becomes a thin wrapper around the binary's new subcommands — existing docs keep working, but Linux/WSL stop hard-failing on `launchctl`.
- Pure-text renderers (`render_plist` / `render_unit` / `render_schtasks_cmd`) live in the shared module and ship 7 unit tests that run on every host; OS-backed E2E is gated on `FORGE_SERVICE_E2E=1` and wired into CI for ubuntu + macos.
- Closes step 5 of #249.

## Test plan
- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` locally (macOS) — all green.
- [x] `FORGE_SERVICE_E2E=1 cargo test --test startup_manager_tests` on macOS — exercises real `launchctl bootstrap / print / bootout` against a sleep binary.
- [x] Built `forge-sensei-server` with the new template and verified `install-service` → `service status` → `service uninstall` roundtrip on macOS (plist written to `~/Library/LaunchAgents`, registered with launchctl, removed cleanly).
- [ ] CI: Linux E2E step (with `loginctl enable-linger` + `XDG_RUNTIME_DIR`) confirms systemd-user path, falls back to graceful skip if unavailable.

## Changelog
> Cross-platform `StartupManager` trait (`src/runtime/startup/`) with per-OS backends for launchctl (macOS), systemd user units (Linux/WSL), and schtasks (Windows). Generated FORGE server binaries now expose `install-service` / `service {start|stop|status|uninstall}` subcommands that emit JSON, replacing the macOS-only shell glue in `install-sensei-server.sh` (which is now a thin wrapper) (#254)

🤖 Generated with [Claude Code](https://claude.com/claude-code)