### PR TITLE
feat(orchestration): inbound triager agent (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Inbound Triager agent (`examples/agents/inbound-triager/`): subscribes to SlackMention, IssueCreated, and PRReviewNeeded events, classifies each via LLM into route/escalate decisions, emits TriageRouted events for downstream ProjectAgents, and escalates to humans via Slack. Includes persistent memory, knowledge store for learning routing patterns, warden supervision, and live Slack integration (#181)
 - Session worker smoke test (`examples/session/session_claude_e2e.forge`): FORGE delegates to Claude Code to write a code-analyzer FORGE program, then validates it with `forge check`, executes it with `forge run`, and verifies the full cycle — proving language bootstrapping end-to-end (#241)
 - Cross-platform install scripts: `install-sensei.sh` now works on macOS, Linux, and WSL. Replaced macOS-only `date -j -f` with portable `python3` fallback, added `--uninstall` flag for service teardown, and WSL/systemd preflight warnings. CI job verifies install/uninstall round-trip on Ubuntu (#257)
 - Cross-platform `StartupManager` trait (`src/runtime/startup/`) with per-OS backends for launchctl (macOS), systemd user units (Linux/WSL), and schtasks (Windows). Generated FORGE server binaries now expose `install-service` / `service {start|stop|status|uninstall}` subcommands that emit JSON, replacing the macOS-only shell glue in `install-sensei-server.sh` (which is now a thin wrapper) (#254)

--- a/examples/agents/inbound-triager/forge.project.toml
+++ b/examples/agents/inbound-triager/forge.project.toml
@@ -1,0 +1,11 @@
+[project]
+name = "inbound-triager"
+version = "0.1.0"
+description = "Inbound triage agent — classifies, routes, or escalates SlackMention, IssueCreated, and PRReviewNeeded events"
+
+[build]
+entry = "main.forge"
+
+[skills]
+slack = { path = "../../../skills/slack" }
+github = { path = "../../../skills/github" }

--- a/examples/agents/inbound-triager/main.forge
+++ b/examples/agents/inbound-triager/main.forge
@@ -1,0 +1,293 @@
+# ================================================================
+# Inbound Triager — classify, route, or escalate
+# ================================================================
+# Subscribes to SlackMention, IssueCreated, and PRReviewNeeded
+# events. For each inbound item: classify whether it can be
+# handled autonomously, route to the appropriate ProjectAgent,
+# or escalate to a human via Slack.
+#
+# Part of the orchestration pipeline (P2.M9):
+#   Monitors → Triager → ProjectAgents → Executors
+#
+# Prerequisites:
+#   - SLACK_BOT_TOKEN env var set (xoxb-...)
+#   - Bot invited to the notification channel
+#   - LLM provider configured (for classification)
+#
+# Usage:
+#   forge run --manifest examples/agents/inbound-triager/forge.project.toml
+#
+# Issue: #181 (Inbound Triager agent)
+# ================================================================
+
+use
+  llm.reason
+  llm.classify
+  skill.slack
+  skill.github
+
+# ── Inbound Events ─────────────────────────────────────────────
+# Re-declared here; in production these come from monitor agents.
+
+event SlackMention
+  channel: Text
+  user: Text
+  message: Text
+  thread_ts: Text
+  timestamp: Text
+  urgency: Text
+
+event IssueCreated
+  repo: Text
+  issue_number: Text
+  title: Text
+  body: Text
+  labels: Text
+  author: Text
+
+event PRReviewNeeded
+  repo: Text
+  pr_number: Text
+  title: Text
+  body: Text
+  author: Text
+  reviewers: Text
+
+# ── Outbound Events ────────────────────────────────────────────
+# Downstream ProjectAgents subscribe with:
+#   subscribe TriageRouted where project == memory.project
+
+event TriageRouted
+  project: Text
+  action: Text
+  source: Text
+  summary: Text
+  context: Text
+
+event TriageEscalated
+  cause: Text
+  source: Text
+  summary: Text
+  context: Text
+  channel: Text
+
+event TriageCompleted
+  source: Text
+  decision: Text
+  project: Text
+
+# ── Tasks ───────────────────────────────────────────────────────
+
+task detect_project
+  needs summary: Text, context: Text
+  gives Text
+  do
+    result = classify "Which project does this belong to?\n\nSummary: {summary}\nContext: {context}" into ["forge", "wiki", "unknown"]
+    when result.sure -> give result
+    when result.unsure -> give "unknown"
+    else -> give "unknown"
+
+task classify_action
+  needs summary: Text, context: Text
+  gives Text
+  do
+    result = classify "Can this request be handled automatically by a coding agent, or does it need human input?\n\nRequest: {summary}\nContext: {context}" into ["auto_route", "needs_context", "needs_human"]
+    when result.sure -> give result
+    when result.unsure -> give "needs_context"
+    else -> give "needs_human"
+
+task determine_action
+  needs source: Text, summary: Text
+  gives Text
+  do
+    result = classify "What action should a project agent take?\n\nSource: {source}\nRequest: {summary}" into ["implement_issue", "review_pr", "answer_question", "investigate"]
+    when result.sure -> give result
+    when result.unsure -> give "investigate"
+    else -> give "investigate"
+
+task build_escalation_context
+  needs source: Text, summary: Text, context: Text
+  gives Text
+  do
+    result = reason "Summarize this for a human engineer in 2-3 sentences.\nSource: {source}\nSummary: {summary}\nContext: {context}"
+    when result.sure -> give result
+    when result.unsure -> give "Source: {source} — {summary}"
+    else -> give "Triage item needs review. Source: {source}"
+
+# ── Agent ───────────────────────────────────────────────────────
+
+agent inbound_triager
+  memory persistent
+    items_triaged: Number
+    items_routed: Number
+    items_escalated: Number
+    last_source: Text
+    last_decision: Text
+    notify_channel: Text
+  knowledge store: ".forge-knowledge/triager"
+    max_entries: 5000
+    retention: 90d
+  subscribe SlackMention
+  subscribe IssueCreated
+  subscribe PRReviewNeeded
+
+  on start
+    memory.items_triaged = 0
+    memory.items_routed = 0
+    memory.items_escalated = 0
+    memory.last_source = "none"
+    memory.last_decision = "none"
+    memory.notify_channel = "C0AS3AQRNN9"
+    say "Inbound Triager active. Listening for SlackMention, IssueCreated, PRReviewNeeded."
+
+  on SlackMention(channel: Text, user: Text, message: Text, thread_ts: Text, timestamp: Text, urgency: Text)
+    memory.items_triaged = memory.items_triaged + 1
+    memory.last_source = "slack"
+    prior = recall "slack triage {message}"
+    project = detect_project(message, "Slack mention from {user}, urgency: {urgency}")
+    handleability = classify_action(message, "Slack mention, urgency: {urgency}")
+    memory.last_decision = handleability
+    if handleability == "auto_route" and project != "unknown"
+      action = determine_action("slack", message)
+      emit TriageRouted(project: project, action: action, source: "slack", summary: message, context: "channel: {channel}, user: {user}")
+      learn "routed slack mention to {project}/{action}: {message}" category: "routing"
+      memory.items_routed = memory.items_routed + 1
+      say "Routed: slack/{project}/{action} — {message}"
+    if handleability == "needs_context"
+      esc_context = build_escalation_context("slack", message, "User: {user}, Channel: {channel}")
+      notification = skill.slack.send_message(channel, "Triage: not confident about this request. Context:\n{esc_context}\nPlease advise.")
+      when notification.sure -> say "Escalation sent to channel"
+      else -> say "Escalation notification failed"
+      emit TriageEscalated(cause: "low confidence", source: "slack", summary: message, context: esc_context, channel: channel)
+      learn "escalated slack mention (needs context): {message}" category: "escalation"
+      memory.items_escalated = memory.items_escalated + 1
+    if handleability == "needs_human"
+      esc_context = build_escalation_context("slack", message, "User: {user}, Channel: {channel}")
+      notification = skill.slack.send_message(channel, "This request needs human attention:\n{esc_context}")
+      when notification.sure -> say "Human notified"
+      else -> say "Human notification failed"
+      emit TriageEscalated(cause: "needs human", source: "slack", summary: message, context: esc_context, channel: channel)
+      learn "escalated slack mention (needs human): {message}" category: "escalation"
+      memory.items_escalated = memory.items_escalated + 1
+    emit TriageCompleted(source: "slack", decision: handleability, project: project)
+
+  on IssueCreated(repo: Text, issue_number: Text, title: Text, body: Text, labels: Text, author: Text)
+    memory.items_triaged = memory.items_triaged + 1
+    memory.last_source = "github_issue"
+    prior = recall "issue triage {title}"
+    project = detect_project(title, "Repo: {repo}, Labels: {labels}")
+    handleability = classify_action(title, body)
+    memory.last_decision = handleability
+    if handleability == "auto_route" and project != "unknown"
+      action = determine_action("issue", title)
+      emit TriageRouted(project: project, action: action, source: "github_issue", summary: title, context: "repo: {repo}, issue: {issue_number}, labels: {labels}")
+      learn "routed issue to {project}/{action}: {title}" category: "routing"
+      memory.items_routed = memory.items_routed + 1
+      say "Routed: issue/{project}/{action} — {title}"
+    if handleability == "needs_context" or handleability == "needs_human" or project == "unknown"
+      esc_context = build_escalation_context("github_issue", title, body)
+      notification = skill.slack.send_message(memory.notify_channel, "Issue needs attention: {repo}#{issue_number} — {title}\n{esc_context}")
+      when notification.sure -> say "Escalation sent for issue #{issue_number}"
+      else -> say "Escalation notification failed"
+      emit TriageEscalated(cause: handleability, source: "github_issue", summary: title, context: esc_context, channel: memory.notify_channel)
+      learn "escalated issue ({handleability}): {title}" category: "escalation"
+      memory.items_escalated = memory.items_escalated + 1
+    emit TriageCompleted(source: "github_issue", decision: handleability, project: project)
+
+  on PRReviewNeeded(repo: Text, pr_number: Text, title: Text, body: Text, author: Text, reviewers: Text)
+    memory.items_triaged = memory.items_triaged + 1
+    memory.last_source = "github_pr"
+    prior = recall "pr triage {title}"
+    project = detect_project(title, "Repo: {repo}")
+    handleability = classify_action(title, body)
+    memory.last_decision = handleability
+    if handleability == "auto_route" and project != "unknown"
+      emit TriageRouted(project: project, action: "review_pr", source: "github_pr", summary: title, context: "repo: {repo}, pr: {pr_number}, author: {author}")
+      learn "routed PR review to {project}: {title}" category: "routing"
+      memory.items_routed = memory.items_routed + 1
+      say "Routed: pr/{project}/review_pr — {title}"
+    if handleability == "needs_context" or handleability == "needs_human" or project == "unknown"
+      esc_context = build_escalation_context("github_pr", title, body)
+      notification = skill.slack.send_message(memory.notify_channel, "PR needs attention: {repo}#{pr_number} — {title}\n{esc_context}")
+      when notification.sure -> say "Escalation sent for PR #{pr_number}"
+      else -> say "Escalation notification failed"
+      emit TriageEscalated(cause: handleability, source: "github_pr", summary: title, context: esc_context, channel: memory.notify_channel)
+      learn "escalated PR ({handleability}): {title}" category: "escalation"
+      memory.items_escalated = memory.items_escalated + 1
+    emit TriageCompleted(source: "github_pr", decision: handleability, project: project)
+
+  on status
+    give "Triaged: {memory.items_triaged}, Routed: {memory.items_routed}, Escalated: {memory.items_escalated}, Last: {memory.last_source}/{memory.last_decision}"
+
+  if stuck for 3 turns
+    say "Triager stuck. Escalating."
+    escalate to human
+
+# ── Warden ──────────────────────────────────────────────────────
+
+warden triage_warden
+  manages [inbound_triager]
+  on stuck: nudge, self
+    after 3: escalate
+  on timeout: restart, self
+  on crash: restart, self
+  on hallucination: nudge, self
+    after 2: escalate
+  on contradiction: nudge, self
+    after 2: escalate
+  on budget: nudge, self
+    after 1: escalate
+  max_retries 3 per 1h then escalate
+
+# ── System ──────────────────────────────────────────────────────
+
+system triage_system
+  use
+    triager: inbound_triager
+
+# ── Entry Point ─────────────────────────────────────────────────
+
+task triage_live_test
+  needs ch: Text
+  gives Text
+  do
+    say "--- Live triage: simulating SlackMention ---"
+    test_message = "Hey @forge-bot, the parser crashes when I nest task calls inside a flow stage. Can you look into this?"
+    project = detect_project(test_message, "Slack mention from U12345, urgency: unknown")
+    say "  Project: {project}"
+    handleability = classify_action(test_message, "Slack mention, urgency: unknown")
+    say "  Handleability: {handleability}"
+    if handleability == "auto_route" and project != "unknown"
+      action = determine_action("slack", test_message)
+      say "  Action: {action}"
+      result = skill.slack.send_message(ch, "Triage result: routed to {project}/{action}\nMessage: {test_message}")
+      when result.sure -> say "  Slack notification sent (routed)"
+      else -> say "  Slack notification failed"
+      give "PASS: routed to {project}/{action}"
+    esc = build_escalation_context("slack", test_message, "User: U12345")
+    result = skill.slack.send_message(ch, "Triage escalation ({handleability}):\n{esc}")
+    when result.sure -> say "  Slack escalation sent"
+    else -> say "  Slack escalation failed"
+    give "PASS: escalated ({handleability}) — project={project}"
+
+fn main
+  say "=== Inbound Triager Agent ==="
+  say "Subscribes to: SlackMention, IssueCreated, PRReviewNeeded"
+  say ""
+  say "Testing classification tasks with sample data..."
+  say ""
+  project = detect_project("Fix parser error in task declarations", "repo: ncmlabs/forge, labels: bug")
+  say "Detected project: {project}"
+  handleability = classify_action("Fix parser error in task declarations", "The parser crashes on nested task calls")
+  say "Handleability: {handleability}"
+  action = determine_action("issue", "Fix parser error in task declarations")
+  say "Action: {action}"
+  context = build_escalation_context("github_issue", "Need production access", "User requests SSH keys to prod servers")
+  say "Escalation context: {context}"
+  say ""
+  say "=== Classification tests complete ==="
+  say ""
+  say "--- Live Slack integration test ---"
+  verdict = triage_live_test("C0AS3AQRNN9")
+  say "Verdict: {verdict}"
+  say "=== All tests complete ==="

--- a/examples/validation.toml
+++ b/examples/validation.toml
@@ -27,6 +27,14 @@ check = "ok"
 manifest = "examples/agents/slack-responder/forge.project.toml"
 
 [[cases]]
+name = "inbound triager agent"
+paths = [
+  "examples/agents/inbound-triager/main.forge",
+]
+check = "ok"
+manifest = "examples/agents/inbound-triager/forge.project.toml"
+
+[[cases]]
 name = "mock-runnable quiz tutor agent"
 paths = ["examples/agents/quiz_tutor.forge"]
 check = "ok"

--- a/roadmap.md
+++ b/roadmap.md
@@ -78,7 +78,7 @@ Everything in this document exists to reach that moment.
 | P2.M6 — Sandbox | `sandbox` isolation: spawn modifier + worktree | #194 ✅ | Done |
 | P2.M7 — Skills Foundation | Pluggable skill architecture, capability types, CLI delegation research, deterministic execution | #163 ✅ #164 ✅ #165 ✅ #237 ✅ | Done |
 | P2.M8 — CLI Skills | GitHub, Slack, Claude Code, Codex/Ollama SKILL.md files | #176 ✅ #177 ✅ #178 ✅ #179 ✅ | Done |
-| P2.M9 — Orchestration | Slack Monitor, Inbound Triager, approval gate | #180 ✅, #181, #182 | In Progress |
+| P2.M9 — Orchestration | Slack Monitor, Inbound Triager, approval gate | #180 ✅, #181 ✅, #182 | In Progress |
 | P2.M10 — Dev System | ProjectAgent, Executor, FORGE + forge-wiki two-project proof | #183-#185 | Frozen |
 | P2.M11 — Knowledge School | forge-sensei curriculum + toolkit knowledge transfer + operational readiness | #166 ✅, #167 ✅, #240, #249 ✅, #256 ✅, #257 ✅ | Near Done |
 | P2.M12 — Toolkit Agents | Generator contract, Task/Flow/Agent/System generators, Repair, Test, SpecAnalyzer | #168, #169-#175 (frozen) | Frozen (except #168) |
@@ -710,7 +710,7 @@ Worktree isolation for safe agent execution:
 | Issue | Title | Status |
 |-------|-------|--------|
 | #180 | Slack Monitor agent — poll channels, detect mentions | Done ✅ |
-| #181 | Inbound Triager agent — classify, route, or escalate | Open |
+| #181 | Inbound Triager agent — classify, route, or escalate | Done ✅ |
 | #182 | Approval gate pattern — events + Slack + webhook | Open |
 
 ### P2.M10: Dev Orchestration System
@@ -786,7 +786,7 @@ Done:
 - `P2.M8` CLI Skills ✅
 
 Now:
-- `P2.M9` Orchestration — Triager (#181), Approval gate (#182)
+- `P2.M9` Orchestration — Approval gate (#182)
 - `P2.M11` Knowledge School — operational readiness (#240)
 
 Blocked next by:
@@ -955,7 +955,7 @@ P2.M5  Verify+Contra   ███████████████████
 P2.M6  Sandbox         ████████████████████  1/1  (100%)  DONE
 P2.M7  Skills          ████████████████████  4/4  (100%)  DONE
 P2.M8  CLI Skills      ████████████████████  4/4  (100%)  DONE
-P2.M9  Orchestration   ██████░░░░░░░░░░░░░░  1/3  ( 33%)  IN PROGRESS
+P2.M9  Orchestration   █████████████░░░░░░░  2/3  ( 67%)  IN PROGRESS
 P2.M10 Dev System      ░░░░░░░░░░░░░░░░░░░░  0/3  (  0%)  FROZEN
 P2.M11 Knowledge       ████████████████░░░░  5/6  ( 83%)  NEAR DONE — #240 remaining
 P2.M12 Toolkit         ░░░░░░░░░░░░░░░░░░░░  0/8  (  0%)  FROZEN


### PR DESCRIPTION
## Summary
- Adds the **Inbound Triager** agent that subscribes to `SlackMention`, `IssueCreated`, and `PRReviewNeeded` events
- Classifies each inbound item via LLM (`classify`/`reason`) into route, escalate-with-context, or escalate-to-human
- Routes confident items to downstream ProjectAgents via `TriageRouted` event; escalates uncertain items to humans via Slack `send_message`
- Persistent memory tracks triage statistics; knowledge store learns routing patterns over time
- Completes 2/3 of P2.M9 (Orchestration), leaving only #182 (Approval gate)

## What's included
- `examples/agents/inbound-triager/main.forge` — 280-line triager: 6 events, 5 tasks, 1 agent, warden, system, live test entry point
- `examples/agents/inbound-triager/forge.project.toml` — project manifest with Slack + GitHub skills
- `examples/validation.toml` — new validation case (`check = "ok"` with manifest)
- `CHANGELOG.md` + `roadmap.md` updates

## Verification
- `cargo test` — full suite passes (0 failures)
- `cargo test --test example_validation_tests` — 2/2 pass (coverage + validation)
- `forge run` with mock — all 4 classification tasks execute
- `forge run` with claude-haiku — correct project detection ("forge"), action classification ("implement_issue"), and escalation context generation
- **Live Slack integration** — escalation message delivered to Slack channel C0AS3AQRNN9, confirmed via Slack API

## Test plan
- [x] `cargo test --test example_validation_tests` passes
- [x] `cargo test` full suite — 0 failures
- [x] `forge run` with `FORGE_MOCK=1` exercises classification tasks
- [x] Live LLM classification produces correct results
- [x] Live Slack notification delivered and confirmed

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)