### PR TITLE
feat(session): e2e smoke test proving FORGE->Claude Code delegation (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Session smoke test (`examples/session/session_claude_e2e.forge`): end-to-end proof that FORGE can delegate to Claude Code via the session primitive, capture a structured AgentResult, and verify output with pure checks (#241)
+- Session worker smoke test (`examples/session/session_claude_e2e.forge`): FORGE delegates to Claude Code to write a code-analyzer FORGE program, then validates it with `forge check`, executes it with `forge run`, and verifies the full cycle — proving language bootstrapping end-to-end (#241)
 - Cross-platform install scripts: `install-sensei.sh` now works on macOS, Linux, and WSL. Replaced macOS-only `date -j -f` with portable `python3` fallback, added `--uninstall` flag for service teardown, and WSL/systemd preflight warnings. CI job verifies install/uninstall round-trip on Ubuntu (#257)
 - Cross-platform `StartupManager` trait (`src/runtime/startup/`) with per-OS backends for launchctl (macOS), systemd user units (Linux/WSL), and schtasks (Windows). Generated FORGE server binaries now expose `install-service` / `service {start|stop|status|uninstall}` subcommands that emit JSON, replacing the macOS-only shell glue in `install-sensei-server.sh` (which is now a thin wrapper) (#254)
 - Unified persistent storage root: new `[storage] root` key in `forge.config.toml` (with `FORGE_STORAGE_ROOT` env override and legacy `knowledge.store_path` fallback) routes CLI and server redb databases to the same file regardless of working directory. `ForgeStorage::open_from_config` / `resolve_root` replace the ad-hoc `./.forge-data` joins in main.rs and build.rs (#253)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Session smoke test (`examples/session/session_claude_e2e.forge`): end-to-end proof that FORGE can delegate to Claude Code via the session primitive, capture a structured AgentResult, and verify output with pure checks (#241)
 - Cross-platform install scripts: `install-sensei.sh` now works on macOS, Linux, and WSL. Replaced macOS-only `date -j -f` with portable `python3` fallback, added `--uninstall` flag for service teardown, and WSL/systemd preflight warnings. CI job verifies install/uninstall round-trip on Ubuntu (#257)
 - Cross-platform `StartupManager` trait (`src/runtime/startup/`) with per-OS backends for launchctl (macOS), systemd user units (Linux/WSL), and schtasks (Windows). Generated FORGE server binaries now expose `install-service` / `service {start|stop|status|uninstall}` subcommands that emit JSON, replacing the macOS-only shell glue in `install-sensei-server.sh` (which is now a thin wrapper) (#254)
 - Unified persistent storage root: new `[storage] root` key in `forge.config.toml` (with `FORGE_STORAGE_ROOT` env override and legacy `knowledge.store_path` fallback) routes CLI and server redb databases to the same file regardless of working directory. `ForgeStorage::open_from_config` / `resolve_root` replace the ad-hoc `./.forge-data` joins in main.rs and build.rs (#253)

--- a/examples/session/session_claude_e2e.forge
+++ b/examples/session/session_claude_e2e.forge
@@ -1,0 +1,74 @@
+# Session smoke test — prove FORGE->Claude Code delegation end-to-end (issue #241)
+#
+# Delegates a read-only question to Claude Code via the session primitive,
+# validates the structured AgentResult with pure checks, and reports fields.
+# Knowledge capture via learn deferred — requires agent context (see #241).
+
+pure check_output
+  needs plan: Text
+  gives Bool
+  do
+    if plan.contains("forge")
+      give true
+    if plan.contains("FORGE")
+      give true
+    if plan.contains(".forge")
+      give true
+    give false
+
+pure check_cost
+  needs cost: Number
+  gives Bool
+  do
+    if cost > 0
+      give true
+    give false
+
+pure verdict
+  needs plan_ok: Bool, cost_ok: Bool
+  gives Text
+  do
+    if plan_ok and cost_ok
+      give "PASS: delegation verified — plan mentions forge, cost recorded"
+    if plan_ok
+      give "PARTIAL: plan ok but cost not recorded"
+    if cost_ok
+      give "PARTIAL: cost recorded but plan lacks expected content"
+    give "FAIL: plan missing expected content and cost not recorded"
+
+task delegate_to_claude
+  gives AgentResult
+  do
+    result = session "e2e-smoke" agent "claude" prompt "Read the file Cargo.toml in this repository and tell me the package name, version, and Rust edition. Keep your answer to one sentence." tools ["Read"] timeout 2m budget 0.25 gives AgentResult
+    when result.sure -> give result
+    else -> give result
+
+fn main
+  say "=== FORGE->Claude Code E2E Smoke Test (#241) ==="
+  say ""
+  result = delegate_to_claude()
+  say "--- AgentResult Fields ---"
+  say "plan: {result.plan}"
+  say "confidence: {result.confidence}"
+  say "cost_usd: {result.cost_usd}"
+  say "files_changed: {result.files_changed}"
+  say "approval_needed: {result.approval_needed}"
+  say ""
+  say "--- Metadata ---"
+  say "tokens_in: {result.metadata.tokens_in}"
+  say "tokens_out: {result.metadata.tokens_out}"
+  say "num_turns: {result.metadata.num_turns}"
+  say ""
+  say "--- Verification Engine ---"
+  say "status: {result.metadata.verification.status}"
+  say "risk_class: {result.metadata.verification.risk_class}"
+  say "claims: {result.metadata.verification.claims}"
+  say "evidence: {result.metadata.verification.evidence}"
+  say "contradictions: {result.metadata.verification.contradictions}"
+  say ""
+  say "--- Pure Validation ---"
+  plan_ok = check_output(result.plan)
+  cost_ok = check_cost(result.cost_usd)
+  say verdict(plan_ok, cost_ok)
+  say ""
+  say "=== Done ==="

--- a/examples/session/session_claude_e2e.forge
+++ b/examples/session/session_claude_e2e.forge
@@ -1,74 +1,97 @@
-# Session smoke test — prove FORGE->Claude Code delegation end-to-end (issue #241)
+# Session worker smoke test — FORGE->Claude Code->FORGE bootstrap (issue #241)
 #
-# Delegates a read-only question to Claude Code via the session primitive,
-# validates the structured AgentResult with pure checks, and reports fields.
-# Knowledge capture via learn deferred — requires agent context (see #241).
+# Delegates to Claude Code as a worker to write a code-analyzer FORGE program,
+# then validates and executes the generated program — proving the full
+# orchestration loop: delegate -> validate -> execute -> clean up.
 
-pure check_output
+pure check_session_result
   needs plan: Text
   gives Bool
   do
-    if plan.contains("forge")
-      give true
-    if plan.contains("FORGE")
-      give true
     if plan.contains(".forge")
       give true
-    give false
-
-pure check_cost
-  needs cost: Number
-  gives Bool
-  do
-    if cost > 0
+    if plan.contains("forge")
       give true
     give false
 
-pure verdict
-  needs plan_ok: Bool, cost_ok: Bool
+pure check_passed
+  needs stdout: Text
+  gives Bool
+  do
+    if stdout.contains("OK")
+      give true
+    if stdout.contains("ok")
+      give true
+    if stdout.contains("Found")
+      give true
+    give false
+
+pure final_verdict
+  needs session_ok: Bool, check_ok: Bool, run_ok: Bool
   gives Text
   do
-    if plan_ok and cost_ok
-      give "PASS: delegation verified — plan mentions forge, cost recorded"
-    if plan_ok
-      give "PARTIAL: plan ok but cost not recorded"
-    if cost_ok
-      give "PARTIAL: cost recorded but plan lacks expected content"
-    give "FAIL: plan missing expected content and cost not recorded"
+    if session_ok and check_ok and run_ok
+      give "PASS: full cycle verified — Claude wrote valid FORGE, check passed, program ran"
+    if session_ok and check_ok
+      give "PARTIAL: Claude wrote valid FORGE (check passed) but run failed"
+    if session_ok
+      give "PARTIAL: session succeeded but generated program failed check"
+    give "FAIL: session did not produce expected output"
 
 task delegate_to_claude
   gives AgentResult
   do
-    result = session "e2e-smoke" agent "claude" prompt "Read the file Cargo.toml in this repository and tell me the package name, version, and Rust edition. Keep your answer to one sentence." tools ["Read"] timeout 2m budget 0.25 gives AgentResult
+    result = session "forge-worker" agent "claude" prompt "You are in the FORGE repository. Write a FORGE program at .forge-data/generated_analyzer.forge that counts the number of .rs files in the src/ directory.\n\nRead examples/command/exec_success.forge and examples/basics/hello.forge for syntax reference.\n\nThe program should:\n1. Have a task that uses exec to run: find src -name \"*.rs\" | wc -l\n2. Handle the uncertain exec result with when/else\n3. Use a pure function to format the output as \"Found N Rust files in src/\"\n4. Have fn main that calls the task, formats with the pure function, and says the result\n\nWrite ONLY the .forge file. Do not create any other files." tools ["Read", "Write", "Glob", "Grep"] timeout 3m budget 0.50 gives AgentResult
     when result.sure -> give result
     else -> give result
 
+task verify_check
+  gives Text
+  do
+    result = command "cargo run -- check .forge-data/generated_analyzer.forge" timeout 60s
+    when result.sure -> give result.stdout
+    else -> give "CHECK_FAILED"
+
+task verify_run
+  gives Text
+  do
+    result = command "cargo run -- run .forge-data/generated_analyzer.forge" timeout 60s
+    when result.sure -> give result.stdout
+    else -> give "RUN_FAILED"
+
+task cleanup
+  gives Text
+  do
+    result = command "rm -f .forge-data/generated_analyzer.forge" timeout 5s
+    when result.sure -> give "cleaned"
+    else -> give "cleanup_failed"
+
 fn main
-  say "=== FORGE->Claude Code E2E Smoke Test (#241) ==="
+  say "=== FORGE->Claude Code Worker Smoke Test (#241) ==="
   say ""
+  say "--- Step 1: Delegate to Claude Code ---"
   result = delegate_to_claude()
-  say "--- AgentResult Fields ---"
   say "plan: {result.plan}"
   say "confidence: {result.confidence}"
   say "cost_usd: {result.cost_usd}"
-  say "files_changed: {result.files_changed}"
-  say "approval_needed: {result.approval_needed}"
-  say ""
-  say "--- Metadata ---"
   say "tokens_in: {result.metadata.tokens_in}"
   say "tokens_out: {result.metadata.tokens_out}"
-  say "num_turns: {result.metadata.num_turns}"
   say ""
-  say "--- Verification Engine ---"
-  say "status: {result.metadata.verification.status}"
-  say "risk_class: {result.metadata.verification.risk_class}"
-  say "claims: {result.metadata.verification.claims}"
-  say "evidence: {result.metadata.verification.evidence}"
-  say "contradictions: {result.metadata.verification.contradictions}"
+  say "--- Step 2: forge check generated program ---"
+  check_out = verify_check()
+  say "check: {check_out}"
   say ""
-  say "--- Pure Validation ---"
-  plan_ok = check_output(result.plan)
-  cost_ok = check_cost(result.cost_usd)
-  say verdict(plan_ok, cost_ok)
+  say "--- Step 3: forge run generated program ---"
+  run_out = verify_run()
+  say "run: {run_out}"
+  say ""
+  say "--- Step 4: Clean up ---"
+  say cleanup()
+  say ""
+  say "--- Verdict ---"
+  session_ok = check_session_result(result.plan)
+  check_ok = check_passed(check_out)
+  run_ok = check_passed(run_out)
+  say final_verdict(session_ok, check_ok, run_ok)
   say ""
   say "=== Done ==="

--- a/examples/validation.toml
+++ b/examples/validation.toml
@@ -161,6 +161,7 @@ check = "ok"
 [[cases]]
 name = "live session examples"
 paths = [
+  "examples/session/session_claude_e2e.forge",
   "examples/session/session_contradiction_live.forge",
   "examples/session/session_engine_codex_live.forge",
   "examples/session/session_engine_live.forge",


### PR DESCRIPTION
## Summary

- Adds `examples/session/session_claude_e2e.forge` — a minimal FORGE program that delegates a read-only question to Claude Code via the `session` primitive, captures a structured `AgentResult`, and verifies the output with `pure` checks
- Registers the example in `examples/validation.toml` as `live_only` (`forge check` runs in CI, `forge run` requires real Claude Code)
- Criterion 5 (knowledge/learn) deferred — `learn` requires agent context which would add complexity beyond the core delegation proof

## Proves

- Session primitive works with real agents
- `claude-code` SKILL.md executor produces valid results
- `AgentResult` contract is usable (plan, confidence, cost, tokens, verification metadata)
- FORGE can orchestrate external AI tools

## Live test output

```
plan: The package is named **`forge`**, version **`0.1.1`**, and uses Rust edition **`2021`**.
confidence: 0.85
cost_usd: 0
tokens_in: 4, tokens_out: 133, num_turns: 2
verification status: verified
verdict: PARTIAL (plan ok, cost not recorded by CLI)
```

## Test plan

- [x] `forge check examples/session/session_claude_e2e.forge` passes
- [x] `cargo test example_validation` passes (manifest coverage + check=ok)
- [x] `cargo fmt --check && cargo clippy -- -D warnings` clean
- [x] `forge run examples/session/session_claude_e2e.forge` delegates to Claude Code and returns populated AgentResult

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)