### PR TITLE
fix: install TypeScript proof-run dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub skill: `list_prs(repo, state, limit)`, `get_pr_reviews(repo, pr_number)`, `get_pr_diff(repo, pr_number)` — three new deterministic executor capabilities for PR history mining and review analysis
 
 ### Fixed
+- Clone-dev TypeScript proof-run guidance and regressions now require
+  `npm ci` before typecheck/test/build, and fix iterations with no staged
+  source diff skip the source commit path while re-running tests (#415).
 - Dev-cycle implementer now trims normalized generated shell, rejects empty
   shell bodies after Markdown fence removal, and has runtime regressions proving
   fenced `bash` responses are executed without passing fences to `sh -c` or

--- a/docs/proof-runs/2026-05-clone-dev-playground.md
+++ b/docs/proof-runs/2026-05-clone-dev-playground.md
@@ -89,7 +89,7 @@ The relevant default is:
 
 ```toml
 [defaults]
-test_cmd = "npm run typecheck && npm test && npm run build"
+test_cmd = "npm ci && npm run typecheck && npm test && npm run build"
 ```
 
 That command is intentionally TypeScript-specific and must stay aligned with

--- a/src/runtime/clone_dev_config.rs
+++ b/src/runtime/clone_dev_config.rs
@@ -975,14 +975,14 @@ mod tests {
         let cfg = CloneDevConfig::from_toml_str(
             r#"
             [defaults]
-            test_cmd = "npm run typecheck && npm test && npm run build"
+            test_cmd = "npm ci && npm run typecheck && npm test && npm run build"
             "#,
         )
         .expect("parse");
 
         assert_eq!(
             cfg.defaults_test_cmd,
-            "npm run typecheck && npm test && npm run build"
+            "npm ci && npm run typecheck && npm test && npm run build"
         );
 
         let record = cfg.to_forge_record();
@@ -995,7 +995,10 @@ mod tests {
             .expect("defaults_test_cmd field");
         match &value.value {
             Value::Text(cmd) => {
-                assert_eq!(cmd, "npm run typecheck && npm test && npm run build")
+                assert_eq!(
+                    cmd,
+                    "npm ci && npm run typecheck && npm test && npm run build"
+                )
             }
             _ => panic!("defaults_test_cmd should be Text"),
         }

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -1220,6 +1220,10 @@ fn dev_cycle_implementer_sanitizes_fenced_shell_and_uses_argv() {
         "fix iteration path should pass generated shell through argv"
     );
     assert!(
+        source.contains("no staged source diff after fix; skipping commit"),
+        "fix iteration path should skip source commits when only local dependency state changed"
+    );
+    assert!(
         source.contains("Before writing any file, create its parent directory with mkdir -p"),
         "implementer prompts should require parent directories before heredocs"
     );
@@ -1568,6 +1572,80 @@ agent implementer
         "no-op commit must not emit ImplementationReady: {:?}",
         ctx.event_sink.emitted
     );
+}
+
+#[tokio::test]
+async fn implementer_noop_fix_iteration_retries_tests_without_commit() {
+    let source = r#"
+use
+  llm.reason
+
+event ImplementationReady
+  issue_id: Text
+
+agent implementer
+  memory
+    workdir: Text
+
+  on TestsFailed(workdir: Text)
+    memory.workdir = workdir
+    fix_code = reason "Generate dependency-only fix shell" for implement
+    apply_result = command ["sh", "-c", fix_code] in "{memory.workdir}" timeout 5s
+    when apply_result.sure -> say "fix applied"
+    else -> give "fix_apply_failed: {apply_result}"
+    commit_result = command "cd {memory.workdir} && git add -A && if git diff --cached --quiet; then echo 'no staged source diff after fix; skipping commit'; else git commit -m 'test commit' && git push origin issue-415; fi 2>&1" timeout 5s
+    when commit_result.sure -> say "commit skipped or pushed"
+    else -> give "fix_commit_push_failed: {commit_result}"
+    emit ImplementationReady(issue_id: "415")
+"#;
+    let program = forge::parser::parse(source).expect("parse failed");
+    let agent_decl = program
+        .items
+        .iter()
+        .find_map(|item| match &item.node {
+            TopLevel::Agent(a) => Some(a.as_ref().clone()),
+            _ => None,
+        })
+        .expect("no agent");
+
+    let agent = AgentProcess::new(
+        agent_decl,
+        None,
+        mock_registry_with(MockProvider::new("mock").with_default(":")),
+        None,
+        program,
+        None,
+        None,
+        None,
+    );
+
+    let workdir = tempfile::tempdir().unwrap();
+    let init = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(workdir.path())
+        .output()
+        .expect("git init failed to spawn");
+    assert!(
+        init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let mut params = HashMap::new();
+    params.insert(
+        "workdir".into(),
+        ConfidentValue::deterministic(Value::Text(shell_path(workdir.path()))),
+    );
+
+    let result = agent.dispatch("TestsFailed", params).await.unwrap();
+    assert!(
+        result.is_none(),
+        "dependency-only fix should not fail the commit path, got: {:?}",
+        result
+    );
+    let ctx = agent.context().lock().unwrap();
+    assert_eq!(ctx.event_sink.emitted.len(), 1);
+    assert_eq!(ctx.event_sink.emitted[0].name, "ImplementationReady");
 }
 
 // ── T2.1 (#296): Implementer iteration loop tests ──────────────────────────

--- a/tests/clone_dev_github_wake_tests.rs
+++ b/tests/clone_dev_github_wake_tests.rs
@@ -20,7 +20,7 @@ const EVENTS_PATH: &str = "workflows/clone-dev/shared/events.forge";
 const MASTERMIND_PATH: &str = "workflows/clone-dev/shared/mastermind.forge";
 const ROUTER_PATH: &str = "workflows/clone-dev/stage2/label_router.forge";
 
-const TYPESCRIPT_TEST_CMD: &str = "npm run typecheck && npm test && npm run build";
+const TYPESCRIPT_TEST_CMD: &str = "npm ci && npm run typecheck && npm test && npm run build";
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 

--- a/workflows/dev-cycle/agents.forge
+++ b/workflows/dev-cycle/agents.forge
@@ -623,10 +623,10 @@ agent implementer
     when apply_result.sure -> say "[implementer] Fix applied"
     else -> give "fix_apply_failed: {apply_result}"
     fix_msg = render_commit_message(memory.fix_commit_template, issue_id, memory.title, memory.criteria, memory.iteration)
-    commit_result = command "cd {memory.workdir} && git add -A && if git diff --cached --quiet; then echo 'no staged changes to commit'; exit 42; fi && git commit -m '{fix_msg}' && git push origin {branch} 2>&1" timeout 60s
-    when commit_result.sure -> say "[implementer] Fix committed and pushed"
+    commit_result = command "cd {memory.workdir} && git add -A && if git diff --cached --quiet; then echo 'no staged source diff after fix; skipping commit'; else git commit -m '{fix_msg}' && git push origin {branch}; fi 2>&1" timeout 60s
+    when commit_result.sure -> say "[implementer] Fix committed, or no source diff was produced"
     else -> give "fix_commit_push_failed: {commit_result}"
-    say "[implementer] Fix iteration {memory.iteration} for {issue_id} pushed. Re-running tests."
+    say "[implementer] Fix iteration {memory.iteration} for {issue_id} ready. Re-running tests."
     emit ImplementationReady(issue_id: issue_id, repo: repo, branch: branch, workdir: memory.workdir, channel: channel, callback_url: callback_url, test_cmd: memory.test_cmd)
 
   on TaskCompleted(task_id: Text, repo: Text, outcome: Text, ci_passed_first_try: Bool, review_rounds: Number, time_to_merge: Number, reverted_within_7d: Bool)


### PR DESCRIPTION
## Summary
- Require `npm ci` in the TypeScript clone-dev proof-run command documented and asserted by Forge regressions.
- Allow implementer fix iterations with no staged source diff to skip a source commit and re-run tests.
- Keep initial no-op implementation commits blocking.

## Acceptance criteria
- [x] TypeScript clone-dev configs use `npm ci && npm run typecheck && npm test && npm run build`, or the tester performs an explicit dependency install before running repo tests.
- [x] A regression/smoke proves a fresh clone of `ncmlabs/forge-playground` can run the configured test command without manual setup.
- [x] Iteration fixes that only change local dependency state do not attempt a source commit.

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- Fresh clone smoke: `gh repo clone ncmlabs/forge-playground <tmp> && npm ci && npm run typecheck && npm test && npm run build`

## Related
- Fixes #415
- Companion playground config PR required for the live `.forge/clone-dev.toml` update.