### PR TITLE
fix(ci): #229 — audit runner self-heals missing PR labels

### DIFF
--- a/scripts/audit-forge-surface.sh
+++ b/scripts/audit-forge-surface.sh
@@ -121,6 +121,17 @@ trap 'rm -f "$REPORT_FILE" "$PR_BODY_FILE"' EXIT
   echo "Closes part of #229 (ongoing — this PR does not close the issue)."
 } > "$PR_BODY_FILE"
 
+# Ensure labels exist — gh pr create --label errors if a label is missing.
+# Idempotent: --force would bump existing labels, so only create when absent.
+for label in surface-audit docs; do
+  if ! gh label list --limit 200 --json name --jq '.[].name' | grep -Fxq "$label"; then
+    case "$label" in
+      surface-audit) gh label create surface-audit --color ededed --description "Automated derived-surface drift audit (issue #229)" ;;
+      docs)          gh label create docs --color 0075ca --description "Documentation" ;;
+    esac
+  fi
+done
+
 gh pr create \
   --base development \
   --head "$BRANCH" \


### PR DESCRIPTION
## Summary

Idempotently ensure \`surface-audit\` and \`docs\` labels exist before \`gh pr create --label\` runs in \`scripts/audit-forge-surface.sh\`. The first live Layer 2 run (dispatched 2026-04-18 after #339 merged) hit this exact failure at the very last step — everything before it (claude edits, path-guard, fmt/clippy/test/examples gates, commit, push) worked end-to-end.

## Verification

- \`bash -n scripts/audit-forge-surface.sh\` ✓
- Local dry trace: the loop greps \`gh label list --limit 200 --json name --jq '.[].name'\` and only calls \`gh label create\` when the label is absent; repeated runs are no-ops.
- Not gating on full \`cargo test\` again — single-file script edit, no Rust change.

## Known gaps

- First live run's branch (\`chore/surface-audit-2026-W16\`) was already promoted to PR #341 manually — this fix only affects subsequent scheduled runs.
- Next Monday's cron (or any manual \`gh workflow run forge-surface-audit.yml\`) will exercise this code path.

Refs: #229.