### PR TITLE
fix(tests): close #288 — real-LLM tests require explicit FORGE_LLM_LIVE=1 opt-in

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,23 @@ cargo test
 - Run the full test suite with `cargo test`
 - Conformance tests live in `conformance/` and validate language semantics
 
+**Opt-in test suites.** A bare `cargo test` must never touch the network or
+paid APIs, even if credentials are set in your shell. Slow or external-system
+tests are gated behind explicit opt-in env vars:
+
+- `FORGE_LLM_LIVE=1` — run real-LLM tests against Anthropic (requires
+  `ANTHROPIC_API_KEY`). Covers `sensei_live_*` and `wiki_real_*`.
+  ```bash
+  FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test --test sensei_live_tests -- --nocapture
+  FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test wiki_real_
+  ```
+- `FORGE_SERVICE_E2E=1` — run the launchctl/systemd startup-manager E2E tests
+  on macOS/Linux.
+
+Use these only when locally verifying a feature end-to-end. Default CI does
+not set them, and you should not either unless you are intentionally
+exercising that surface.
+
 ## Pull Request Guidelines
 
 - Keep PRs focused on a single change

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ forge build examples/basics/hello.forge -o bin/hello
 
 # Run all tests (no API calls — uses mock provider)
 cargo test
+
+# Run real-LLM tests locally to verify end-to-end (opt-in — issue #288)
+FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test --test sensei_live_tests
 ```
 
 ---

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -62,7 +62,10 @@ export default defineConfig({
       reuseExistingServer: true,
       timeout: 120_000,
       env: {
-        ...(process.env.ANTHROPIC_API_KEY
+        // Real-LLM opt-in (#288): only forward the API key when the developer
+        // has explicitly set FORGE_LLM_LIVE=1. Otherwise force mock mode even
+        // if the key is present in the parent env.
+        ...(process.env.FORGE_LLM_LIVE === '1' && process.env.ANTHROPIC_API_KEY
           ? { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY }
           : { FORGE_MOCK: '1' }),
       },
@@ -74,7 +77,10 @@ export default defineConfig({
       reuseExistingServer: true,
       timeout: 120_000,
       env: {
-        ...(process.env.ANTHROPIC_API_KEY
+        // Real-LLM opt-in (#288): only forward the API key when the developer
+        // has explicitly set FORGE_LLM_LIVE=1. Otherwise force mock mode even
+        // if the key is present in the parent env.
+        ...(process.env.FORGE_LLM_LIVE === '1' && process.env.ANTHROPIC_API_KEY
           ? { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY }
           : { FORGE_MOCK: '1' }),
       },

--- a/tests/e2e/specs/sentinel-topology-real.spec.ts
+++ b/tests/e2e/specs/sentinel-topology-real.spec.ts
@@ -5,8 +5,14 @@ import { TopologyPage } from '../pages/sentinel.page';
 // They verify the full live topology experience: scan triggers LLM calls,
 // SSE events stream in real-time, nodes pulse, edges animate, and detail
 // panels populate with real agent data.
+// Explicit opt-in only (#288): both FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY
+// must be set — otherwise the tests skip cleanly so a default run never
+// makes paid calls.
 test.beforeEach(async () => {
-  test.skip(!process.env.ANTHROPIC_API_KEY, 'requires ANTHROPIC_API_KEY');
+  test.skip(
+    process.env.FORGE_LLM_LIVE !== '1' || !process.env.ANTHROPIC_API_KEY,
+    'requires FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY'
+  );
 });
 
 test.describe('Sentinel Topology — Real LLM Live Graph (issue #141)', () => {

--- a/tests/e2e/specs/warden-real.spec.ts
+++ b/tests/e2e/specs/warden-real.spec.ts
@@ -4,9 +4,14 @@ import { DocsPage } from '../pages/docs.page';
 import { AdminPage } from '../pages/admin.page';
 
 // These tests require a real ANTHROPIC_API_KEY and hit the actual Claude API.
-// They are skipped when the key is not set.
+// Explicit opt-in only (#288): both FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY
+// must be set — otherwise the tests skip cleanly so a default run never
+// makes paid calls.
 test.beforeEach(async () => {
-  test.skip(!process.env.ANTHROPIC_API_KEY, 'requires ANTHROPIC_API_KEY');
+  test.skip(
+    process.env.FORGE_LLM_LIVE !== '1' || !process.env.ANTHROPIC_API_KEY,
+    'requires FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY'
+  );
 });
 
 test.describe('Warden Supervision — Real API (issue #64)', () => {

--- a/tests/sensei_live_tests.rs
+++ b/tests/sensei_live_tests.rs
@@ -1,7 +1,10 @@
 // FORGE sensei end-to-end acceptance tests — epic #249
-// Mock tests run always; real-LLM tests gated on ANTHROPIC_API_KEY.
+// Mock tests run always; real-LLM tests require explicit opt-in (#288) via
+// FORGE_LLM_LIVE=1 AND ANTHROPIC_API_KEY. Having only the API key in the
+// environment is intentionally NOT enough — a bare `cargo test` must never
+// make paid API calls.
 // Run mock tests:  cargo test --test sensei_live_tests
-// Run live tests:  ANTHROPIC_API_KEY=sk-... cargo test --test sensei_live_tests -- --nocapture
+// Run live tests:  FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test --test sensei_live_tests -- --nocapture
 
 use std::path::Path;
 use std::sync::Arc;
@@ -24,6 +27,12 @@ fn mock_registry() -> Arc<ProviderRegistry> {
 }
 
 fn haiku_registry() -> Option<Arc<ProviderRegistry>> {
+    // Real-LLM opt-in (#288): both FORGE_LLM_LIVE=1 and a non-empty API key
+    // are required. Having just the key (common on dev laptops) must not
+    // trigger paid calls during a default `cargo test` run.
+    if std::env::var("FORGE_LLM_LIVE").ok().as_deref() != Some("1") {
+        return None;
+    }
     let api_key = std::env::var("ANTHROPIC_API_KEY").ok()?;
     if api_key.is_empty() {
         return None;
@@ -223,14 +232,14 @@ async fn spawn_sensei_server_with_sse() -> (String, tempfile::TempDir) {
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// 3a. Real LLM endpoint tests (gated on ANTHROPIC_API_KEY)
-// Run with: ANTHROPIC_API_KEY=sk-... cargo test --test sensei_live_tests sensei_live_
+// 3a. Real LLM endpoint tests (explicit opt-in — #288)
+// Run with: FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test --test sensei_live_tests sensei_live_
 // ═══════════════════════════════════════════════════════════════════
 
 #[tokio::test]
 async fn sensei_live_ask_returns_intelligent_answer() {
     let Some((base, _tmp)) = spawn_sensei_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 
@@ -257,7 +266,7 @@ async fn sensei_live_ask_returns_intelligent_answer() {
 #[tokio::test]
 async fn sensei_live_review_returns_feedback() {
     let Some((base, _tmp)) = spawn_sensei_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 
@@ -286,7 +295,7 @@ async fn sensei_live_review_returns_feedback() {
 #[tokio::test]
 async fn sensei_live_assess_detailed_classifies_and_predicts() {
     let Some((base, _tmp)) = spawn_sensei_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 
@@ -324,7 +333,7 @@ async fn sensei_live_assess_detailed_classifies_and_predicts() {
 #[tokio::test]
 async fn sensei_live_self_assess_completes() {
     let Some((base, _tmp)) = spawn_sensei_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 
@@ -350,7 +359,7 @@ async fn sensei_live_self_assess_completes() {
 #[tokio::test]
 async fn sensei_live_ingest_then_ask_roundtrip() {
     let Some((base, _tmp)) = spawn_sensei_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 
@@ -391,7 +400,7 @@ async fn sensei_live_ingest_then_ask_roundtrip() {
 #[tokio::test]
 async fn sensei_live_learn_from_session() {
     let Some((base, _tmp)) = spawn_sensei_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 

--- a/tests/wiki_acceptance_tests.rs
+++ b/tests/wiki_acceptance_tests.rs
@@ -1,7 +1,8 @@
 // FORGE wiki end-to-end acceptance tests — issue #65
 // Comprehensive test suite for the wiki example using mock provider.
 // Zero API calls for mock tests: FORGE_MOCK=1 cargo test wiki_
-// Real-API tests gated on ANTHROPIC_API_KEY: cargo test wiki_real_
+// Real-API tests require explicit opt-in (#288):
+//   FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test wiki_real_
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -1778,12 +1779,20 @@ async fn wiki_qa_else_branch() {
 }
 
 // ═══════════════════════════════════════════════════════════════════
-// Real-LLM Tests (gated on ANTHROPIC_API_KEY)
+// Real-LLM Tests (require explicit opt-in — #288)
 // Uses claude-haiku-4-5-20251001 for speed.
-// Run with: ANTHROPIC_API_KEY=sk-... cargo test wiki_real_
+// Requires BOTH FORGE_LLM_LIVE=1 AND ANTHROPIC_API_KEY; a bare `cargo test`
+// (even with the API key in the environment) must never make paid calls.
+// Run with: FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test wiki_real_
 // ═══════════════════════════════════════════════════════════════════
 
 fn haiku_registry() -> Option<Arc<ProviderRegistry>> {
+    // Real-LLM opt-in (#288): both FORGE_LLM_LIVE=1 and a non-empty API key
+    // are required. Having just the key (common on dev laptops) must not
+    // trigger paid calls during a default `cargo test` run.
+    if std::env::var("FORGE_LLM_LIVE").ok().as_deref() != Some("1") {
+        return None;
+    }
     let api_key = std::env::var("ANTHROPIC_API_KEY").ok()?;
     if api_key.is_empty() {
         return None;
@@ -1844,7 +1853,7 @@ async fn spawn_wiki_server_real() -> Option<(String, tempfile::TempDir)> {
 #[tokio::test]
 async fn wiki_real_search_returns_results() {
     let Some((base, _tmp)) = spawn_wiki_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 
@@ -1865,7 +1874,7 @@ async fn wiki_real_search_returns_results() {
 #[tokio::test]
 async fn wiki_real_qa_answers_question() {
     let Some((base, _tmp)) = spawn_wiki_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 
@@ -1889,7 +1898,7 @@ async fn wiki_real_qa_answers_question() {
 #[tokio::test]
 async fn wiki_real_fact_check() {
     let Some((base, _tmp)) = spawn_wiki_server_real().await else {
-        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        eprintln!("SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run");
         return;
     };
 


### PR DESCRIPTION
Closes #288.

## Summary

`cargo test` with no filter currently hits the real Anthropic API whenever `ANTHROPIC_API_KEY` is set in the environment. On a dev laptop where the key is part of the normal shell env, a bare `cargo test` silently makes paid Haiku calls and drags the suite to 20+ minutes.

This PR flips the gate from **implicit opt-out** to **explicit opt-in**. Both `FORGE_LLM_LIVE=1` AND a non-empty `ANTHROPIC_API_KEY` are now required for any test to hit a real provider. Either missing → skip with an actionable message. Mirrors the existing `FORGE_SERVICE_E2E=1` pattern in `startup_manager_tests.rs`.

This is Option 2 from the issue — smallest change, no cargo-feature plumbing, no MockProvider refactor.

## Scope

- \`tests/sensei_live_tests.rs\` — \`haiku_registry()\` gate + 6 \`sensei_live_*\` skip messages + header comment
- \`tests/wiki_acceptance_tests.rs\` — \`haiku_registry()\` gate + 3 \`wiki_real_*\` skip messages + header comment
- \`tests/e2e/playwright.config.ts\` — wiki + sentinel webServers force \`FORGE_MOCK=1\` unless \`FORGE_LLM_LIVE=1\` (even with the key present)
- \`tests/e2e/specs/warden-real.spec.ts\`, \`sentinel-topology-real.spec.ts\` — per-test skip gate aligned
- \`CONTRIBUTING.md\` + \`README.md\` — document the opt-in env var

**No changes** to \`.github/workflows/ci.yml\` — PR CI never sets \`ANTHROPIC_API_KEY\`, so it stays real-LLM-free automatically once the gate is flipped.

## Local opt-in (the new invocation)

\`\`\`bash
FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test --test sensei_live_tests -- --nocapture
FORGE_LLM_LIVE=1 ANTHROPIC_API_KEY=sk-... cargo test wiki_real_
\`\`\`

## Test plan

- [x] \`unset ANTHROPIC_API_KEY; cargo test --test sensei_live_tests --test wiki_acceptance_tests\` → 52 pass, 0 fail, ~2.5s
- [x] \`ANTHROPIC_API_KEY=sk-fake cargo test --test sensei_live_tests --test wiki_acceptance_tests\` → 52 pass, 0 fail, ~2.5s (identical)
- [x] All 9 \`sensei_live_*\` / \`wiki_real_*\` tests skip with the new message \`SKIP: set FORGE_LLM_LIVE=1 and ANTHROPIC_API_KEY to run\`
- [x] No fake key leaked to stdout/stderr (grep \`sk-fake-leaktest\` in \`--nocapture\` output → 0 hits)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] CI green on PR

## Follow-ups (separate issues, not in scope here)

- Smarter \`MockProvider\` with scripted responses so the 9 live tests also have deterministic mock coverage (Option 3 from #288)
- Optional: nightly GitHub Actions job that sets \`FORGE_LLM_LIVE=1\` + a repo-secret key for continuous live coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)