### PR TITLE
fix(checker): cross-file lifecycle references in multi-source serve

### DIFF
--- a/src/checker/spawn_checker.rs
+++ b/src/checker/spawn_checker.rs
@@ -70,14 +70,9 @@ fn check_stmt(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     match &stmt.node {
-        Stmt::Retire(r) => {
-            // Warn if retire with knowledge export is used outside an agent
-            // (knowledge export requires a knowledge store, which only agents have).
-            if r.knowledge_export.is_some() {
-                // This is a best-effort check — at the checker level we can't
-                // always determine context, so we just warn.
-                // The runtime will produce a proper error if no knowledge store.
-            }
+        Stmt::Retire(_) => {
+            // Retire with knowledge export: the runtime will produce a proper
+            // error if no knowledge store — nothing to check statically.
         }
         Stmt::Spawn(s) => {
             let template_name = &s.template.node;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1063,6 +1063,7 @@ fn try_build_executor_multi(
         .unwrap_or_default();
     diagnostics.extend(forge::checker::check_all(&composed.program, &merged_fname));
 
+    // Render all diagnostics, but only fail on errors (not warnings)
     if !diagnostics.is_empty() {
         for diag in &diagnostics {
             if let Some(sf) = source_files.iter().find(|sf| sf.path == diag.file) {
@@ -1071,7 +1072,13 @@ fn try_build_executor_multi(
                 diag.render(&sf.source);
             }
         }
-        return Err(anyhow::anyhow!("{} diagnostic error(s)", diagnostics.len()));
+        let error_count = diagnostics
+            .iter()
+            .filter(|d| d.kind == forge::diagnostic::DiagnosticKind::Error)
+            .count();
+        if error_count > 0 {
+            return Err(anyhow::anyhow!("{} diagnostic error(s)", error_count));
+        }
     }
 
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1035,26 +1035,17 @@ fn try_build_executor_multi(
                     .map(|e| e.to_diagnostic(&sf.path, &cap_registry)),
             );
         }
-        diagnostics.extend(forge::checker::check_all(&sf.program, &sf.path));
     }
 
-    // Cross-file boundary check
+    // Cross-file boundary check (pre-merge, per-file)
     let boundary_refs: Vec<_> = source_files
         .iter()
         .map(|sf| (&sf.program, sf.path.as_str()))
         .collect();
     diagnostics.extend(forge::checker::boundary_checker::check(&boundary_refs));
 
-    if !diagnostics.is_empty() {
-        for diag in &diagnostics {
-            if let Some(sf) = source_files.iter().find(|sf| sf.path == diag.file) {
-                diag.render(&sf.source);
-            }
-        }
-        return Err(anyhow::anyhow!("{} diagnostic error(s)", diagnostics.len()));
-    }
-
-    // Merge programs
+    // Merge programs before semantic checks so cross-file references
+    // (e.g. lifecycle states declared in one file, used in another) resolve (#313)
     let composed = forge::compose::merge_programs(&source_files).map_err(|errs| {
         anyhow::anyhow!(
             "{}",
@@ -1064,6 +1055,24 @@ fn try_build_executor_multi(
                 .join("\n")
         )
     })?;
+
+    // Semantic checkers on merged program (states, requires, spawn, etc.)
+    let merged_fname = source_files
+        .first()
+        .map(|sf| sf.path.clone())
+        .unwrap_or_default();
+    diagnostics.extend(forge::checker::check_all(&composed.program, &merged_fname));
+
+    if !diagnostics.is_empty() {
+        for diag in &diagnostics {
+            if let Some(sf) = source_files.iter().find(|sf| sf.path == diag.file) {
+                diag.render(&sf.source);
+            } else if let Some(sf) = source_files.first() {
+                diag.render(&sf.source);
+            }
+        }
+        return Err(anyhow::anyhow!("{} diagnostic error(s)", diagnostics.len()));
+    }
 
     let cmd_mgr = Arc::new(Mutex::new(CommandManager::new()));
     let session_mgr =

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1346,11 +1346,9 @@ fn build_retire_stmt(pair: Pair) -> anyhow::Result<Spanned<Stmt>> {
 
     for child in inner {
         match child.as_rule() {
-            Rule::string_arg => {
+            Rule::string_arg if target.is_none() => {
                 // First string_arg is the target alias
-                if target.is_none() {
-                    target = Some(build_string_arg(child)?);
-                }
+                target = Some(build_string_arg(child)?);
             }
             Rule::retire_option => {
                 let opt_inner = child.into_inner().next().unwrap();

--- a/src/portability.rs
+++ b/src/portability.rs
@@ -115,7 +115,7 @@ pub fn build_package(
         }
     }
     let mut domains: Vec<(String, usize)> = domain_counts.into_iter().collect();
-    domains.sort_by(|a, b| b.1.cmp(&a.1));
+    domains.sort_by_key(|entry| std::cmp::Reverse(entry.1));
     let top_domains: Vec<String> = domains.into_iter().take(5).map(|(d, _)| d).collect();
 
     let expertise = ExpertiseMetrics {

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -1358,15 +1358,12 @@ impl TaskExecutor {
                             TopLevel::Agent(a) if a.name.node == *template_name => {
                                 agent_decl = Some(a.as_ref().clone());
                             }
-                            TopLevel::States(s) => {
+                            TopLevel::States(s) if states_decl.is_none() => {
                                 // Collect states decls for lifecycle lookup
-                                if states_decl.is_none() {
-                                    if let Some(ref ad) = agent_decl {
-                                        if ad.lifecycle.as_ref().map(|l| &l.node)
-                                            == Some(&s.name.node)
-                                        {
-                                            states_decl = Some(s.clone());
-                                        }
+                                if let Some(ref ad) = agent_decl {
+                                    if ad.lifecycle.as_ref().map(|l| &l.node) == Some(&s.name.node)
+                                    {
+                                        states_decl = Some(s.clone());
                                     }
                                 }
                             }

--- a/tests/states_checker_tests.rs
+++ b/tests/states_checker_tests.rs
@@ -1,5 +1,6 @@
 // Tests for FORGE states checker (issue #17)
 
+use forge::compose::SourceFile;
 use forge::diagnostic::{Diagnostic, DiagnosticKind};
 use forge::parser::parse;
 
@@ -399,4 +400,65 @@ agent room
         "expected opaque guard warning, got: {:?}",
         warns
     );
+}
+
+// ── Cross-file lifecycle references (#313) ──────────────────
+
+fn check_merged(sources: &[(&str, &str)]) -> Vec<Diagnostic> {
+    let source_files: Vec<SourceFile> = sources
+        .iter()
+        .map(|(path, src)| SourceFile {
+            path: path.to_string(),
+            source: src.to_string(),
+            program: parse(src).unwrap(),
+        })
+        .collect();
+    let composed = forge::compose::merge_programs(&source_files).unwrap();
+    let merged_fname = source_files
+        .first()
+        .map(|sf| sf.path.clone())
+        .unwrap_or_default();
+    forge::checker::check_all(&composed.program, &merged_fname)
+}
+
+#[test]
+fn cross_file_lifecycle_resolves_after_merge() {
+    let states_src = "\
+states MasteryLevel
+  novice -> apprentice when score >= 40
+  apprentice -> expert when score >= 90
+  expert -> expert
+";
+    let agent_src = "\
+agent learner
+  lifecycle: MasteryLevel
+  on progress(msg: Text)
+    requires lifecycle == novice
+    transition to apprentice
+";
+    let diags = check_merged(&[("states.forge", states_src), ("agent.forge", agent_src)]);
+    let errs = errors(&diags);
+    assert!(
+        errs.is_empty(),
+        "cross-file lifecycle should resolve after merge, got: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn truly_unknown_lifecycle_still_errors_after_merge() {
+    let states_src = "\
+states MasteryLevel
+  novice -> apprentice when score >= 40
+";
+    let agent_src = "\
+agent learner
+  lifecycle: DoesNotExist
+  on progress(msg: Text)
+    say msg
+";
+    let diags = check_merged(&[("states.forge", states_src), ("agent.forge", agent_src)]);
+    let errs = errors(&diags);
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].message.contains("DoesNotExist"));
 }


### PR DESCRIPTION
## Summary

- Run `check_all()` on the **merged program** instead of per-file in `try_build_executor_multi()`, matching the pattern already used by `build.rs`
- Cross-file lifecycle references (e.g. `states MasteryLevel` in `shared/states.forge` used by `server/agent.forge`) now resolve correctly in `forge serve --source` mode
- Only fail on diagnostic **errors**, not warnings (matching `build.rs` behavior) — opaque lifecycle guard warnings no longer prevent server startup
- Fixed 4 pre-existing clippy warnings on `development`
- Added 2 regression tests for cross-file lifecycle resolution

Closes #313

## Test plan

- [x] `cargo test` — all ~1,200 tests pass, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `forge serve` with full sensei source set starts without `unknown lifecycle` errors
- [x] Sensei E2E: ingest-fact returns `{"result":"Learned [grammar]"}`
- [x] Sensei E2E: ask returns real LLM answer using ingested context (verified with Claude Haiku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)