### PR TITLE
feat(workflows): close #362 — mastermind_intake conversational classifier (T9.1)

### DIFF
--- a/examples/validation.toml
+++ b/examples/validation.toml
@@ -332,12 +332,13 @@ merge = true
 manifest = "workflows/dev-cycle/forge.project.toml"
 
 [[cases]]
-name = "clone-dev top-level assembly (#356, T8.1; T8.3 #358)"
+name = "clone-dev top-level assembly (#356, T8.1; T8.3 #358; T9.1 #362)"
 paths = [
   "workflows/clone-dev/main.forge",
   "workflows/clone-dev/shared/types.forge",
   "workflows/clone-dev/shared/events.forge",
   "workflows/clone-dev/shared/mastermind.forge",
+  "workflows/clone-dev/stage1/mastermind_intake.forge",
   "workflows/clone-dev/stage2/label_router.forge",
   "workflows/clone-dev/stage2/triage_specialist.forge",
   "workflows/dev-cycle/agents.forge",

--- a/tests/clone_dev_intake_tests.rs
+++ b/tests/clone_dev_intake_tests.rs
@@ -119,7 +119,10 @@ fn build_intake_registry(classification: &str, domain: &str) -> Arc<ProviderRegi
     let mock = MockProvider::new("mock-classify")
         .with_response("Classify this DevOps request", classification)
         .with_response("Pick one domain", domain)
-        .with_response("Ask one focused clarifying", "Could you share a screenshot or log line?")
+        .with_response(
+            "Ask one focused clarifying",
+            "Could you share a screenshot or log line?",
+        )
         .with_default("mock fallback");
 
     let mut registry = ProviderRegistry::new("mock-classify");
@@ -170,9 +173,12 @@ async fn fire_and_drain_one(
     let (events_tx, mut events_rx) = tokio::sync::broadcast::channel::<String>(512);
     let tracer = forge::tracer::Tracer::with_live(events_tx.clone());
 
-    let executor =
-        TaskExecutor::new(program, build_intake_registry(classification, domain), Some(tracer.clone()))
-            .with_config(forge::config::ForgeConfig::default_mock_config());
+    let executor = TaskExecutor::new(
+        program,
+        build_intake_registry(classification, domain),
+        Some(tracer.clone()),
+    )
+    .with_config(forge::config::ForgeConfig::default_mock_config());
 
     let event_bus = EventBus::new_shared(executor.tracer().cloned());
     let instance_registry = Arc::new(tokio::sync::RwLock::new(InstanceRegistry::new()));
@@ -233,9 +239,12 @@ async fn fire_two_turns_same_thread(
     let (events_tx, mut events_rx) = tokio::sync::broadcast::channel::<String>(1024);
     let tracer = forge::tracer::Tracer::with_live(events_tx.clone());
 
-    let executor =
-        TaskExecutor::new(program, build_intake_registry(classification, domain), Some(tracer.clone()))
-            .with_config(forge::config::ForgeConfig::default_mock_config());
+    let executor = TaskExecutor::new(
+        program,
+        build_intake_registry(classification, domain),
+        Some(tracer.clone()),
+    )
+    .with_config(forge::config::ForgeConfig::default_mock_config());
 
     let event_bus = EventBus::new_shared(executor.tracer().cloned());
     let instance_registry = Arc::new(tokio::sync::RwLock::new(InstanceRegistry::new()));
@@ -343,8 +352,13 @@ async fn investigation_path_routes_to_ops_and_stitches_finding_back_into_thread(
     // correctly, routes, and the investigator's reply lands in the
     // same thread." This single-turn variant proves the full classify
     // → investigate → finding → stitch-back loop in one shot.
-    let frames =
-        fire_and_drain_one("investigation", "ops", "T1", "logs are spiking on api-gateway").await;
+    let frames = fire_and_drain_one(
+        "investigation",
+        "ops",
+        "T1",
+        "logs are spiking on api-gateway",
+    )
+    .await;
 
     // 1. mastermind_intake emitted InvestigationRequested for the ops domain.
     assert!(
@@ -356,7 +370,9 @@ async fn investigation_path_routes_to_ops_and_stitches_finding_back_into_thread(
     //    and emitted Finding back.
     let says = say_lines(&frames);
     assert!(
-        says.iter().any(|s| s.starts_with("ECHO|") && s.contains("thread_ts=T1") && s.contains("domain=ops")),
+        says.iter().any(|s| s.starts_with("ECHO|")
+            && s.contains("thread_ts=T1")
+            && s.contains("domain=ops")),
         "echo_investigator should print ECHO line; says={says:#?}"
     );
     assert!(
@@ -426,7 +442,8 @@ async fn clarification_classification_asks_a_question_in_thread() {
     );
     let says = say_lines(&frames);
     assert!(
-        says.iter().any(|s| s.contains("classification=clarification_needed")),
+        says.iter()
+            .any(|s| s.contains("classification=clarification_needed")),
         "intake should log clarification classification; says={says:#?}"
     );
 }

--- a/tests/clone_dev_intake_tests.rs
+++ b/tests/clone_dev_intake_tests.rs
@@ -1,0 +1,458 @@
+// Integration test for T9.1 (#362) — mastermind_intake conversational
+// classifier for Stage-1 fuzzy intake.
+//
+// Verifies the full Stage-1 loop on the event bus:
+//   POST /devops_request → emit DevOpsRequest →
+//     mastermind_intake (correlate on thread_ts → wake) →
+//     classify_request (`reason for classify`) →
+//     emit InvestigationRequested OR PostMessage →
+//     echo_investigator → emit Finding (correlate match wakes intake) →
+//     emit PostMessage(channel, text, thread_ts).
+//
+// Mirrors tests/label_router_integration_tests.rs for harness wiring
+// (compose source files, build_program, EventBus + InstanceRegistry +
+// system runtime). The MockProvider's pattern-matching API
+// (src/llm/providers/mock.rs:43) lets us return deterministic
+// classifications based on prompt substrings.
+//
+// Skips:
+//   - HTTP /wake/... HMAC layer (covered by tests/webhook_integration_tests.rs)
+//   - Real Slack delivery (PostMessage emission is verified; no skill.slack.* call)
+//   - Cross-process redb rehydration (covered for the underlying primitive
+//     by examples/agents/wake-rehydration-smoke and #334 tests; this test
+//     verifies in-process correlation reuses the same agent instance)
+// ──────────────────────────────────────────────────────────────────────
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use forge::compose;
+use forge::llm::providers::mock::MockProvider;
+use forge::llm::registry::ProviderRegistry;
+use forge::runtime::confidence::{ConfidentValue, Value};
+use forge::runtime::event_bus::EventBus;
+use forge::runtime::executor::TaskExecutor;
+use forge::runtime::instance_registry::InstanceRegistry;
+
+const INTAKE_PATH: &str = "workflows/clone-dev/stage1/mastermind_intake.forge";
+
+// Test harness: declares the four events mastermind_intake references
+// (DevOpsRequest, InvestigationRequested, Finding, PostMessage), plus a
+// minimal echo_investigator that closes the InvestigationRequested →
+// Finding loop without needing the real T9.2 (#363) investigators.
+//
+// PostMessage is redeclared here (rather than sourcing slack-adapter)
+// because slack_adapter calls `skill.slack.*` which won't work in the
+// test sandbox — and the test only needs to observe the *emit*, not the
+// downstream Slack API call.
+const TEST_HARNESS_SRC: &str = r#"#! boundary: server
+
+event DevOpsRequest
+  channel: Text
+  user: Text
+  text: Text
+  thread_ts: Text
+  message_ts: Text
+
+event InvestigationRequested
+  thread_ts: Text
+  domain: Text
+  context: Text
+  channel: Text
+
+event Finding
+  thread_ts: Text
+  domain: Text
+  summary: Text
+  evidence: Text[]
+  confidence: Number
+  suggested_action: Text
+
+event PostMessage
+  channel: Text
+  text: Text
+  thread_ts: Text
+
+agent echo_investigator
+  memory
+    last_thread: Text
+    last_domain: Text
+  subscribe InvestigationRequested where domain == "ops"
+
+  on start
+    memory.last_thread = ""
+    memory.last_domain = ""
+    say "[echo_investigator] ready"
+
+  on InvestigationRequested(thread_ts: Text, domain: Text, context: Text, channel: Text)
+    memory.last_thread = thread_ts
+    memory.last_domain = domain
+    say "ECHO|thread_ts={thread_ts}|domain={domain}|context={context}"
+    emit Finding(thread_ts: thread_ts, domain: "ops", summary: "echo: {context}", evidence: [], confidence: 0.9, suggested_action: "answer")
+
+warden test_warden
+  manages [mastermind_intake, echo_investigator]
+  on stuck: nudge, self
+  on timeout: restart, self
+  on crash: restart, self
+  on hallucination: nudge, self
+  on contradiction: nudge, self
+  on budget: nudge, self
+
+system test_system
+  use
+    intake: mastermind_intake
+    investigator: echo_investigator
+
+endpoint fire_devops(channel: Text, user: Text, text: Text, thread_ts: Text, message_ts: Text) -> Text
+  emit DevOpsRequest(channel: channel, user: user, text: text, thread_ts: thread_ts, message_ts: message_ts)
+  give "queued"
+"#;
+
+/// Build a mock provider that returns a specific classification for the
+/// primary classify, a specific domain for the domain classify, and a
+/// canned clarification text for the ask_clarification fall-through.
+/// Patterns are matched against the prompt text via substring search
+/// (see src/llm/providers/mock.rs:90–94).
+fn build_intake_registry(classification: &str, domain: &str) -> Arc<ProviderRegistry> {
+    let mock = MockProvider::new("mock-classify")
+        .with_response("Classify this DevOps request", classification)
+        .with_response("Pick one domain", domain)
+        .with_response("Ask one focused clarifying", "Could you share a screenshot or log line?")
+        .with_default("mock fallback");
+
+    let mut registry = ProviderRegistry::new("mock-classify");
+    registry.register("mock-classify", Arc::new(mock));
+    // mastermind_intake's three `reason ... for classify` calls (and the
+    // un-phased ask_clarification reason) all resolve through this chain
+    // because the default provider also points at mock-classify.
+    registry.set_phase_chain("classify", vec!["mock-classify".into()]);
+    Arc::new(registry)
+}
+
+fn build_program() -> forge::ast::Program {
+    let intake_src = std::fs::read_to_string(INTAKE_PATH)
+        .unwrap_or_else(|e| panic!("could not read {INTAKE_PATH}: {e}"));
+    let intake_prog = forge::parser::parse(&intake_src).expect("parse mastermind_intake.forge");
+    let harness_prog = forge::parser::parse(TEST_HARNESS_SRC).expect("parse harness");
+    let files = vec![
+        compose::SourceFile {
+            path: INTAKE_PATH.to_string(),
+            source: intake_src,
+            program: intake_prog,
+        },
+        compose::SourceFile {
+            path: "test_harness.forge".to_string(),
+            source: TEST_HARNESS_SRC.to_string(),
+            program: harness_prog,
+        },
+    ];
+    let composed = compose::merge_programs(&files).expect("merge");
+    let diagnostics = forge::checker::check_all(&composed.program, "test_harness.forge");
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.kind == forge::diagnostic::DiagnosticKind::Error)
+        .collect();
+    assert!(errors.is_empty(), "checker errors: {errors:#?}");
+    composed.program
+}
+
+/// Boot the system, fire one DevOpsRequest, and drain SSE frames for a
+/// fixed window. Returns the parsed JSON frames in arrival order.
+async fn fire_and_drain_one(
+    classification: &str,
+    domain: &str,
+    thread_ts: &str,
+    text: &str,
+) -> Vec<serde_json::Value> {
+    let program = build_program();
+    let (events_tx, mut events_rx) = tokio::sync::broadcast::channel::<String>(512);
+    let tracer = forge::tracer::Tracer::with_live(events_tx.clone());
+
+    let executor =
+        TaskExecutor::new(program, build_intake_registry(classification, domain), Some(tracer.clone()))
+            .with_config(forge::config::ForgeConfig::default_mock_config());
+
+    let event_bus = EventBus::new_shared(executor.tracer().cloned());
+    let instance_registry = Arc::new(tokio::sync::RwLock::new(InstanceRegistry::new()));
+
+    let system_runtime = executor
+        .build_system_runtime()
+        .expect("build system runtime")
+        .expect("test_system should produce a runtime")
+        .with_shared_infrastructure(event_bus.clone(), instance_registry.clone());
+
+    let executor = executor.with_event_bus(event_bus.clone());
+
+    tokio::spawn(async move {
+        let _ = system_runtime.start().await;
+    });
+
+    // Let the system runtime register subscriptions + run `on start`.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let mut args = HashMap::new();
+    args.insert(
+        "channel".to_string(),
+        ConfidentValue::deterministic(Value::Text("C123".into())),
+    );
+    args.insert(
+        "user".to_string(),
+        ConfidentValue::deterministic(Value::Text("U456".into())),
+    );
+    args.insert(
+        "text".to_string(),
+        ConfidentValue::deterministic(Value::Text(text.into())),
+    );
+    args.insert(
+        "thread_ts".to_string(),
+        ConfidentValue::deterministic(Value::Text(thread_ts.into())),
+    );
+    args.insert(
+        "message_ts".to_string(),
+        ConfidentValue::deterministic(Value::Text(format!("{thread_ts}-m1"))),
+    );
+
+    let _ = executor
+        .exec_endpoint("fire_devops", args, None)
+        .await
+        .expect("endpoint dispatch");
+
+    drain_frames(&mut events_rx, Duration::from_millis(2000)).await
+}
+
+/// Boot the system, fire two DevOpsRequest events on the same thread,
+/// and drain SSE frames. Used by the multi-turn correlation test.
+async fn fire_two_turns_same_thread(
+    classification: &str,
+    domain: &str,
+    thread_ts: &str,
+) -> Vec<serde_json::Value> {
+    let program = build_program();
+    let (events_tx, mut events_rx) = tokio::sync::broadcast::channel::<String>(1024);
+    let tracer = forge::tracer::Tracer::with_live(events_tx.clone());
+
+    let executor =
+        TaskExecutor::new(program, build_intake_registry(classification, domain), Some(tracer.clone()))
+            .with_config(forge::config::ForgeConfig::default_mock_config());
+
+    let event_bus = EventBus::new_shared(executor.tracer().cloned());
+    let instance_registry = Arc::new(tokio::sync::RwLock::new(InstanceRegistry::new()));
+
+    let system_runtime = executor
+        .build_system_runtime()
+        .expect("build system runtime")
+        .expect("test_system should produce a runtime")
+        .with_shared_infrastructure(event_bus.clone(), instance_registry.clone());
+
+    let executor = executor.with_event_bus(event_bus.clone());
+
+    tokio::spawn(async move {
+        let _ = system_runtime.start().await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    for turn in 1..=2 {
+        let mut args = HashMap::new();
+        args.insert(
+            "channel".to_string(),
+            ConfidentValue::deterministic(Value::Text("C123".into())),
+        );
+        args.insert(
+            "user".to_string(),
+            ConfidentValue::deterministic(Value::Text("U456".into())),
+        );
+        args.insert(
+            "text".to_string(),
+            ConfidentValue::deterministic(Value::Text(format!("turn {turn} message"))),
+        );
+        args.insert(
+            "thread_ts".to_string(),
+            ConfidentValue::deterministic(Value::Text(thread_ts.into())),
+        );
+        args.insert(
+            "message_ts".to_string(),
+            ConfidentValue::deterministic(Value::Text(format!("{thread_ts}-m{turn}"))),
+        );
+
+        let _ = executor
+            .exec_endpoint("fire_devops", args, None)
+            .await
+            .expect("endpoint dispatch");
+
+        // Pause between turns so the first one fully drains through the
+        // bus before the second arrives. Without this the correlation
+        // index for the first turn might not be persisted in time for
+        // the second turn's lookup.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+
+    drain_frames(&mut events_rx, Duration::from_millis(1500)).await
+}
+
+async fn drain_frames(
+    rx: &mut tokio::sync::broadcast::Receiver<String>,
+    window: Duration,
+) -> Vec<serde_json::Value> {
+    let mut frames = Vec::<String>::new();
+    let deadline = std::time::Instant::now() + window;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Ok(frame)) => frames.push(frame),
+            Ok(Err(_)) | Err(_) => break,
+        }
+    }
+    frames
+        .iter()
+        .filter_map(|f| serde_json::from_str(f).ok())
+        .collect()
+}
+
+// ── Frame helpers ─────────────────────────────────────────────────────
+// SSE event_emit frames carry only `source_agent` + `event` name +
+// `subscribers` count (src/tracer.rs:258), so we lean on `say` frames
+// emitted by the agents to verify field-level outcomes — same approach
+// label_router_integration_tests.rs uses.
+
+fn emits_event_from(frames: &[serde_json::Value], event: &str, source_agent: &str) -> bool {
+    frames
+        .iter()
+        .any(|v| v["event"] == event && v["source_agent"] == source_agent)
+}
+
+fn say_lines(frames: &[serde_json::Value]) -> Vec<String> {
+    frames
+        .iter()
+        .filter(|v| v["event"] == "say")
+        .filter_map(|v| v["text"].as_str())
+        .map(String::from)
+        .collect()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn investigation_path_routes_to_ops_and_stitches_finding_back_into_thread() {
+    // DoD: "Integration test: a two-turn conversation classifies
+    // correctly, routes, and the investigator's reply lands in the
+    // same thread." This single-turn variant proves the full classify
+    // → investigate → finding → stitch-back loop in one shot.
+    let frames =
+        fire_and_drain_one("investigation", "ops", "T1", "logs are spiking on api-gateway").await;
+
+    // 1. mastermind_intake emitted InvestigationRequested for the ops domain.
+    assert!(
+        emits_event_from(&frames, "InvestigationRequested", "mastermind_intake"),
+        "intake should emit InvestigationRequested; frames={frames:#?}"
+    );
+
+    // 2. echo_investigator received it (filter where domain == "ops" hit)
+    //    and emitted Finding back.
+    let says = say_lines(&frames);
+    assert!(
+        says.iter().any(|s| s.starts_with("ECHO|") && s.contains("thread_ts=T1") && s.contains("domain=ops")),
+        "echo_investigator should print ECHO line; says={says:#?}"
+    );
+    assert!(
+        emits_event_from(&frames, "Finding", "echo_investigator"),
+        "echo_investigator should emit Finding; frames={frames:#?}"
+    );
+
+    // 3. mastermind_intake's Finding handler emitted PostMessage with
+    //    the originating thread_ts (the stitch-back).
+    assert!(
+        emits_event_from(&frames, "PostMessage", "mastermind_intake"),
+        "intake should re-emit PostMessage on Finding; frames={frames:#?}"
+    );
+}
+
+#[tokio::test]
+async fn dev_task_classification_emits_stub_postmessage_for_proposal_phase() {
+    // dev_task is the route that T9.3 (#364) solution_proposer will own.
+    // Until then mastermind_intake emits a stub PostMessage so the
+    // conversation in the Slack thread doesn't dead-end.
+    let frames = fire_and_drain_one(
+        "dev_task",
+        "ops", // unused on this path
+        "T2",
+        "we should add a /metrics endpoint",
+    )
+    .await;
+
+    assert!(
+        !emits_event_from(&frames, "InvestigationRequested", "mastermind_intake"),
+        "dev_task path must not emit InvestigationRequested; frames={frames:#?}"
+    );
+    assert!(
+        emits_event_from(&frames, "PostMessage", "mastermind_intake"),
+        "dev_task path should emit a PostMessage stub; frames={frames:#?}"
+    );
+
+    let says = say_lines(&frames);
+    assert!(
+        says.iter().any(|s| s.contains("classification=dev_task")),
+        "intake should log dev_task classification; says={says:#?}"
+    );
+}
+
+#[tokio::test]
+async fn clarification_classification_asks_a_question_in_thread() {
+    // The DoD says: "Falls back to `reason \"ask for clarification\"` when
+    // classification confidence is low." The MockProvider always returns
+    // .sure, so we exercise the same code path by directly classifying as
+    // "clarification_needed" — the agent then calls ask_clarification and
+    // emits PostMessage(thread_ts) with the resulting question.
+    let frames = fire_and_drain_one(
+        "clarification_needed",
+        "ops",
+        "T3",
+        "something is off but I'm not sure what",
+    )
+    .await;
+
+    assert!(
+        !emits_event_from(&frames, "InvestigationRequested", "mastermind_intake"),
+        "clarification path must not emit InvestigationRequested"
+    );
+    assert!(
+        emits_event_from(&frames, "PostMessage", "mastermind_intake"),
+        "clarification path should emit PostMessage with the follow-up question"
+    );
+    let says = say_lines(&frames);
+    assert!(
+        says.iter().any(|s| s.contains("classification=clarification_needed")),
+        "intake should log clarification classification; says={says:#?}"
+    );
+}
+
+#[tokio::test]
+async fn two_turns_same_thread_share_persistent_memory_via_correlation() {
+    // DoD: "Memory keyed by `thread_ts`; survives restart via `mode: wake`
+    // rehydration (#333)." This test proves the in-process half — the
+    // same agent instance handles both turns via the CorrelationDriver
+    // index (the underlying redb persistence + cross-process restart is
+    // proven by the #334 e2e smoke at examples/basics/correlate_e2e.forge
+    // and tests/correlate_*_tests.rs).
+    let frames = fire_two_turns_same_thread("investigation", "ops", "T4").await;
+
+    let says = say_lines(&frames);
+    let intake_lines: Vec<&String> = says
+        .iter()
+        .filter(|s| s.contains("[mastermind_intake] thread=T4"))
+        .collect();
+
+    assert!(
+        intake_lines.iter().any(|s| s.contains("turn=1")),
+        "first turn should log turn=1; intake_lines={intake_lines:#?}"
+    );
+    assert!(
+        intake_lines.iter().any(|s| s.contains("turn=2")),
+        "second turn should log turn=2 (same instance via correlation); intake_lines={intake_lines:#?}"
+    );
+}

--- a/workflows/clone-dev/main.forge
+++ b/workflows/clone-dev/main.forge
@@ -28,7 +28,13 @@
 #       fall-through agent for unmapped / multi-labeled / unlabeled
 #       inbound issues.
 #
-# Single `org_warden` supervises all ten agents.
+#   stage1/mastermind_intake.forge
+#     • T9.1 (#362): conversational classifier for fuzzy Slack-mention
+#       intake. One persistent instance per Slack thread_ts (correlated
+#       via #334). Routes investigation requests by domain to the
+#       T9.2 (#363) investigators.
+#
+# Single `org_warden` supervises all eleven agents.
 #
 # HTTP surface (one port):
 #   GET  /health                     → liveness probe
@@ -51,6 +57,7 @@
 #     -s workflows/clone-dev/shared/types.forge \
 #     -s workflows/clone-dev/shared/events.forge \
 #     -s workflows/clone-dev/shared/mastermind.forge \
+#     -s workflows/clone-dev/stage1/mastermind_intake.forge \
 #     -s workflows/clone-dev/stage2/label_router.forge \
 #     -s workflows/clone-dev/stage2/triage_specialist.forge \
 #     -s workflows/dev-cycle/agents.forge \
@@ -69,7 +76,7 @@
 # was copied verbatim).
 
 warden org_warden
-  manages [mastermind, planner, implementer, tester, reviewer, release_manager, triage_specialist, swarm_mastery_coordinator, swarm_mastery_tuple, slack_adapter]
+  manages [mastermind, mastermind_intake, planner, implementer, tester, reviewer, release_manager, triage_specialist, swarm_mastery_coordinator, swarm_mastery_tuple, slack_adapter]
   on stuck: nudge, self
     after 3: escalate
   on timeout: restart, self
@@ -91,6 +98,7 @@ warden org_warden
 system clone_dev_system
   use
     mm: mastermind
+    intake: mastermind_intake
     plan: planner
     impl: implementer
     test: tester
@@ -129,3 +137,12 @@ endpoint seed_task(task_id: Text, specialist: Text, project: Text) -> Text
 endpoint cross_project(source_task_id: Text, target_repo: Text, description: Text, labels: Text) -> Text
   emit CrossProjectRequested(source_task_id: source_task_id, target_repo: target_repo, description: description, labels: labels)
   give "CrossProjectRequested queued (source={source_task_id} target_repo={target_repo})"
+
+# T9.1 (#362) — smoke endpoint for the Stage-1 mastermind_intake.
+# Stands in for the future T9.5 (#366) slack_devops_monitor by emitting
+# DevOpsRequest directly. mastermind_intake correlates on thread_ts so
+# repeating calls with the same thread_ts route to the same agent
+# instance (multi-turn conversation).
+endpoint devops_request(channel: Text, user: Text, text: Text, thread_ts: Text, message_ts: Text) -> Text
+  emit DevOpsRequest(channel: channel, user: user, text: text, thread_ts: thread_ts, message_ts: message_ts)
+  give "DevOpsRequest queued (thread_ts={thread_ts} user={user})"

--- a/workflows/clone-dev/shared/events.forge
+++ b/workflows/clone-dev/shared/events.forge
@@ -80,3 +80,35 @@ event TaskRouted
   outcome: Text
   matched_suffix: Text
   diagnostic: Text
+
+# T9.1 (#362): Stage-1 fuzzy intake. Produced by T9.5 slack_devops_monitor
+# (#366) and consumed by mastermind_intake (workflows/clone-dev/stage1/).
+# thread_ts is the correlation key; one mastermind_intake instance per
+# Slack thread, rehydrated via CorrelationDriver (#334) on each turn.
+event DevOpsRequest
+  channel: Text
+  user: Text
+  text: Text
+  thread_ts: Text
+  message_ts: Text
+
+# T9.1 (#362): domain dispatch from mastermind_intake to the T9.2 (#363)
+# investigators. Each investigator subscribes with `where domain == "<self>"`.
+# thread_ts threads through so the eventual Finding can stitch back into
+# the same Slack thread.
+event InvestigationRequested
+  thread_ts: Text
+  domain: Text
+  context: Text
+  channel: Text
+
+# T9.1 (#362) declares the contract; T9.2 (#363) populates it. mastermind_intake
+# correlates on Finding.thread_ts to wake the right thread instance and post
+# the investigator's reply back into the originating Slack thread.
+event Finding
+  thread_ts: Text
+  domain: Text
+  summary: Text
+  evidence: Text[]
+  confidence: Number
+  suggested_action: Text

--- a/workflows/clone-dev/stage1/mastermind_intake.forge
+++ b/workflows/clone-dev/stage1/mastermind_intake.forge
@@ -71,11 +71,16 @@ task classify_domain
     when result.unsure -> give "ops"
     else -> give "ops"
 
+# `for classify` keeps this on the same Stage-1 phase chain as the
+# other two reason calls in this agent. Without an explicit phase,
+# the routing chain falls through to a provider that may not be
+# available (e.g., ops_investigate's ollama-local) and crashes the
+# handler — surfaced during the T9.1 real-LLM smoke run.
 task ask_clarification
   needs text: Text
   gives Text
   do
-    result = reason "Ask one focused clarifying question about this request: {text}"
+    result = reason "Ask one focused clarifying question about this request: {text}" for classify
     when result.sure -> give result
     when result.unsure -> give "Could you give a bit more detail about what you're seeing?"
     else -> give "Could you give a bit more detail about what you're seeing?"

--- a/workflows/clone-dev/stage1/mastermind_intake.forge
+++ b/workflows/clone-dev/stage1/mastermind_intake.forge
@@ -1,0 +1,143 @@
+#! boundary: server
+
+# ================================================================
+# Clone-Dev Stage 1 — mastermind_intake (T9.1, #362)
+# ================================================================
+# Conversational classifier for fuzzy Slack-mention intake. Front
+# door of Stage 1; sits parallel to the existing structured-inbound
+# mastermind in workflows/clone-dev/shared/mastermind.forge.
+#
+# Follows the four invariants from
+# examples/agents/mastermind-pattern/README.md:
+#   1. Classification via `reason ... for classify` — LLM suggests,
+#      explicit `if classification ==` branching commits to a route.
+#   2. Typed routing event — emits InvestigationRequested(domain, ...)
+#      so T9.2 (#363) investigators filter `where domain == "<self>"`.
+#   3. Correlation — `correlate on DevOpsRequest.thread_ts mode: wake`
+#      keys one persistent agent instance per Slack thread, rehydrated
+#      from redb on each turn (CorrelationDriver, #334).
+#   4. Single warden — registered in workflows/clone-dev/main.forge's
+#      `org_warden manages [...]` block.
+#
+# Lifecycle: one instance per Slack thread_ts.
+#   - First mention on a new thread → fresh agent spawned, memory
+#     initialized in `on start`.
+#   - Subsequent mentions on the same thread → CorrelationDriver
+#     match → rehydrate from redb → handler sees prior turn_count
+#     and history.
+#
+# Stitch-back: when a T9.2 investigator emits Finding(thread_ts: ...),
+# the second `correlate on Finding.thread_ts` block wakes the right
+# intake instance, which posts the finding back into the Slack thread
+# via slack_adapter's PostMessage event.
+#
+# Cross-references:
+#   - DevOpsRequest, InvestigationRequested, Finding declared in
+#     workflows/clone-dev/shared/events.forge.
+#   - PostMessage consumed by examples/agents/slack-adapter/agents.forge
+#     (auto-routes to reply_thread when thread_ts != "").
+#   - DevOpsRequest producer: T9.5 (#366) slack_devops_monitor (future).
+#     Until then, the /devops_request smoke endpoint in main.forge stands
+#     in for direct testing.
+#   - `for classify` resolves through [llm.routing].classify per T8.6
+#     (#361); see workflows/dev-cycle/clone-dev.toml:32.
+# ================================================================
+
+use
+  llm.reason
+
+# ── Confidence-fallback tasks ──────────────────────────────────
+# The `when .sure / .unsure / else` triple lives inside dedicated
+# tasks so the agent handler can branch on a clean Text value. Low-
+# confidence on the primary classify falls through to the
+# `clarification_needed` route, which pulls a follow-up question via
+# `ask_clarification`.
+
+task classify_request
+  needs text: Text
+  gives Text
+  do
+    result = reason "Classify this DevOps request into exactly one of: investigation, small_task, dev_task, clarification_needed. Text: {text}. Reply with the category name only." for classify
+    when result.sure -> give result
+    when result.unsure -> give "clarification_needed"
+    else -> give "clarification_needed"
+
+task classify_domain
+  needs text: Text
+  gives Text
+  do
+    result = reason "Pick one domain for this investigation: code, ops, security. Text: {text}. Reply with the domain only." for classify
+    when result.sure -> give result
+    when result.unsure -> give "ops"
+    else -> give "ops"
+
+task ask_clarification
+  needs text: Text
+  gives Text
+  do
+    result = reason "Ask one focused clarifying question about this request: {text}"
+    when result.sure -> give result
+    when result.unsure -> give "Could you give a bit more detail about what you're seeing?"
+    else -> give "Could you give a bit more detail about what you're seeing?"
+
+# ── Agent ──────────────────────────────────────────────────────
+
+agent mastermind_intake
+  memory persistent
+    thread_ts: Text
+    channel: Text
+    user: Text
+    turn_count: Number
+    history: Text[]
+    last_classification: Text
+    last_domain: Text
+  correlate on DevOpsRequest.thread_ts
+    mode: wake
+  correlate on Finding.thread_ts
+    mode: wake
+
+  on start
+    memory.turn_count = 0
+    memory.last_classification = "none"
+    memory.last_domain = ""
+    say "[mastermind_intake] ready"
+
+  on DevOpsRequest(channel: Text, user: Text, text: Text, thread_ts: Text, message_ts: Text)
+    memory.thread_ts = thread_ts
+    memory.channel = channel
+    memory.user = user
+    memory.turn_count = memory.turn_count + 1
+    classification = classify_request(text)
+    memory.last_classification = classification
+    say "[mastermind_intake] thread={thread_ts} turn={memory.turn_count} classification={classification}"
+    if classification == "investigation"
+      domain_raw = classify_domain(text)
+      domain = "ops"
+      if domain_raw == "code"
+        domain = "code"
+      if domain_raw == "security"
+        domain = "security"
+      memory.last_domain = domain
+      memory.history = memory.history + ["turn{memory.turn_count}: investigation/{domain}"]
+      emit InvestigationRequested(thread_ts: thread_ts, domain: domain, context: text, channel: channel)
+    if classification == "small_task"
+      memory.history = memory.history + ["turn{memory.turn_count}: small_task"]
+      emit PostMessage(channel: channel, text: "[stub] small_task path is not yet implemented; T9.x will land it.", thread_ts: thread_ts)
+    if classification == "dev_task"
+      memory.history = memory.history + ["turn{memory.turn_count}: dev_task"]
+      emit PostMessage(channel: channel, text: "I think this should become a tracked issue. T9.3/T9.4 will draft and create it once landed.", thread_ts: thread_ts)
+    if classification == "clarification_needed"
+      question = ask_clarification(text)
+      memory.history = memory.history + ["turn{memory.turn_count}: clarify"]
+      emit PostMessage(channel: channel, text: question, thread_ts: thread_ts)
+
+  # Stitch-back: a Finding for this thread → post the summary into
+  # the same Slack thread via slack_adapter. memory.channel was set
+  # on the inbound DevOpsRequest handler that opened this thread.
+  on Finding(thread_ts: Text, domain: Text, summary: Text, evidence: Text[], confidence: Number, suggested_action: Text)
+    memory.history = memory.history + ["finding/{domain}/{suggested_action}"]
+    emit PostMessage(channel: memory.channel, text: "{summary} (confidence={confidence}, suggested={suggested_action})", thread_ts: thread_ts)
+
+  if stuck for 3 turns
+    say "[mastermind_intake] stuck. escalating."
+    escalate to lead


### PR DESCRIPTION
## Summary

- New `workflows/clone-dev/stage1/mastermind_intake.forge`: Stage-1 conversational classifier. One persistent agent instance per Slack `thread_ts` via `correlate on DevOpsRequest.thread_ts` (mode: wake) — multi-turn state survives process restart through CorrelationDriver (#334) + redb.
- Routes via `reason ... for classify` (T8.6 #361 routing chain) into one of `investigation` / `small_task` / `dev_task` / `clarification_needed`. Investigation paths emit `InvestigationRequested(domain, …)` for the T9.2 (#363) `code` / `ops` / `security` investigators; the second `correlate on Finding.thread_ts` block stitches their replies back into the same Slack thread via `PostMessage` to slack_adapter.
- Falls back to `reason "ask for clarification"` whenever the primary classify confidence is unsure (`when result.unsure -> give "clarification_needed"` inside the `classify_request` task).
- 4 new integration tests in `tests/clone_dev_intake_tests.rs` exercising the full event-bus loop with a `MockProvider` + a stubbed `echo_investigator`: investigation→ops→Finding→stitch-back, dev_task stub, clarification path, and two-turn same-thread memory persistence via correlation.
- Three new event types in `shared/events.forge` (`DevOpsRequest`, `InvestigationRequested`, `Finding`) — T9.5 (#366) will produce `DevOpsRequest`; T9.2 (#363) will populate `Finding`. Schemas land here so this agent compiles cleanly and the contracts are stable for siblings.
- `main.forge` wires `mastermind_intake` into `org_warden manages [...]` and the `system clone_dev_system use` block; adds a `/devops_request` smoke endpoint that stands in for T9.5 until the Slack monitor lands.
- `examples/validation.toml` updated: clone-dev assembly case now includes the new file.

Closes #362.

## Test plan

- [x] `cargo test --test clone_dev_intake_tests` (4/4 passing)
- [x] `cargo test --test example_validation_tests` (2/2 passing — manifest coverage + clone-dev assembly composes clean)
- [x] `cargo test --test label_router_integration_tests --test clone_dev_routing_tests` (no regressions)
- [x] `cargo check --tests` (clean)
- [ ] Manual smoke (deferred — needs LLM provider; see plan): `cargo run -- serve` with all `-s` sources, then `curl -X POST :3300/devops_request -d 'thread_ts=T1' -d 'text=...'`, observe `correlation_registered → InvestigationRequested → PostMessage` on `/__forge/events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)